### PR TITLE
Implement CI/CD pipeline for iOS building

### DIFF
--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15-large
+    runs-on: macos-15
     name: Build IOS
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -1,0 +1,48 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: macos-15-large
+    name: Build IOS
+    steps:
+      - uses: actions/checkout@v2
+        name: Check out repository
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: |
+          bun i && bun run submodule-reload
+          npx expo prebuild
+      - uses: sparkfabrik/ios-build-action@v2.3.0
+        with:
+          upload-to-testflight: false
+          increment-build-number: false
+          build-pods: true
+          pods-path: "ios/Podfile"
+          configuration: Release
+          # Change later to app-store if wanted
+          #export-method: app-store
+          export-method: ad-hoc
+          workspace-path: "ios/Streamyfin.xcodeproj/project.xcworkspace/"
+          project-path: "ios/Streamyfin.xcodeproj"
+          scheme: Streamyfin
+          #apple-key-id: ${{ secrets.APPLE_KEY_ID }}
+          #apple-key-issuer-id: ${{ secrets.APPLE_KEY_ISSUER_ID }}
+          #apple-key-content: ${{ secrets.APPLE_KEY_CONTENT }}
+          #team-id: ${{ secrets.TEAM_ID }}
+          #team-name: ${{ secrets.TEAM_NAME }}
+          #match-password: ${{ secrets.MATCH_PASSWORD }}
+          #match-git-url: ${{ secrets.MATCH_GIT_URL }}
+          #match-git-basic-authorization: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          #match-build-type: "appstore"
+          #browserstack-upload: true
+          #browserstack-username: ${{ secrets.BROWSERSTACK_USERNAME }}
+          #browserstack-access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          #fastlane-env: stage
+          ios-app-id: com.stetsed.teststreamyfin
+          output-path: build-${{ github.sha }}.ipa


### PR DESCRIPTION
This PR attempts to implement automated building for the iOS app for streamyfin.

Current limitations:
- Cannot test myself due to lack of apple ID credentials that i can use, as such as said in discord would prob be smart to merge into a test branch with the secrets added to the org.
- No caching is done, in theory this shouldn't be a major problem due to bun being relativley well optimized, but in theory caching the node modules shouldn't be hard.
- Right now it prebuilds both android and iOS while android is not needed, and it installs some of the dev packages that aren't used on the iOS side, so it might make sense to filter those into groups