### PR TITLE
fix: Remove Page Path from Log Page Header

### DIFF
--- a/app/(auth)/(tabs)/(home)/_layout.tsx
+++ b/app/(auth)/(tabs)/(home)/_layout.tsx
@@ -84,6 +84,12 @@ export default function IndexLayout() {
         }}
       />
       <Stack.Screen
+        name="settings/logs/page"
+        options={{
+          title: "",
+        }}
+      />
+      <Stack.Screen
         name="intro/page"
         options={{
           headerShown: false,


### PR DESCRIPTION
Quick fix to hide the page path from the header in the log view of the Settings page. Currently it shows this:

![Capture d’écran du 2025-01-12 23-06-15](https://github.com/user-attachments/assets/10a0382a-8707-440e-b290-bdc22e6a19a0)

## Summary by Sourcery

Bug Fixes:
- Removed the page path from the log page header.