### PR TITLE
fix: only run iOS build if it’s on a branch of the repo

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -12,6 +12,8 @@ on:
     branches: [develop, master]
 
 jobs:
+  main-repo-only:
+    if: github.repository == 'streamyfin/streamyfin' && (github.event_name != 'pull_request' || github.event.pull_request?.head.repo.full_name == 'streamyfin/streamyfin')
   build:
     runs-on: macos-15
     name: 🏗️ Build iOS IPA


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to add a new job that only runs for specific events in the main repository. This does not affect existing build processes for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->