### PR TITLE
fix: Fixed the import of expo-application to be the as expo docs and it allowed application to be populated

### DIFF
--- a/components/settings/UserInfo.tsx
+++ b/components/settings/UserInfo.tsx
@@ -1,5 +1,5 @@
 import { apiAtom, useJellyfin, userAtom } from "@/providers/JellyfinProvider";
-import Application from "expo-application";
+import * as Application from "expo-application";
 import Constants from "expo-constants";
 import { useAtom } from "jotai";
 import { useTranslation } from "react-i18next";


### PR DESCRIPTION
The version of the app should now be displayed in app

## Summary by Sourcery

Bug Fixes:
- Resolved an import problem that was preventing the application version from being displayed in the user settings