### PR TITLE
fix: only run iOS build if it’s on a branch of the repo

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -12,6 +12,8 @@ on:
     branches: [develop, master]
 
 jobs:
+  main-repo-only:
+    if: github.repository == 'streamyfin/streamyfin' && (github.event_name != 'pull_request' || github.event.pull_request?.head.repo.full_name == 'streamyfin/streamyfin')
   build:
     runs-on: macos-15
     name: 🏗️ Build iOS IPA

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -12,9 +12,8 @@ on:
     branches: [develop, master]
 
 jobs:
-  main-repo-only:
-    if: github.repository == 'streamyfin/streamyfin' && (github.event_name != 'pull_request' || github.event.pull_request?.head.repo.full_name == 'streamyfin/streamyfin')
   build:
+    if: github.event_name != 'pull_request' || github.event.pull_request?.head.repo.full_name == github.repository
     runs-on: macos-15
     name: 🏗️ Build iOS IPA
     permissions:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request?.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'streamyfin/streamyfin'
     runs-on: macos-15
     name: 🏗️ Build iOS IPA
     permissions:


### PR DESCRIPTION
### Problem

GitHub Actions jobs were running for all pull requests—including those opened from forked repositories.
This posed two main issues:

- **Security risk:** Forked repositories cannot access repository secrets, but if jobs run for forks, steps requiring secrets will fail or need to be skipped.
- **Workflow failures:** Jobs/processes expecting secrets (like deployment tokens or keys) may error out on fork-based PRs, creating confusion for contributors and maintainers.

**Summary:**
Jobs should not attempt to run with required secrets on PRs from forks, since secrets are purposely not accessible to workflows triggered by forks for security reasons.

### Fix

A condition was introduced to restrict jobs to run only when:

- It is not a pull request event, **or**
- If it’s a pull request, the source branch (`head.repo.full_name`) must match the main repository (not a fork).

This ensures:

- **PRs from forks cannot run jobs requiring secrets**, eliminating related security exposures or workflow errors.
- Internal PRs (from branches inside the main repo) continue to work as expected, with full access to secrets.


#### Example Condition

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request?.head.repo.full_name == github.repository
```

- **Effect:** Internal PRs and all non-PR events run jobs; PRs originating from forks are skipped.


### Rationale

This approach protects sensitive information and avoids broken workflows due to missing secrets—addressing both security and CI reliability concerns regarding forks and secrets in GitHub Actions.

Here’s an improved, updated description reflecting your last adjustments, keeping clarity and engineering/DevOps best practices in mind:

### Problem

Previously, GitHub Actions jobs were triggered for all pull requests—including those opened from forked repositories.
This created significant challenges:

- **Security risk:** Forks never receive repository secrets (such as deployment tokens, API keys, or service credentials). Running jobs that expect these secrets on fork-based PRs could create a vector for accidental information leakage, or (more commonly) result in workflow failures.
- **Workflow instability:** Steps dependent on secrets fail on PRs from forks. This can confuse contributors, lead to unnecessary failed checks, and obscure the real status or test results of PRs.

**Summary:**
Jobs that rely on secrets must not run on pull requests from forks. GitHub intentionally blocks access to secrets for fork-based workflows, so we need to ensure our workflows behave accordingly.

### Solution

A job-level condition was added so that sensitive jobs are triggered only when:

- The event is not a pull request (`pull_request`), **or**
- If the event is a pull request, the branch’s repository (`head.repo.full_name`) matches the main repository—indicating the PR comes from a branch within the main repo and is not from a fork.

This ensures:

- **PRs from forks cannot execute jobs requiring secrets**, fully preventing accidental exposure or step failures due to missing secrets.
- PRs and pushes from within the primary repository (`streamyfin/streamyfin`) continue to run with secrets available, as intended for trusted contributors.


#### Example Job Condition

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'streamyfin/streamyfin'
```

or more generally,

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

**Effect:**
Only internal PRs and non-PR events (pushes, workflow_dispatch, etc.) run sensitive jobs.
PRs originating from forks are skipped for those jobs.

### Rationale

This approach safeguards secrets, clarifies contributor experience (especially for external contributors and new maintainers), and avoids noisy, misleading CI failures on forks—making the CI pipeline more secure and reliable when interacting with open-source contributions via GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to only run for certain pull requests, improving workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->