### PR TITLE
fix: Keyboard breaking UI when already logged in

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -223,7 +223,8 @@ const Login: React.FC = () => {
                       setCredentials({ ...credentials, username: text })
                     }
                     value={credentials.username}
-                    autoFocus
+                    // use auto focus with small delay so keyboard only shows up when not logged in
+                    autoFocusDelay={500}
                     secureTextEntry={false}
                     keyboardType="default"
                     returnKeyType="done"

--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -13,13 +13,13 @@ export function Input(props: TextInputProps & AutoFocusDelayProps) {
   const { style, ...otherProps } = props;
   const inputRef = React.useRef<TextInput>(null);
 
-  if(props.autoFocus && props.autoFocusDelay) {
-    console.warn('autoFocusDelay is obsolete when using autoFocus');
-  }
-
   // focus the input after the given amount of ms
   useEffect(() => {
     if(!props.autoFocusDelay) return;
+    if(props.autoFocus) {
+      console.warn('autoFocusDelay has no effect when autoFocus is true');
+      return
+    }
     const timer = setTimeout(() => {
       if(inputRef.current) {
         inputRef.current.focus();

--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -1,8 +1,32 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { TextInput, TextInputProps } from "react-native";
-export function Input(props: TextInputProps) {
+
+type AutoFocusDelayProps = {
+  /**
+   * If true, focuses the input after the given amount of ms on componentDidMount.
+   * The default value is false.
+   */
+  autoFocusDelay?: number
+}
+
+export function Input(props: TextInputProps & AutoFocusDelayProps) {
   const { style, ...otherProps } = props;
   const inputRef = React.useRef<TextInput>(null);
+
+  if(props.autoFocus && props.autoFocusDelay) {
+    console.warn('autoFocusDelay is obsolete when using autoFocus');
+  }
+
+  // focus the input after the given amount of ms
+  useEffect(() => {
+    if(!props.autoFocusDelay) return;
+    const timer = setTimeout(() => {
+      if(inputRef.current) {
+        inputRef.current.focus();
+      }
+    }, props.autoFocusDelay);
+    return () => clearTimeout(timer);
+  }, [])
 
   return (
     <TextInput


### PR DESCRIPTION
> Note: This may also be an issue on ios, but I could only test on android

When opening the app the login page shows up for a split second and because of the autoFocus on the username input, the keyboard shows up, which could mess up to general ui (happened like half of the time).

The fix is a custom property `autoFocusDelay` on the Input component, which triggers the autoFocus after a given amount of time.
The username input uses this `autoFocusDelay` instead of `autoFocus` with a short time, so the keyboard does not show up, when already logged in, but not too long, so it isn't noticeable when not logged in.

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where the keyboard would appear briefly on the login screen when the app was opened while already logged in.