### PR TITLE
[android] Trust android local CA store for self signed certificates

### DIFF
--- a/app.json
+++ b/app.json
@@ -112,7 +112,8 @@
       ],
       ["react-native-bottom-tabs"],
       ["./plugins/withChangeNativeAndroidTextToWhite.js"],
-      ["./plugins/withGoogleCastActivity.js"]
+      ["./plugins/withGoogleCastActivity.js"],
+      ["./plugins/withTrustLocalCerts.js"]
     ],
     "experiments": {
       "typedRoutes": true

--- a/plugins/network_security_config.xml
+++ b/plugins/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/plugins/withTrustLocalCerts.js
+++ b/plugins/withTrustLocalCerts.js
@@ -1,0 +1,44 @@
+const { AndroidConfig, withAndroidManifest } = require("@expo/config-plugins");
+const { Paths } = require("@expo/config-plugins/build/android");
+const path = require("path");
+const fs = require("fs");
+const fsPromises = fs.promises;
+
+const { getMainApplicationOrThrow } = AndroidConfig.Manifest;
+
+const withTrustLocalCerts = (config) => {
+  return withAndroidManifest(config, async (config) => {
+    config.modResults = await setCustomConfigAsync(config, config.modResults);
+    return config;
+  });
+};
+
+async function setCustomConfigAsync(config, androidManifest) {
+  const src_file_path = path.join(__dirname, "network_security_config.xml");
+  const res_file_path = path.join(
+    await Paths.getResourceFolderAsync(config.modRequest.projectRoot),
+    "xml",
+    "network_security_config.xml"
+  );
+
+  const res_dir = path.resolve(res_file_path, "..");
+
+  if (!fs.existsSync(res_dir)) {
+    await fsPromises.mkdir(res_dir);
+  }
+
+  try {
+    await fsPromises.copyFile(src_file_path, res_file_path);
+  } catch (e) {
+    throw new Error(
+      `Failed to copy network security config file from ${src_file_path} to ${res_file_path}: ${e.message}`
+    );
+  }
+  const mainApplication = getMainApplicationOrThrow(androidManifest);
+  mainApplication.$["android:networkSecurityConfig"] =
+    "@xml/network_security_config";
+
+  return androidManifest;
+}
+
+module.exports = withTrustLocalCerts;


### PR DESCRIPTION
As the title suggests, this forces the app to also trust the local cert authority installed by the user. This is needed for me since my instance is not on the public internet.

A lot of this comes from this useful [Stack Overflow](https://stackoverflow.com/a/70775576) post, with a couple of minimal adjustments for this codebase.

Tested locally and working perfectly fine.

## Summary by Sourcery

New Features:
- Added support for user-installed CA certificates on Android.