### PR TITLE
fix: improve empty state layout in library view

### DIFF
--- a/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
+++ b/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
@@ -433,14 +433,18 @@ const Page = () => {
       </View>
     );
 
-  if (flatData.length === 0)
+  if (flatData.length === 0) {
     return (
-      <View className='h-full w-full flex justify-center items-center'>
-        <Text className='text-lg text-neutral-500'>
-          {t("library.no_items_found")}
-        </Text>
+      <View className='h-full w-full mt-24'>
+        {ListHeaderComponent()}
+        <View className='flex justify-center items-center flex-1 -mt-24'>
+          <Text className='text-lg text-neutral-500'>
+            {t("library.no_items_found")}
+          </Text>
+        </View>
       </View>
     );
+  }
 
   return (
     <FlashList


### PR DESCRIPTION
Fixed header filter disappearing.

From Discord: 
> Question about the library/collection view.. using the genre and year filter works great. But when using a filter combination, setting both genre and year, that results in no items found the whole filter menu disappears.. rendering the collection view unusable? Do more people notice the same? 