### PR TITLE
fix: phone_usage to device_usage due PR #456 for DE language

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -184,7 +184,7 @@
       "storage": {
         "storage_title": "Speicher",
         "app_usage": "App {{usedSpace}}%",
-        "phone_usage": "Handy {{availableSpace}}%",
+        "device_usage": "Gerät {{availableSpace}}%",
         "size_used": "{{used}} von {{total}} benutzt",
         "delete_all_downloaded_files": "Alle Downloads löschen"
       },


### PR DESCRIPTION
Changed phone_usage to device_usage due PR #456 for de.json

## Summary by Sourcery

Rename phone usage to device usage.

Enhancements:
- Standardize the term "device usage" across the application.

Chores:
- Update German translations.