### PR TITLE
fix: rename merge conflict label

### DIFF
--- a/.github/workflows/conflict.yml
+++ b/.github/workflows/conflict.yml
@@ -19,6 +19,6 @@ jobs:
       - name: 🚩 Apply merge conflict label
         uses: eps1lon/actions-label-merge-conflict@v3.0.3
         with:
-          dirtyLabel: 'merge conflict'
+          dirtyLabel: 'merge-conflict'
           commentOnDirty: 'This pull request has merge conflicts. Please resolve the conflicts so the PR can be successfully reviewed and merged.'
           repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Change dirtyLabel from 'merge conflict' to 'merge-conflict' in .github/workflows/conflict.yml