### PR TITLE
Fix mark as played sheet logic being reversed

### DIFF
--- a/components/PlayedStatus.tsx
+++ b/components/PlayedStatus.tsx
@@ -46,7 +46,7 @@ export const PlayedStatus: React.FC<Props> = ({ item, ...props }) => {
       <RoundButton
         fillColor={item.UserData?.Played ? "primary" : undefined}
         icon={item.UserData?.Played ? "checkmark" : "checkmark"}
-        onPress={() => markAsPlayedStatus(!item.UserData?.Played || true)}
+        onPress={() => markAsPlayedStatus(!item.UserData?.Played)}
         size="large"
       />
     </View>

--- a/components/PlayedStatus.tsx
+++ b/components/PlayedStatus.tsx
@@ -46,7 +46,7 @@ export const PlayedStatus: React.FC<Props> = ({ item, ...props }) => {
       <RoundButton
         fillColor={item.UserData?.Played ? "primary" : undefined}
         icon={item.UserData?.Played ? "checkmark" : "checkmark"}
-        onPress={() => markAsPlayedStatus(item.UserData?.Played || false)}
+        onPress={() => markAsPlayedStatus(!item.UserData?.Played || true)}
         size="large"
       />
     </View>

--- a/hooks/useMarkAsPlayed.ts
+++ b/hooks/useMarkAsPlayed.ts
@@ -51,17 +51,17 @@ export const useMarkAsPlayed = (item: BaseItemDto) => {
 
     try {
       if (played) {
-        await markAsNotPlayed({
-          api: api,
-          itemId: item?.Id,
-          userId: user?.Id,
-        });
+		await markAsPlayed({
+			api: api,
+			item: item,
+			userId: user?.Id,
+		  });
       } else {
-        await markAsPlayed({
-          api: api,
-          item: item,
-          userId: user?.Id,
-        });
+        await markAsNotPlayed({
+			api: api,
+			itemId: item?.Id,
+			userId: user?.Id,
+		});
       }
       invalidateQueries();
     } catch (error) {


### PR DESCRIPTION
fixes #435 

This issue was caused by the logic for marking content as played being backward. When you tapped "Mark not played" it would mark it as played, and vice versa.

I've changed the logic a little to make more sense and ensured it's updated in both the long-press sheet and the mark as played button at the top right when viewing a show.

## Summary by Sourcery

Bug Fixes:
- Correct the reversed behavior when marking content as played or not played through the long-press sheet and the button at the top right when viewing a show.