### PR TITLE
fix: tv home screen navigation

### DIFF
--- a/components/settings/HomeIndex.tsx
+++ b/components/settings/HomeIndex.tsx
@@ -36,6 +36,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ActivityIndicator,
+  Platform,
   RefreshControl,
   ScrollView,
   TouchableOpacity,
@@ -87,6 +88,12 @@ export const HomeIndex = () => {
 
   const { downloadedFiles, cleanCacheDirectory } = useDownload();
   useEffect(() => {
+    if (Platform.isTV) {
+      navigation.setOptions({
+        headerLeft: () => null,
+      });
+      return;
+    }
     const hasDownloads = downloadedFiles && downloadedFiles.length > 0;
     navigation.setOptions({
       headerLeft: () => (

--- a/providers/DownloadProvider.tsx
+++ b/providers/DownloadProvider.tsx
@@ -842,12 +842,39 @@ export function DownloadProvider({ children }: { children: React.ReactNode }) {
 }
 
 export function useDownload() {
+  if (Platform.isTV) {
+    // Since tv doesn't do downloads, just return no-op functions for everything
+    return {
+      processes: [],
+      startBackgroundDownload: useCallback(
+        async (
+          _url: string,
+          _item: BaseItemDto,
+          _mediaSource: MediaSourceInfo,
+          _maxBitrate?: Bitrate,
+        ) => {},
+        [],
+      ),
+      downloadedFiles: [],
+      deleteAllFiles: async (): Promise<void> => {},
+      deleteFile: async (id: string): Promise<void> => {},
+      deleteItems: async (items: BaseItemDto[]) => {},
+      saveDownloadedItemInfo: (item: BaseItemDto, size?: number) => {},
+      removeProcess: (id: string) => {},
+      setProcesses: () => {},
+      startDownload: async (_process: JobStatus): Promise<void> => {},
+      getDownloadedItem: (itemId: string) => {},
+      deleteFileByType: async (_type: BaseItemDto["Type"]) => {},
+      appSizeUsage: async () => 0,
+      getDownloadedItemSize: (itemId: string) => {},
+      APP_CACHE_DOWNLOAD_DIRECTORY: "",
+      cleanCacheDirectory: async (): Promise<void> => {},
+    };
+  }
+
   const context = useContext(DownloadContext);
   if (context === null) {
     throw new Error("useDownload must be used within a DownloadProvider");
-  }
-  if (Platform.isTV) {
-    throw new Error("useDownload is not supported on TVOS");
   }
   return context;
 }


### PR DESCRIPTION
Removed the download button from the home-page header as not needed for TV.

## Summary by Sourcery

Provide stubbed download functionality for TV platforms and hide the download button in the home screen header on TV devices.

Enhancements:
- Return no-op implementations in useDownload instead of throwing errors on TV platforms.
- Hide the download button in HomeIndex header when running on TV.