### PR TITLE
Remove Alamofire

### DIFF
--- a/modules/vlc-player/ios/VlcPlayer.podspec
+++ b/modules/vlc-player/ios/VlcPlayer.podspec
@@ -12,7 +12,6 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
   s.ios.dependency 'VLCKit', s.version
   s.tvos.dependency 'VLCKit', s.version
-  s.dependency 'Alamofire', '~> 5.10'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove the Alamofire dependency from the project's CocoaPods specification file