### PR TITLE
fix(511): fixed long named translations for the subtitle can break UI

### DIFF
--- a/components/SubtitleTrackSelector.tsx
+++ b/components/SubtitleTrackSelector.tsx
@@ -43,7 +43,7 @@ export const SubtitleTrackSelector: React.FC<Props> = ({
       <DropdownMenu.Root>
         <DropdownMenu.Trigger>
           <View className="flex flex-col " {...props}>
-            <Text className="opacity-50 mb-1 text-xs">
+            <Text numberOfLines={1} className="opacity-50 mb-1 text-xs">
               {t("item_card.subtitles")}
             </Text>
             <TouchableOpacity className="bg-neutral-900  h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between">


### PR DESCRIPTION
fixed long named translations for the subtitle can break UI in the subtitle screen

Before :
<img src="https://github.com/user-attachments/assets/af0d8895-3d2e-4d16-af26-853971125617" height=400/>
After: 
<img src="https://github.com/user-attachments/assets/0d7e06cc-a4e7-49be-831a-063a10292f6c" height=400 />


Addressed issue: https://github.com/streamyfin/streamyfin/issues/511

## Summary by Sourcery

Bug Fixes:
- Fixes a UI issue where long subtitle names would break the layout in the subtitle selection screen by limiting the number of lines in the subtitle text.