### PR TITLE
Feature: Remove duplicate names from media sources

### DIFF
--- a/components/MediaSourceSelector.tsx
+++ b/components/MediaSourceSelector.tsx
@@ -29,6 +29,27 @@ export const MediaSourceSelector: React.FC<Props> = ({
     [item, selected]
   );
 
+  const commonPrefix = useMemo(() => {
+    const mediaSources = item.MediaSources || [];
+    if (!mediaSources.length) return "";
+
+    let commonPrefix = "";
+    for (let i = 0; i < mediaSources[0].Name.length; i++) {
+      const char = mediaSources[0].Name[i];
+      if (mediaSources.every((source) => source.Name[i] === char)) {
+        commonPrefix += char;
+      } else {
+        commonPrefix = commonPrefix.slice(0, -1);
+        break;
+      }
+    }
+    return commonPrefix;
+  }, [item.MediaSources]);
+
+  const name = (name?: string | null) => {
+    return name?.replace(commonPrefix, "").toLowerCase();
+  };
+
   return (
     <View
       className="flex shrink"
@@ -63,9 +84,7 @@ export const MediaSourceSelector: React.FC<Props> = ({
               }}
             >
               <DropdownMenu.ItemTitle>
-                {`${name(source.Name)} - ${convertBitsToMegabitsOrGigabits(
-                  source.Size
-                )}`}
+                {`${name(source.Name)}`}
               </DropdownMenu.ItemTitle>
             </DropdownMenu.Item>
           ))}
@@ -73,10 +92,4 @@ export const MediaSourceSelector: React.FC<Props> = ({
       </DropdownMenu.Root>
     </View>
   );
-};
-
-const name = (name?: string | null) => {
-  if (name && name.length > 40)
-    return name.substring(0, 20) + " [...] " + name.substring(name.length - 20);
-  return name;
 };


### PR DESCRIPTION
Before:

<img width="330" alt="Screenshot 2025-01-09 at 10 15 55" src="https://github.com/user-attachments/assets/b72183ce-361b-4e1d-bc05-2c630ccfee95" />

after:

<img width="413" alt="Screenshot 2025-01-09 at 10 13 13" src="https://github.com/user-attachments/assets/121fecea-b918-42ce-9471-d0ceeffc7750" />

## Summary by Sourcery

New Features:
- Display shorter media source names in the dropdown.