### PR TITLE
fix: improve Jellyseerr login handling and state management

### DIFF
--- a/components/settings/Jellyseerr.tsx
+++ b/components/settings/Jellyseerr.tsx
@@ -12,6 +12,7 @@ import { Input } from "../common/Input";
 import { Text } from "../common/Text";
 import { ListGroup } from "../list/ListGroup";
 import { ListItem } from "../list/ListItem";
+import {URL_REGEX} from "@/constants/Regex";
 
 export const JellyseerrSettings = () => {
   const {
@@ -35,7 +36,7 @@ export const JellyseerrSettings = () => {
 
   const loginToJellyseerrMutation = useMutation({
     mutationFn: async () => {
-      if (!jellyseerrServerUrl) {
+      if (!jellyseerrServerUrl || !URL_REGEX.test(jellyseerrServerUrl)) {
         throw new Error("Missing server url");
       }
       if (!user?.Name)

--- a/components/settings/Jellyseerr.tsx
+++ b/components/settings/Jellyseerr.tsx
@@ -15,7 +15,6 @@ import { ListItem } from "../list/ListItem";
 
 export const JellyseerrSettings = () => {
   const {
-    jellyseerrApi,
     jellyseerrUser,
     setJellyseerrUser,
     clearAllJellyseerData,
@@ -24,28 +23,29 @@ export const JellyseerrSettings = () => {
   const { t } = useTranslation();
 
   const [user] = useAtom(userAtom);
-  const [settings, updateSettings, pluginSettings] = useSettings();
+  const [settings, updateSettings] = useSettings();
 
   const [jellyseerrPassword, setJellyseerrPassword] = useState<
-    string | undefined
-  >(undefined);
+    string
+  >("");
 
-  const [jellyseerrServerUrl, setjellyseerrServerUrl] = useState<
+  const [jellyseerrServerUrl, setJellyseerrServerUrl] = useState<
     string | undefined
   >(settings?.jellyseerrServerUrl || undefined);
 
   const loginToJellyseerrMutation = useMutation({
     mutationFn: async () => {
-      if (!jellyseerrServerUrl && !settings?.jellyseerrServerUrl)
+      if (!jellyseerrServerUrl) {
         throw new Error("Missing server url");
+      }
       if (!user?.Name)
         throw new Error("Missing required information for login");
       const jellyseerrTempApi = new JellyseerrApi(
-        jellyseerrServerUrl || settings.jellyseerrServerUrl || ""
+        jellyseerrServerUrl
       );
       const testResult = await jellyseerrTempApi.test();
       if (!testResult.isValid) throw new Error("Invalid server url");
-      return jellyseerrTempApi.login(user.Name, jellyseerrPassword || "");
+      return jellyseerrTempApi.login(user.Name, jellyseerrPassword);
     },
     onSuccess: (user) => {
       setJellyseerrUser(user);
@@ -55,15 +55,15 @@ export const JellyseerrSettings = () => {
       toast.error(t("jellyseerr.failed_to_login"));
     },
     onSettled: () => {
-      setJellyseerrPassword(undefined);
+      setJellyseerrPassword("");
     },
   });
 
   const clearData = () => {
     clearAllJellyseerData().finally(() => {
       setJellyseerrUser(undefined);
-      setJellyseerrPassword(undefined);
-      setjellyseerrServerUrl(undefined);
+      setJellyseerrPassword("");
+      setJellyseerrServerUrl(undefined);
     });
   };
 
@@ -143,7 +143,7 @@ export const JellyseerrSettings = () => {
               returnKeyType="done"
               autoCapitalize="none"
               textContentType="URL"
-              onChangeText={setjellyseerrServerUrl}
+              onChangeText={setJellyseerrServerUrl}
               editable={!loginToJellyseerrMutation.isPending}
             />
             <View>
@@ -158,6 +158,7 @@ export const JellyseerrSettings = () => {
                   "home.settings.plugins.jellyseerr.password_placeholder",
                   { username: user?.Name }
                 )}
+                style={{ flexShrink: 1 }}
                 value={jellyseerrPassword}
                 keyboardType="default"
                 secureTextEntry={true}

--- a/constants/Regex.ts
+++ b/constants/Regex.ts
@@ -1,0 +1,1 @@
+export const URL_REGEX = /^(https:\/\/|http:\/\/)([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/;

--- a/hooks/useJellyseerr.ts
+++ b/hooks/useJellyseerr.ts
@@ -172,7 +172,7 @@ export class JellyseerrApi {
       });
   }
 
-  async login(username: string, password: string): Promise<JellyseerrUser> {
+  async login(username: string, password: string = ''): Promise<JellyseerrUser> {
     return this.axios
       ?.post<JellyseerrUser>(Endpoints.API_V1 + Endpoints.AUTH_JELLYFIN, {
         username,


### PR DESCRIPTION
handle empty password in Jellyseerr login and update state initialisation.
Targeted Passwordless accounts & enabled their login

I did prefer `useState<string>("")` over `useState<string | undefined>(undefined)` because:
1. Avoids `undefined` complexity; empty string (`""`) is simpler for checks and form handling.
2. Ensures type consistency (`string` instead of `string | undefined`).
3. Aligns with APIs/form libraries that use `""` for empty values.
4. Reduces bugs by avoiding `undefined` edge cases.
we use `undefined` only if explicitly distinguishing "no value" from "empty value" is necessary.


I did also remove the **settings.jellyseerrServerUrl** in the mutation condition because it is useless, we are getting the **settings.jellyseerrServerUrl** already and putting it in the **jellyseerrServerUrl** state value

Resolves issue : https://github.com/streamyfin/streamyfin/issues/536

continuation for PR: https://github.com/streamyfin/streamyfin/pull/540

DEMO: 


https://github.com/user-attachments/assets/4611e00c-cef2-43ff-a673-8bc7c5485298