### PR TITLE
fix: remove unwanted detail calls on search

### DIFF
--- a/app/(auth)/(tabs)/(search)/index.tsx
+++ b/app/(auth)/(tabs)/(search)/index.tsx
@@ -331,7 +331,7 @@ export default function search() {
             <View className={l1 || l2 ? "opacity-0" : "opacity-100"}>
               <SearchItemWrapper
                 header={t("search.movies")}
-                ids={movies?.map((m) => m.Id!)}
+                items={movies}
                 renderItem={(item: BaseItemDto) => (
                   <TouchableItemRouter
                     key={item.Id}
@@ -349,7 +349,7 @@ export default function search() {
                 )}
               />
               <SearchItemWrapper
-                ids={series?.map((m) => m.Id!)}
+                items={series}
                 header={t("search.series")}
                 renderItem={(item: BaseItemDto) => (
                   <TouchableItemRouter
@@ -368,7 +368,7 @@ export default function search() {
                 )}
               />
               <SearchItemWrapper
-                ids={episodes?.map((m) => m.Id!)}
+                items={episodes}
                 header={t("search.episodes")}
                 renderItem={(item: BaseItemDto) => (
                   <TouchableItemRouter
@@ -382,7 +382,7 @@ export default function search() {
                 )}
               />
               <SearchItemWrapper
-                ids={collections?.map((m) => m.Id!)}
+                items={collections}
                 header={t("search.collections")}
                 renderItem={(item: BaseItemDto) => (
                   <TouchableItemRouter
@@ -398,7 +398,7 @@ export default function search() {
                 )}
               />
               <SearchItemWrapper
-                ids={actors?.map((m) => m.Id!)}
+                items={actors}
                 header={t("search.actors")}
                 renderItem={(item: BaseItemDto) => (
                   <TouchableItemRouter

--- a/components/search/SearchItemWrapper.tsx
+++ b/components/search/SearchItemWrapper.tsx
@@ -9,7 +9,6 @@ import type { PropsWithChildren } from "react";
 import { Text } from "../common/Text";
 
 type SearchItemWrapperProps<T> = {
-  ids?: string[] | null;
   items?: T[];
   renderItem: (item: any) => React.ReactNode;
   header?: string;
@@ -17,7 +16,6 @@ type SearchItemWrapperProps<T> = {
 };
 
 export const SearchItemWrapper = <T,>({
-  ids,
   items,
   renderItem,
   header,
@@ -26,33 +24,7 @@ export const SearchItemWrapper = <T,>({
   const [api] = useAtom(apiAtom);
   const [user] = useAtom(userAtom);
 
-  const { data, isLoading: l1 } = useQuery({
-    queryKey: ["items", ids],
-    queryFn: async () => {
-      if (!user?.Id || !api || !ids || ids.length === 0) {
-        return [];
-      }
-
-      const itemPromises = ids.map((id) =>
-        getUserItemData({
-          api,
-          userId: user.Id,
-          itemId: id,
-        }),
-      );
-
-      const results = await Promise.all(itemPromises);
-
-      // Filter out null items
-      return results.filter(
-        (item) => item !== null,
-      ) as unknown as BaseItemDto[];
-    },
-    enabled: !!ids && ids.length > 0 && !!api && !!user?.Id,
-    staleTime: Number.POSITIVE_INFINITY,
-  });
-
-  if (!data && (!items || items.length === 0)) return null;
+  if (!items || items.length === 0) return null;
 
   return (
     <>
@@ -67,7 +39,7 @@ export const SearchItemWrapper = <T,>({
         keyExtractor={(_, index) => index.toString()}
         estimatedItemSize={250}
         /*@ts-ignore */
-        data={data || items}
+        data={items}
         onEndReachedThreshold={1}
         onEndReached={onEndReached}
         //@ts-ignore


### PR DESCRIPTION
## Summary by Sourcery

Remove redundant detail fetching from search results by simplifying SearchItemWrapper to render provided items directly instead of querying by IDs and update all search usages accordingly.

Bug Fixes:
- Prevent unwanted per-item detail calls in SearchItemWrapper during search.

Enhancements:
- Remove the ids prop and associated useQuery logic from SearchItemWrapper, switching to a direct items prop.
- Update all instances of SearchItemWrapper in the search page to pass items arrays instead of ID lists.