### PR TITLE
fix: Fixed container name mp4 in transcoding profiles

### DIFF
--- a/utils/profiles/native.js
+++ b/utils/profiles/native.js
@@ -79,7 +79,7 @@ export const generateDeviceProfile = async () => {
         Type: MediaTypes.Video,
         Context: "Streaming",
         Protocol: "hls",
-        Container: "fmp4",
+        Container: "mp4",
         VideoCodec: "h264, hevc",
         AudioCodec: "aac,mp3,ac3,dts",
       },


### PR DESCRIPTION
The HLS container should either be `mp4` or `ts`.

See also: jellyfin-web client https://github.com/jellyfin/jellyfin-web/blob/5d9cda6dc917f04ba9b11f71a3137cdcc8dfbdab/src/scripts/browserDeviceProfile.js#L829

Should fixes: https://github.com/streamyfin/streamyfin/issues/585

## Summary by Sourcery

Bug Fixes:
- Correct the HLS container setting from "fmp4" to "mp4" in the native device profile