### PR TITLE
feat: Use VLC discovery API for chromecast and other devices

### DIFF
--- a/components/list/ListItem.tsx
+++ b/components/list/ListItem.tsx
@@ -1,4 +1,4 @@
-import { Ionicons } from "@expo/vector-icons";
+import {Ionicons, MaterialCommunityIcons} from "@expo/vector-icons";
 import { PropsWithChildren, ReactNode } from "react";
 import {
   TouchableOpacity,
@@ -13,7 +13,7 @@ interface Props extends TouchableOpacityProps, ViewProps {
   value?: string | null | undefined;
   children?: ReactNode;
   iconAfter?: ReactNode;
-  icon?: keyof typeof Ionicons.glyphMap;
+  icon?: keyof typeof Ionicons.glyphMap | keyof typeof MaterialCommunityIcons.glyphMap;
   showArrow?: boolean;
   textColor?: "default" | "blue" | "red";
   onPress?: () => void;
@@ -89,7 +89,19 @@ const ListItemContent = ({
       <View className="flex flex-row items-center w-full">
         {icon && (
           <View className="border border-neutral-800 rounded-md h-8 w-8 flex items-center justify-center mr-2">
-            <Ionicons name="person-circle-outline" size={18} color="white" />
+            {icon in Ionicons.glyphMap ?
+              <Ionicons
+                name={icon as keyof typeof Ionicons.glyphMap}
+                size={18}
+                color="white"
+              />
+              :
+              <MaterialCommunityIcons
+                name={icon as keyof typeof MaterialCommunityIcons.glyphMap}
+                size={18}
+                color="white"
+              />
+            }
           </View>
         )}
         <Text

--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -80,6 +80,7 @@ interface Props {
   mediaSource?: MediaSourceInfo | null;
   seek: (ticks: number) => void;
   startPictureInPicture: () => Promise<void>;
+  startDiscovery: () => Promise<void>;
   play: (() => Promise<void>) | (() => void);
   pause: () => void;
   getAudioTracks?: (() => Promise<TrackInfo[] | null>) | (() => TrackInfo[]);
@@ -93,32 +94,33 @@ interface Props {
 const CONTROLS_TIMEOUT = 4000;
 
 export const Controls: React.FC<Props> = ({
-                                            item,
-                                            seek,
-                                            startPictureInPicture,
-                                            play,
-                                            pause,
-                                            togglePlay,
-                                            isPlaying,
-                                            isSeeking,
-                                            progress,
-                                            isBuffering,
-                                            cacheProgress,
-                                            showControls,
-                                            setShowControls,
-                                            ignoreSafeAreas,
-                                            setIgnoreSafeAreas,
-                                            mediaSource,
-                                            isVideoLoaded,
-                                            getAudioTracks,
-                                            getSubtitleTracks,
-                                            setSubtitleURL,
-                                            setSubtitleTrack,
-                                            setAudioTrack,
-                                            offline = false,
-                                            enableTrickplay = true,
-                                            isVlc = false,
-                                          }) => {
+  item,
+  seek,
+  startDiscovery,
+  startPictureInPicture,
+  play,
+  pause,
+  togglePlay,
+  isPlaying,
+  isSeeking,
+  progress,
+  isBuffering,
+  cacheProgress,
+  showControls,
+  setShowControls,
+  ignoreSafeAreas,
+  setIgnoreSafeAreas,
+  mediaSource,
+  isVideoLoaded,
+  getAudioTracks,
+  getSubtitleTracks,
+  setSubtitleURL,
+  setSubtitleTrack,
+  setAudioTrack,
+  offline = false,
+  enableTrickplay = true,
+  isVlc = false,
+}) => {
   const [settings] = useSettings();
   const router = useRouter();
   const insets = useSafeAreaInsets();
@@ -494,6 +496,17 @@ export const Controls: React.FC<Props> = ({
             )}
 
             <View className="flex flex-row items-center space-x-2 ">
+              <TouchableOpacity
+                onPress={startDiscovery}
+                className="aspect-square flex flex-col rounded-xl items-center justify-center p-2"
+              >
+                <MaterialIcons
+                  name="cast"
+                  size={24}
+                  color="white"
+                  style={{ opacity: showControls ? 1 : 0 }}
+                />
+              </TouchableOpacity>
               {!Platform.isTV && (
                 <TouchableOpacity
                   onPress={startPictureInPicture}

--- a/modules/vlc-player/ios/VlcPlayerModule.swift
+++ b/modules/vlc-player/ios/VlcPlayerModule.swift
@@ -23,7 +23,8 @@ public class VlcPlayerModule: Module {
                 "onVideoLoadEnd",
                 "onVideoProgress",
                 "onVideoError",
-                "onPipStarted"
+                "onPipStarted",
+                "onDiscoveryStateChanged"
             )
 
             AsyncFunction("startPictureInPicture") { (view: VlcPlayerView) in
@@ -40,6 +41,14 @@ public class VlcPlayerModule: Module {
 
             AsyncFunction("stop") { (view: VlcPlayerView) in
                 view.stop()
+            }
+
+            AsyncFunction("startDiscovery") { (view: VlcPlayerView) in
+                view.startDiscovery()
+            }
+
+            AsyncFunction("stopDiscovery") { (view: VlcPlayerView) in
+                view.stopDiscovery()
             }
 
             AsyncFunction("seekTo") { (view: VlcPlayerView, time: Int32) in

--- a/modules/vlc-player/src/VlcPlayer.types.ts
+++ b/modules/vlc-player/src/VlcPlayer.types.ts
@@ -30,6 +30,18 @@ export type PipStartedPayload = {
   };
 };
 
+export type VLCRendererItem = {
+  index: number,
+  name: string,
+  type: string,
+  iconURI: string,
+  flags: number
+}
+
+export type OnDiscoveryStateChangedPayload = {
+  nativeEvent: { renderers: VLCRendererItem[] }
+}
+
 export type VideoStateChangePayload = PlaybackStatePayload;
 
 export type VideoProgressPayload = ProgressUpdatePayload;
@@ -71,9 +83,12 @@ export type VlcPlayerViewProps = {
   onVideoLoadEnd?: (event: VideoLoadStartPayload) => void;
   onVideoError?: (event: PlaybackStatePayload) => void;
   onPipStarted?: (event: PipStartedPayload) => void;
+  onDiscoveryStateChanged?: (event: OnDiscoveryStateChangedPayload) => void;
 };
 
 export interface VlcPlayerViewRef {
+  startDiscovery: () => Promise<void>;
+  stopDiscovery: () => Promise<void>;
   startPictureInPicture: () => Promise<void>;
   play: () => Promise<void>;
   pause: () => Promise<void>;

--- a/modules/vlc-player/src/VlcPlayerView.tsx
+++ b/modules/vlc-player/src/VlcPlayerView.tsx
@@ -23,6 +23,12 @@ const VlcPlayerView = React.forwardRef<VlcPlayerViewRef, VlcPlayerViewProps>(
     const nativeRef = React.useRef<NativeViewRef>(null);
 
     React.useImperativeHandle(ref, () => ({
+      startDiscovery: async () => {
+        await nativeRef.current?.startDiscovery()
+      },
+      stopDiscovery: async () => {
+        await nativeRef.current?.stopDiscovery()
+      },
       startPictureInPicture: async () => {
         await nativeRef.current?.startPictureInPicture()
       },
@@ -100,6 +106,7 @@ const VlcPlayerView = React.forwardRef<VlcPlayerViewRef, VlcPlayerViewProps>(
       onVideoLoadEnd,
       onVideoError,
       onPipStarted,
+      onDiscoveryStateChanged,
       ...otherProps
     } = props;
 
@@ -127,6 +134,7 @@ const VlcPlayerView = React.forwardRef<VlcPlayerViewRef, VlcPlayerViewProps>(
         onVideoProgress={onVideoProgress}
         onVideoError={onVideoError}
         onPipStarted={onPipStarted}
+        onDiscoveryStateChanged={onDiscoveryStateChanged}
       />
     );
   }

--- a/translations/de.json
+++ b/translations/de.json
@@ -352,7 +352,8 @@
     "audio_tracks": "Audiospuren:",
     "playback_state": "Wiedergabestatus:",
     "no_data_available": "Keine Daten verfügbar",
-    "index": "Index:"
+    "index": "Index:",
+    "device_discovery": "Device discovery"
   },
   "item_card": {
     "next_up": "Als Nächstes",

--- a/translations/en.json
+++ b/translations/en.json
@@ -356,7 +356,8 @@
     "audio_tracks": "Audio Tracks:",
     "playback_state": "Playback State:",
     "no_data_available": "No data available",
-    "index": "Index:"
+    "index": "Index:",
+    "device_discovery": "Device discovery"
   },
   "item_card": {
     "next_up": "Next up",

--- a/translations/es.json
+++ b/translations/es.json
@@ -352,7 +352,8 @@
     "audio_tracks": "Pistas de audio:",
     "playback_state": "Estado de la reproducción:",
     "no_data_available": "No hay datos disponibles",
-    "index": "Índice:"
+    "index": "Índice:",
+    "device_discovery": "Device discovery"
   },
   "item_card": {
     "next_up": "A continuación",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -353,7 +353,8 @@
     "audio_tracks": "Pistes audio:",
     "playback_state": "État de lecture:",
     "no_data_available": "Aucune donnée disponible",
-    "index": "Index:"
+    "index": "Index:",
+    "device_discovery": "Device discovery"
   },
   "item_card": {
     "next_up": "À suivre",

--- a/translations/it.json
+++ b/translations/it.json
@@ -352,7 +352,8 @@
     "audio_tracks": "Tracce audio:",
     "playback_state": "Stato della riproduzione:",
     "no_data_available": "Nessun dato disponibile",
-    "index": "Indice:"
+    "index": "Indice:",
+    "device_discovery": "Device discovery"
   },
   "item_card": {
     "next_up": "Il prossimo",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -351,7 +351,8 @@
     "audio_tracks": "音声トラック:",
     "playback_state": "再生状態:",
     "no_data_available": "データなし",
-    "index": "インデックス:"
+    "index": "インデックス:",
+    "device_discovery": "Device discovery"
   },
   "item_card": {
     "next_up": "次",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -352,7 +352,8 @@
     "audio_tracks": "Audio Tracks:",
     "playback_state": "Afspeelstatus:",
     "no_data_available": "Geen data beschikbaar",
-    "index": "Index:"
+    "index": "Index:",
+    "device_discovery": "Device discovery"
   },
   "item_card": {
     "next_up": "Volgende",

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -351,7 +351,8 @@
     "audio_tracks": "Ses Parçaları:",
     "playback_state": "Oynatma Durumu:",
     "no_data_available": "Veri bulunamadı",
-    "index": "İndeks:"
+    "index": "İndeks:",
+    "device_discovery": "Device discovery"
   },
   "item_card": {
     "next_up": "Sıradaki",

--- a/translations/zh-CN.json
+++ b/translations/zh-CN.json
@@ -351,7 +351,8 @@
     "audio_tracks": "音频轨道：",
     "playback_state": "播放状态：",
     "no_data_available": "无可用数据",
-    "index": "索引："
+    "index": "索引：",
+    "device_discovery": "Device discovery"
   },
   "item_card": {
     "next_up": "下一个",

--- a/translations/zh-TW.json
+++ b/translations/zh-TW.json
@@ -351,7 +351,8 @@
     "audio_tracks": "音頻軌道：",
     "playback_state": "播放狀態：",
     "no_data_available": "無可用數據",
-    "index": "索引："
+    "index": "索引：",
+    "device_discovery": "Device discovery"
   },
   "item_card": {
     "next_up": "下一個",


### PR DESCRIPTION
# WIP.
## These changes do not represent the finished product. Currently waiting on a few issues to be fixed in VLCKit 4.

TODO:
- Android implementation
- VLCKit 4.0 missing Chromecast modules. [Follow videolan Issue](https://code.videolan.org/videolan/VLCKit/-/issues/744)
- Handle renderItem types for future devices (airplay & upnp). [See support for it here](https://code.videolan.org/videolan/VLCKit/-/blame/master/Headers/Public/Renderer/VLCRendererItem.h?ref_type=heads#L45)
- Better layout
- remove our other chromecast dependencies

Currently, this only works for chromecast. 
In the future, this implementation will also work for other types like upnp & airplay.

## Summary by Sourcery

This pull request introduces device discovery functionality to the VLC player, enabling users to cast videos to Chromecast devices. It integrates the VLCRendererDiscoverer API from VLCKit to find available renderers and presents them in a bottom sheet modal for selection. The player controls have been updated to include a 'cast' button that triggers the discovery process.

New Features:
- Adds device discovery using the VLC discovery API, allowing users to cast videos to Chromecast devices.
- Implements a bottom sheet modal to display available renderers (currently only Chromecast) for selection.

Enhancements:
- Improves the VLC player by integrating VLCRendererDiscoverer to find and list available casting devices.
- Updates the player controls to include a 'cast' button that triggers the device discovery process and presents the bottom sheet modal.

Tests:
- Adds debug logging for the VLC player to help with debugging casting issues.