### PR TITLE
feat: Add default quality setting

### DIFF
--- a/components/DownloadItem.tsx
+++ b/components/DownloadItem.tsx
@@ -66,7 +66,7 @@ export const DownloadItems: React.FC<DownloadProps> = ({
   const [selectedAudioStream, setSelectedAudioStream] = useState<number>(-1);
   const [selectedSubtitleStream, setSelectedSubtitleStream] =
     useState<number>(0);
-  const [maxBitrate, setMaxBitrate] = useState<Bitrate>({
+  const [maxBitrate, setMaxBitrate] = useState<Bitrate>(settings?.defaultBitrate ?? {
     key: "Max",
     value: undefined,
   });
@@ -194,10 +194,11 @@ export const DownloadItems: React.FC<DownloadProps> = ({
 
       for (const item of items) {
         if (itemsNotDownloaded.length > 1) {
-          ({ mediaSource, audioIndex, subtitleIndex } = getDefaultPlaySettings(
-            item,
-            settings!
-          ));
+          const defaults = getDefaultPlaySettings(item, settings!);
+          mediaSource = defaults.mediaSource;
+          audioIndex = defaults.audioIndex;
+          subtitleIndex = defaults.subtitleIndex;
+          // Keep using the selected bitrate for consistency across all downloads
         }
 
         const res = await getStreamUrl({

--- a/components/settings/OtherSettings.tsx
+++ b/components/settings/OtherSettings.tsx
@@ -165,7 +165,7 @@ export const OtherSettings: React.FC = () => {
           showArrow
         />
         <ListItem
-          title={t("home.settings.other.default_quality")}
+          title="Default quality"
           disabled={pluginSettings?.defaultBitrate?.locked}
         >
           <Dropdown

--- a/components/settings/OtherSettings.tsx
+++ b/components/settings/OtherSettings.tsx
@@ -164,6 +164,15 @@ export const OtherSettings: React.FC = () => {
           showArrow
         />
         <ListItem
+          title={t("home.settings.other.default_bitrate")}
+          disabled={pluginSettings?.defaultBitrate?.locked}
+        >
+          <BitrateSelector
+            selected={settings.defaultBitrate}
+            onChange={(bitrate) => updateSettings({ defaultBitrate: bitrate })}
+          />
+        </ListItem>
+        <ListItem
           title={t("home.settings.other.disable_haptic_feedback")}
           disabled={pluginSettings?.disableHapticFeedback?.locked}
         >

--- a/components/settings/OtherSettings.tsx
+++ b/components/settings/OtherSettings.tsx
@@ -1,6 +1,6 @@
 import { Platform } from "react-native";
 import { ScreenOrientationEnum, useSettings } from "@/utils/atoms/settings";
-import { BitrateSelector } from "@/components/BitrateSelector";
+import { BitrateSelector, BITRATES } from "@/components/BitrateSelector";
 import {
   BACKGROUND_FETCH_TASK,
   registerBackgroundFetchAsync,

--- a/components/settings/OtherSettings.tsx
+++ b/components/settings/OtherSettings.tsx
@@ -165,12 +165,29 @@ export const OtherSettings: React.FC = () => {
           showArrow
         />
         <ListItem
-          title={t("home.settings.other.default_bitrate")}
+          title={t("home.settings.other.default_quality")}
           disabled={pluginSettings?.defaultBitrate?.locked}
         >
-          <BitrateSelector
+          <Dropdown
+            data={BITRATES}
+            disabled={pluginSettings?.defaultBitrate?.locked}
+            keyExtractor={(item) => item.key}
+            titleExtractor={(item) => item.key}
             selected={settings.defaultBitrate}
-            onChange={(bitrate) => updateSettings({ defaultBitrate: bitrate })}
+            title={
+              <TouchableOpacity className="flex flex-row items-center justify-between py-3 pl-3">
+                <Text className="mr-1 text-[#8E8D91]">
+                  {settings.defaultBitrate?.key}
+                </Text>
+                <Ionicons
+                  name="chevron-expand-sharp"
+                  size={18}
+                  color="#5A5960"
+                />
+              </TouchableOpacity>
+            }
+            label={t("home.settings.other.quality")}
+            onSelected={(defaultBitrate) => updateSettings({ defaultBitrate })}
           />
         </ListItem>
         <ListItem

--- a/components/settings/OtherSettings.tsx
+++ b/components/settings/OtherSettings.tsx
@@ -1,5 +1,6 @@
 import { Platform } from "react-native";
 import { ScreenOrientationEnum, useSettings } from "@/utils/atoms/settings";
+import { BitrateSelector } from "@/components/BitrateSelector";
 import {
   BACKGROUND_FETCH_TASK,
   registerBackgroundFetchAsync,

--- a/hooks/useDefaultPlaySettings.ts
+++ b/hooks/useDefaultPlaySettings.ts
@@ -28,8 +28,8 @@ const useDefaultPlaySettings = (
       (x) => x.Type === "Audio"
     )?.Index;
 
-    // 4. Get default bitrate
-    const bitrate = BITRATES[0];
+    // 4. Get default bitrate from settings or fallback to max
+    const bitrate = settings?.defaultBitrate ?? BITRATES[0];
 
     return {
       defaultAudioIndex:

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -11,6 +11,7 @@ import {
   BaseItemKind,
   ItemFilter,
 } from "@jellyfin/sdk/lib/generated-client";
+import { Bitrate, BITRATES } from "@/components/BitrateSelector";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { writeInfoLog } from "@/utils/log";
 
@@ -122,6 +123,7 @@ export type Settings = {
   marlinServerUrl?: string;
   openInVLC?: boolean;
   downloadQuality?: DownloadOption;
+  defaultBitrate?: Bitrate;
   libraryOptions: LibraryOptions;
   defaultAudioLanguage: CultureDto | null;
   playDefaultAudioTrack: boolean;
@@ -169,6 +171,7 @@ const loadSettings = (): Settings => {
     marlinServerUrl: "",
     openInVLC: false,
     downloadQuality: DownloadOptions[0],
+    defaultBitrate: BITRATES[0],
     libraryOptions: {
       display: "list",
       cardStyle: "detailed",

--- a/utils/jellyfin/getDefaultPlaySettings.ts
+++ b/utils/jellyfin/getDefaultPlaySettings.ts
@@ -92,10 +92,8 @@ export function getDefaultPlaySettings(
     }
   }
 
-  // 4. Get default bitrate
-  const bitrate = BITRATES.sort(
-    (a, b) => (b.value || Infinity) - (a.value || Infinity)
-  )[0];
+  // 4. Get default bitrate from settings or fallback to max
+  const bitrate = settings.defaultBitrate ?? BITRATES[0];
 
   return {
     item,


### PR DESCRIPTION
This adds a default quality (bitrate) setting for all videos in "Other" setting (download and stream).
Could fix #94 and #393, partly fixes #215.

## Summary by Sourcery

New Features:
- Allow users to select a default video quality.