### PR TITLE
[android] fix: Revert change that broke self signed cert

### DIFF
--- a/plugins/network_security_config.xml
+++ b/plugins/network_security_config.xml
@@ -3,6 +3,7 @@
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
+            <certificates src="user" />
         </trust-anchors>
     </base-config>
 </network-security-config>


### PR DESCRIPTION
Partially revert 252fc43 since it reverted a change needed to let the app accept user self signed certificates.

## Summary by Sourcery

Bug Fixes:
- Fixed an issue that prevented the app from accepting user-added certificates.