### PR TITLE
fix: remove unused imports and optimize keepAwake usage in the player

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -21,6 +21,7 @@ import { getStreamUrl } from "@/utils/jellyfin/media/getStreamUrl";
 import { writeToLog } from "@/utils/log";
 import native from "@/utils/profiles/native";
 import { msToTicks, ticksToSeconds } from "@/utils/time";
+import { activateKeepAwakeAsync, deactivateKeepAwake } from "expo-keep-awake";
 import {
   getPlaystateApi,
   getUserLibraryApi,
@@ -298,16 +299,18 @@ export default function page() {
     setIsPipStarted(pipStarted);
   }, []);
 
-  const onPlaybackStateChanged = useCallback((e: PlaybackStatePayload) => {
+  const onPlaybackStateChanged = useCallback(async (e: PlaybackStatePayload) => {
     const { state, isBuffering, isPlaying } = e.nativeEvent;
 
     if (state === "Playing") {
       setIsPlaying(true);
+      if (!Platform.isTV) await activateKeepAwakeAsync()
       return;
     }
 
     if (state === "Paused") {
       setIsPlaying(false);
+      if (!Platform.isTV) await deactivateKeepAwake();
       return;
     }
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,5 @@
 import "@/augmentations";
 import { Platform } from "react-native";
-import { Text } from "@/components/common/Text";
 import i18n from "@/i18n";
 import { DownloadProvider } from "@/providers/DownloadProvider";
 import {
@@ -28,8 +27,6 @@ const BackgroundFetch = !Platform.isTV
   ? require("expo-background-fetch")
   : null;
 import * as FileSystem from "expo-file-system";
-import { useFonts } from "expo-font";
-import { useKeepAwake } from "expo-keep-awake";
 const Notifications = !Platform.isTV ? require("expo-notifications") : null;
 import { router, Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
@@ -38,7 +35,7 @@ const TaskManager = !Platform.isTV ? require("expo-task-manager") : null;
 import { getLocales } from "expo-localization";
 import { Provider as JotaiProvider } from "jotai";
 import { useEffect, useRef } from "react";
-import { I18nextProvider, useTranslation } from "react-i18next";
+import { I18nextProvider } from "react-i18next";
 import { Appearance, AppState } from "react-native";
 import { SystemBars } from "react-native-edge-to-edge";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -265,10 +262,7 @@ function Layout() {
   }, [settings?.preferedLanguage, i18n]);
 
   if (!Platform.isTV) {
-    useKeepAwake();
     useNotificationObserver();
-
-    const { i18n } = useTranslation();
 
     useEffect(() => {
       checkAndRequestPermissions();


### PR DESCRIPTION
Remove unused imports and optimise keepAwake usage in the player

Here in this fix, It got to my attention that useKeepAwake was used in the layout component which makes the app alwyas on
So what i did basically is I coupled the keep awake with the play/pause action.

Addressed issue: https://github.com/streamyfin/streamyfin/issues/517

## Summary by Sourcery

Bug Fixes:
- The app no longer keeps the screen awake when the player is not playing, fixing an issue where the screen would stay on unnecessarily.