### PR TITLE
Fix orientation race condition

### DIFF
--- a/app/(auth)/player/_layout.tsx
+++ b/app/(auth)/player/_layout.tsx
@@ -1,33 +1,8 @@
-import * as ScreenOrientation from "@/packages/expo-screen-orientation";
-import { useSettings } from "@/utils/atoms/settings";
 import { Stack } from "expo-router";
-import React, { useLayoutEffect } from "react";
-import { Platform } from "react-native";
+import React from "react";
 import { SystemBars } from "react-native-edge-to-edge";
 
 export default function Layout() {
-  const [settings] = useSettings();
-
-  useLayoutEffect(() => {
-    if (Platform.isTV) return;
-
-    if (!settings.followDeviceOrientation && settings.defaultVideoOrientation) {
-      ScreenOrientation.lockAsync(settings.defaultVideoOrientation);
-    }
-
-    return () => {
-      if (Platform.isTV) return;
-
-      if (settings.followDeviceOrientation === true) {
-        ScreenOrientation.unlockAsync();
-      } else {
-        ScreenOrientation.lockAsync(
-          ScreenOrientation.OrientationLock.PORTRAIT_UP,
-        );
-      }
-    };
-  });
-
   return (
     <>
       <SystemBars hidden />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -414,21 +414,32 @@ function Layout() {
     }, []);
 
     useEffect(() => {
-      if (Platform.isTV) return;
-      if (segments.includes("direct-player" as never)) {
+      if (Platform.isTV) {
         return;
       }
 
-      // If the user has auto rotate enabled, unlock the orientation
+      if (segments.includes("direct-player" as never)) {
+        if (
+          !settings.followDeviceOrientation &&
+          settings.defaultVideoOrientation
+        ) {
+          ScreenOrientation.lockAsync(settings.defaultVideoOrientation);
+        }
+        return;
+      }
+
       if (settings.followDeviceOrientation === true) {
         ScreenOrientation.unlockAsync();
       } else {
-        // If the user has auto rotate disabled, lock the orientation to portrait
         ScreenOrientation.lockAsync(
           ScreenOrientation.OrientationLock.PORTRAIT_UP,
         );
       }
-    }, [settings.followDeviceOrientation, segments]);
+    }, [
+      settings.followDeviceOrientation,
+      settings.defaultVideoOrientation,
+      segments,
+    ]);
 
     useEffect(() => {
       const subscription = AppState.addEventListener(

--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -522,9 +522,6 @@ export const Controls: FC<Props> = ({
 
   const onClose = async () => {
     lightHapticFeedback();
-    await ScreenOrientation.lockAsync(
-      ScreenOrientation.OrientationLock.PORTRAIT_UP,
-    );
     router.back();
   };
 


### PR DESCRIPTION
It looks like the issue stems from multiple parts of the codebase trying to change the orientation, which is leading to a race condition. This seems to cause orientation locks—something I’ve noticed frequently when pressing the exit button to leave the video player.

Right now, this is one of my biggest frustrations when using the app. The changes I’ve made centralize orientation handling to a single location, which removes the race condition. I’ve tested this across various scenarios, and it appears to be working well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed all logic related to screen orientation management and settings-based orientation locking/unlocking in relevant components.
  * Updated behavior so that orientation is no longer locked to portrait mode when closing video player controls.
  * Adjusted effect logic to lock orientation to a default setting only if the user has disabled following device orientation and a default orientation is set.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->