### PR TITLE
feat: focus search bar on second tab press

### DIFF
--- a/app/(auth)/(tabs)/_layout.tsx
+++ b/app/(auth)/(tabs)/_layout.tsx
@@ -20,6 +20,7 @@ import type {
   TabNavigationState,
 } from "@react-navigation/native";
 import { SystemBars } from "react-native-edge-to-edge";
+import { eventBus } from "@/utils/eventBus";
 
 export const NativeTabs = withLayoutContext<
   BottomTabNavigationOptions,
@@ -76,6 +77,11 @@ export default function TabLayout() {
           }}
         />
         <NativeTabs.Screen
+          listeners={({ navigation }) => ({
+            tabPress: (e) => {
+              eventBus.emit("searchTabPressed");
+            },
+          })}
           name="(search)"
           options={{
             title: t("tabs.search"),

--- a/utils/eventBus.ts
+++ b/utils/eventBus.ts
@@ -1,0 +1,26 @@
+type Listener<T = void> = (data?: T) => void;
+
+class EventBus {
+  private listeners: Record<string, Listener<any>[]> = {};
+
+  on<T = void>(event: string, callback: Listener<T>): () => void {
+    if (!this.listeners[event]) {
+      this.listeners[event] = [];
+    }
+    this.listeners[event].push(callback);
+    return () => this.off(event, callback);
+  }
+
+  off<T = void>(event: string, callback: Listener<T>): void {
+    if (!this.listeners[event]) return;
+    this.listeners[event] = this.listeners[event].filter(
+      (fn) => fn !== callback
+    );
+  }
+
+  emit<T = void>(event: string, data?: T): void {
+    this.listeners[event]?.forEach((callback) => callback(data));
+  }
+}
+
+export const eventBus = new EventBus();


### PR DESCRIPTION
## Summary by Sourcery

This pull request introduces a feature that focuses the search bar when the search tab is pressed a second time. It also introduces an event bus to allow communication between the tab layout and the search screen.

New Features:
- Implements focusing the search bar when the search tab is pressed a second time, improving user experience by immediately enabling search input.

Enhancements:
- Adds an event bus to facilitate communication between the tab layout and the search screen.
- The search screen now uses a ref to control the header search bar, allowing programmatic focus.