### PR TITLE
fix: Rendered more hooks than during the previous render in NextEpisodeCountDownButton

### DIFF
--- a/components/video-player/controls/NextEpisodeCountDownButton.tsx
+++ b/components/video-player/controls/NextEpisodeCountDownButton.tsx
@@ -60,11 +60,11 @@ const NextEpisodeCountDownButton: React.FC<NextEpisodeCountDownButtonProps> = ({
     }
   };
 
+  const { t } = useTranslation();
+
   if (!show) {
     return null;
   }
-
-  const { t } = useTranslation();
 
   return (
     <TouchableOpacity


### PR DESCRIPTION
Simple fix, title says it all

## Summary by Sourcery

Bug Fixes:
- Fix the "Rendered more hooks than during the previous render" error in `NextEpisodeCountDownButton`.