### PR TITLE
feat(player): add hardware keyboard support for play/pause on iPad

### DIFF
--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -13,6 +13,8 @@ import { VideoPlayer, useSettings } from "@/utils/atoms/settings";
 import { getDefaultPlaySettings } from "@/utils/jellyfin/getDefaultPlaySettings";
 import { getItemById } from "@/utils/jellyfin/user-library/getItemById";
 import { writeToLog } from "@/utils/log";
+import { Keyboard } from "react-native";
+import { useEffect } from "react";
 import {
   formatTimeString,
   msToTicks,
@@ -156,6 +158,22 @@ export const Controls: FC<Props> = ({
   useEffect(() => {
     prefetchAllTrickplayImages();
   }, []);
+
+  useEffect(() => {
+    const onKeyPress = (e: any) => {
+      // Check for spacebar (key could be ' ' or 'Spacebar' depending on platform)
+      if (e?.key === ' ' || e?.key === 'Spacebar') {
+        togglePlay(progress.value);
+      }
+    };
+
+    // Add event listener (works on some platforms)
+    window?.addEventListener?.('keydown', onKeyPress);
+
+    return () => {
+      window?.removeEventListener?.('keydown', onKeyPress);
+    };
+  }, [togglePlay, progress]);
 
   useEffect(() => {
     if (item) {


### PR DESCRIPTION
This commit adds support for toggling playback using the spacebar on iPads with external keyboards. The logic listens for 'keydown' events and triggers `togglePlay` when the space key is pressed.

This improves accessibility and matches user expectations from other media apps like Swiftfin or Plex.

Closes #718 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to toggle video play and pause using the spacebar key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->