### PR TITLE
fix: conditionally hide the jellyseer report issue button

### DIFF
--- a/app/(auth)/(tabs)/(home,libraries,search,favorites)/jellyseerr/page.tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites)/jellyseerr/page.tsx
@@ -236,18 +236,18 @@ const Page: React.FC = () => {
                   }}
                 />
               </View>
-              <View className='mb-4'>
+              <View>
                 <GenreTags genres={details?.genres?.map((g) => g.name) || []} />
               </View>
               {isLoading || isFetching ? (
-                <Button loading={true} disabled={true} color='purple' />
+                <Button loading={true} disabled={true} color='purple' className='mt-4' />
               ) : canRequest ? (
-                <Button color='purple' onPress={request}>
+                <Button color='purple' onPress={request} className='mt-4'>
                   {t("jellyseerr.request_button")}
                 </Button>
-              ) : (
+                ) : details?.mediaInfo?.jellyfinMediaId && (
                 <Button
-                  className='bg-yellow-500/50 border-yellow-400 ring-yellow-400 text-yellow-100'
+                  className='mt-4 bg-yellow-500/50 border-yellow-400 ring-yellow-400 text-yellow-100'
                   color='transparent'
                   onPress={() => bottomSheetModalRef?.current?.present()}
                   iconLeft={


### PR DESCRIPTION
Fixes #631

## Summary by Sourcery

Conditionally hide the Jellyseerr report issue button based on media information availability

Bug Fixes:
- Modify the visibility of the report issue button to only show when a Jellyfin media ID is present

Enhancements:
- Add consistent margin to buttons for improved layout spacing