### PR TITLE
fix: Change too long texts in the Spanish translation

### DIFF
--- a/translations/es.json
+++ b/translations/es.json
@@ -87,7 +87,7 @@
       },
       "audio": {
         "audio_title": "Audio",
-        "set_audio_track": "Establecer pista de audio del elemento anterior",
+        "set_audio_track": "Establecer pista del elemento anterior",
         "audio_language": "Idioma de audio",
         "audio_hint": "Elige un idioma de audio por defecto.",
         "none": "Ninguno",
@@ -97,7 +97,7 @@
         "subtitle_title": "Subtítulos",
         "subtitle_language": "Idioma de subtítulos",
         "subtitle_mode": "Modo de subtítulos",
-        "set_subtitle_track": "Establecer pista de subtítulos del elemento anterior",
+        "set_subtitle_track": "Establecer pista del elemento anterior",
         "subtitle_size": "Tamaño de subtítulos",
         "subtitle_hint": "Configurar preferencias de subtítulos.",
         "none": "Ninguno",


### PR DESCRIPTION
I changed two texts that were too long to fit in the iPhone settings menu in the Spanish translation of the app. Here is a screenshot of the problem:
![IMG_0461](https://github.com/user-attachments/assets/bedc208f-a74c-470b-86c8-45e0d0e0892c)

I changed these texts to fit.

## Summary by Sourcery

Bug Fixes:
- Shorten texts in the Spanish translation to prevent overflow in the iPhone settings menu.