### PR TITLE
feat: adding reportPlaybackStart which allows tracking to work well

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -152,7 +152,6 @@ export default function page() {
   }
 
   const [stream, setStream] = useState<Stream | null>(null);
-  const [streamReady, setStreamReady] = useState(false);
   const [streamStatus, setStreamStatus] = useState({
     isLoading: true,
     isError: false,
@@ -193,7 +192,6 @@ export default function page() {
           result = { mediaSource, sessionId, url };
         }
         setStream(result);
-        setStreamReady(true);
       } catch (error) {
         console.error("Failed to fetch stream:", error);
         setStreamStatus({ isLoading: false, isError: true });
@@ -205,7 +203,7 @@ export default function page() {
   }, [itemId, mediaSourceId, bitrateValue, api, item, user?.Id]);
 
   useEffect(() => {
-    if (!streamReady) return;
+    if (!stream) return;
 
     const reportPlaybackStart = async () => {
       await getPlaystateApi(api!).reportPlaybackStart({
@@ -214,7 +212,7 @@ export default function page() {
     };
 
     reportPlaybackStart();
-  }, [streamReady]);
+  }, [stream]);
 
   const togglePlay = async () => {
     lightHapticFeedback();

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -217,20 +217,15 @@ export default function page() {
   }, [streamReady]);
 
   const togglePlay = async () => {
-    console.log("I'm triggered");
     lightHapticFeedback();
     setIsPlaying(!isPlaying);
-    writeToLog("ERROR", `${isPlaying}`, isPlaying);
     if (isPlaying) {
       await videoRef.current?.pause();
       reportPlaybackStopped();
     } else {
       videoRef.current?.play();
-      await getPlaystateApi(api!).onPlaybackStart({
-        itemId: item?.Id!,
-        mediaSourceId: mediaSourceId,
-        // positionTicks: currentTimeInTicks,
-        playSessionId: stream?.sessionId!,
+      await getPlaystateApi(api!).reportPlaybackStart({
+        playbackStartInfo: currentPlayStateInfo() as PlaybackStartInfo,
       });
     }
   };


### PR DESCRIPTION
Adding this seems to allow the tracking to be picked up and work correctly

## Summary by Sourcery

Improve playback tracking functionality in the direct player component by adding proper reporting of playback start and handling stream readiness

New Features:
- Add a new state variable to track stream readiness before reporting playback start

Bug Fixes:
- Ensure playback tracking is correctly initiated when stream is fully loaded

Enhancements:
- Implement reporting of playback start when stream becomes ready
- Add more detailed logging and tracking for playback state changes