### PR TITLE
fix: remove description of pr in message

### DIFF
--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -20,5 +20,4 @@ jobs:
             **Title:** ${{ github.event.pull_request.title }}
             **By:** ${{ github.event.pull_request.user.login }}
             **Branch:** ${{ github.event.pull_request.head.ref }}
-            **Description:** ${{ github.event.pull_request.body }}
             🔗 ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
remove pr description in discord notification because it may put an error because the message in more than 2000 characters long, which is the maximum by discord limits