### PR TITLE
feat: Mark/unmark favorite quick action

### DIFF
--- a/app/(auth)/(tabs)/(home,libraries,search,favorites)/series/[id].tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites)/series/[id].tsx
@@ -84,7 +84,7 @@ const page: React.FC = () => {
         allEpisodes &&
         allEpisodes.length > 0 && (
           <View className="flex flex-row items-center space-x-2">
-            <AddToFavorites item={item} type="series" />
+            <AddToFavorites item={item} />
             {!Platform.isTV && (
               <>
                 <DownloadItems

--- a/components/AddToFavorites.tsx
+++ b/components/AddToFavorites.tsx
@@ -1,99 +1,15 @@
-import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
-import { getUserLibraryApi } from "@jellyfin/sdk/lib/utils/api";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAtom } from "jotai";
-import { useMemo } from "react";
-import { TouchableOpacityProps, View, ViewProps } from "react-native";
+import { useFavorite } from "@/hooks/useFavorite";
 import { RoundButton } from "./RoundButton";
+import { View } from "react-native";
 
 interface Props extends ViewProps {
   item: BaseItemDto;
   type: "item" | "series";
 }
 
-export const AddToFavorites: React.FC<Props> = ({ item, type, ...props }) => {
-  const queryClient = useQueryClient();
-  const [api] = useAtom(apiAtom);
-  const [user] = useAtom(userAtom);
-
-  const isFavorite = useMemo(() => {
-    return item.UserData?.IsFavorite;
-  }, [item.UserData?.IsFavorite]);
-
-  const updateItemInQueries = (newData: Partial<BaseItemDto>) => {
-    queryClient.setQueryData<BaseItemDto | undefined>(
-      [type, item.Id],
-      (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          ...newData,
-          UserData: { ...old.UserData, ...newData.UserData },
-        };
-      }
-    );
-  };
-
-  const markFavoriteMutation = useMutation({
-    mutationFn: async () => {
-      if (api && user) {
-        await getUserLibraryApi(api).markFavoriteItem({
-          userId: user.Id,
-          itemId: item.Id!,
-        });
-      }
-    },
-    onMutate: async () => {
-      await queryClient.cancelQueries({ queryKey: [type, item.Id] });
-      const previousItem = queryClient.getQueryData<BaseItemDto>([
-        type,
-        item.Id,
-      ]);
-      updateItemInQueries({ UserData: { IsFavorite: true } });
-
-      return { previousItem };
-    },
-    onError: (err, variables, context) => {
-      if (context?.previousItem) {
-        queryClient.setQueryData([type, item.Id], context.previousItem);
-      }
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: [type, item.Id] });
-      queryClient.invalidateQueries({ queryKey: ["home", "favorites"] });
-    },
-  });
-
-  const unmarkFavoriteMutation = useMutation({
-    mutationFn: async () => {
-      if (api && user) {
-        await getUserLibraryApi(api).unmarkFavoriteItem({
-          userId: user.Id,
-          itemId: item.Id!,
-        });
-      }
-    },
-    onMutate: async () => {
-      await queryClient.cancelQueries({ queryKey: [type, item.Id] });
-      const previousItem = queryClient.getQueryData<BaseItemDto>([
-        type,
-        item.Id,
-      ]);
-      updateItemInQueries({ UserData: { IsFavorite: false } });
-
-      return { previousItem };
-    },
-    onError: (err, variables, context) => {
-      if (context?.previousItem) {
-        queryClient.setQueryData([type, item.Id], context.previousItem);
-      }
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: [type, item.Id] });
-      queryClient.invalidateQueries({ queryKey: ["home", "favorites"] });
-    },
-  });
+export const AddToFavorites = ({ item, type, ...props }) => {
+  const { isFavorite, toggleFavorite, _ } = useFavorite(item);
 
   return (
     <View {...props}>
@@ -101,13 +17,7 @@ export const AddToFavorites: React.FC<Props> = ({ item, type, ...props }) => {
         size="large"
         icon={isFavorite ? "heart" : "heart-outline"}
         fillColor={isFavorite ? "primary" : undefined}
-        onPress={() => {
-          if (isFavorite) {
-            unmarkFavoriteMutation.mutate();
-          } else {
-            markFavoriteMutation.mutate();
-          }
-        }}
+        onPress={toggleFavorite}
       />
     </View>
   );

--- a/components/AddToFavorites.tsx
+++ b/components/AddToFavorites.tsx
@@ -1,16 +1,16 @@
+
 import { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
 import { useFavorite } from "@/hooks/useFavorite";
-import { RoundButton } from "./RoundButton";
 import { View } from "react-native";
+import { RoundButton } from "@/components/RoundButton";
 
 interface Props extends ViewProps {
   item: BaseItemDto;
-  type: "item" | "series";
 }
 
-export const AddToFavorites = ({ item, type, ...props }) => {
-  const { isFavorite, toggleFavorite, _ } = useFavorite(item);
-
+export const AddToFavorites = ({ item, ...props }) => {
+  const { isFavorite, toggleFavorite, _} = useFavorite(item);
+  
   return (
     <View {...props}>
       <RoundButton

--- a/components/ItemContent.tsx
+++ b/components/ItemContent.tsx
@@ -98,7 +98,7 @@ export const ItemContent: React.FC<{ item: BaseItemDto }> = React.memo(
                       <DownloadSingleItem item={item} size="large" />
                     )}
                     <PlayedStatus items={[item]} size="large" />
-                    <AddToFavorites item={item} type="item" />
+                    <AddToFavorites item={item} />
                   </View>
                 )}
               </View>

--- a/components/common/TouchableItemRouter.tsx
+++ b/components/common/TouchableItemRouter.tsx
@@ -1,4 +1,5 @@
 import { useMarkAsPlayed } from "@/hooks/useMarkAsPlayed";
+import { useFavorite } from "@/hooks/useFavorite";
 import {
   BaseItemDto,
   BaseItemPerson,
@@ -7,7 +8,6 @@ import { useRouter, useSegments } from "expo-router";
 import { PropsWithChildren, useCallback } from "react";
 import { TouchableOpacity, TouchableOpacityProps } from "react-native";
 import { useActionSheet } from "@expo/react-native-action-sheet";
-import { useHaptic } from "@/hooks/useHaptic";
 
 interface Props extends TouchableOpacityProps {
   item: BaseItemDto;
@@ -57,14 +57,14 @@ export const TouchableItemRouter: React.FC<PropsWithChildren<Props>> = ({
   const segments = useSegments();
   const { showActionSheetWithOptions } = useActionSheet();
   const markAsPlayedStatus = useMarkAsPlayed([item]);
-
+  const { isFavorite, toggleFavorite, _} = useFavorite(item);
+  
   const from = segments[2];
 
   const showActionSheet = useCallback(() => {
     if (!(item.Type === "Movie" || item.Type === "Episode")) return;
-
-    const options = ["Mark as Played", "Mark as Not Played", "Cancel"];
-    const cancelButtonIndex = 2;
+    const options = ["Mark as Played", "Mark as Not Played", isFavorite ? "Unmark as Favorite" : "Mark as Favorite", "Cancel"];
+    const cancelButtonIndex = 3;
 
     showActionSheetWithOptions(
       {
@@ -74,14 +74,14 @@ export const TouchableItemRouter: React.FC<PropsWithChildren<Props>> = ({
       async (selectedIndex) => {
         if (selectedIndex === 0) {
           await markAsPlayedStatus(true);
-          // Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
         } else if (selectedIndex === 1) {
           await markAsPlayedStatus(false);
-          // Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        } else if (selectedIndex === 2) {
+          toggleFavorite()
         }
       }
     );
-  }, [showActionSheetWithOptions, markAsPlayedStatus]);
+  }, [showActionSheetWithOptions, isFavorite, markAsPlayedStatus]);
 
   if (
     from === "(home)" ||

--- a/components/common/TouchableItemRouter.tsx
+++ b/components/common/TouchableItemRouter.tsx
@@ -62,7 +62,7 @@ export const TouchableItemRouter: React.FC<PropsWithChildren<Props>> = ({
   const from = segments[2];
 
   const showActionSheet = useCallback(() => {
-    if (!(item.Type === "Movie" || item.Type === "Episode")) return;
+    if (!(item.Type === "Movie" || item.Type === "Episode" || item.Type === "Series")) return;
     const options = ["Mark as Played", "Mark as Not Played", isFavorite ? "Unmark as Favorite" : "Mark as Favorite", "Cancel"];
     const cancelButtonIndex = 3;
 

--- a/hooks/useFavorite.ts
+++ b/hooks/useFavorite.ts
@@ -1,0 +1,109 @@
+import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
+import { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
+import { getUserLibraryApi } from "@jellyfin/sdk/lib/utils/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAtom } from "jotai";
+import { useEffect, useState, useMemo } from "react";
+
+export const useFavorite = (item: BaseItemDto) => {
+  const queryClient = useQueryClient();
+  const [api] = useAtom(apiAtom);
+  const [user] = useAtom(userAtom);
+  const type = item.Type;
+  const [isFavorite, setIsFavorite] = useState(item.UserData?.IsFavorite);
+
+  useEffect(() => {
+    setIsFavorite(item.UserData?.IsFavorite);
+  }, [item.UserData?.IsFavorite]);
+
+  const updateItemInQueries = (newData: Partial<BaseItemDto>) => {
+    queryClient.setQueryData<BaseItemDto | undefined>(
+      [type, item.Id],
+      (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          ...newData,
+          UserData: { ...old.UserData, ...newData.UserData },
+        };
+      }
+    );
+  };
+
+  const markFavoriteMutation = useMutation({
+    mutationFn: async () => {
+      if (api && user) {
+        await getUserLibraryApi(api).markFavoriteItem({
+          userId: user.Id,
+          itemId: item.Id!,
+        });
+      }
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: [type, item.Id] });
+      const previousItem = queryClient.getQueryData<BaseItemDto>([
+        type,
+        item.Id,
+      ]);
+      updateItemInQueries({ UserData: { IsFavorite: true } });
+
+      return { previousItem };
+    },
+    onError: (err, variables, context) => {
+      if (context?.previousItem) {
+        queryClient.setQueryData([type, item.Id], context.previousItem);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [type, item.Id] });
+      queryClient.invalidateQueries({ queryKey: ["home", "favorites"] });
+      setIsFavorite(true);
+    },
+  });
+
+  const unmarkFavoriteMutation = useMutation({
+    mutationFn: async () => {
+      if (api && user) {
+        await getUserLibraryApi(api).unmarkFavoriteItem({
+          userId: user.Id,
+          itemId: item.Id!,
+        });
+      }
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: [type, item.Id] });
+      const previousItem = queryClient.getQueryData<BaseItemDto>([
+        type,
+        item.Id,
+      ]);
+      updateItemInQueries({ UserData: { IsFavorite: false } });
+
+      return { previousItem };
+    },
+    onError: (err, variables, context) => {
+      if (context?.previousItem) {
+        queryClient.setQueryData([type, item.Id], context.previousItem);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [type, item.Id] });
+      queryClient.invalidateQueries({ queryKey: ["home", "favorites"] });
+      setIsFavorite(false);
+    },
+  });
+
+  const toggleFavorite = () => {
+    if (isFavorite) {
+      unmarkFavoriteMutation.mutate();
+    } else {
+      markFavoriteMutation.mutate();
+    }
+  };
+
+  return {
+    isFavorite,
+    toggleFavorite,
+    markFavoriteMutation,
+    unmarkFavoriteMutation,
+  };
+};

--- a/hooks/useFavorite.ts
+++ b/hooks/useFavorite.ts
@@ -9,7 +9,7 @@ export const useFavorite = (item: BaseItemDto) => {
   const queryClient = useQueryClient();
   const [api] = useAtom(apiAtom);
   const [user] = useAtom(userAtom);
-  const type = item.Type;
+  const type = "item";
   const [isFavorite, setIsFavorite] = useState(item.UserData?.IsFavorite);
 
   useEffect(() => {


### PR DESCRIPTION

![Screenshot 2025-02-22 at 17 31 10](https://github.com/user-attachments/assets/7278a4a5-f98b-4484-a9d7-8e55f29bee42)


## Summary by Sourcery

Implements the functionality to mark and unmark items as favorites. It introduces a new `useFavorite` hook to manage the favorite state and API interactions, and integrates the favorite action into the item action sheet for easy access.

New Features:
- Adds the ability to mark and unmark items as favorites.

Enhancements:
- Introduces a `useFavorite` hook to encapsulate the logic for marking and unmarking items as favorites, including managing the favorite state and handling API calls.
- Integrates the favorite action into the item action sheet, allowing users to toggle the favorite status directly from the action sheet.