### PR TITLE
feat: add setting to disable volume and brightness sliders

### DIFF
--- a/components/settings/OtherSettings.tsx
+++ b/components/settings/OtherSettings.tsx
@@ -164,6 +164,19 @@ export const OtherSettings: React.FC = () => {
           />
         </ListItem>
 
+        <ListItem
+          title={t("home.settings.other.volume_and_brightness_sliders")}
+          disabled={false}
+        >
+          <Switch
+            value={settings.volumeAndBrightnessSlidersEnabled}
+            disabled={pluginSettings?.volumeAndBrightnessSlidersEnabled?.locked}
+            onValueChange={(value) =>
+              updateSettings({ volumeAndBrightnessSlidersEnabled: value })
+            }
+          />
+        </ListItem>
+
         {/* {(Platform.OS === "ios" || Platform.isTVOS)&& (
           <ListItem
             title={t("home.settings.other.video_player")}

--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -651,22 +651,26 @@ export const Controls: FC<Props> = ({
               justifyContent: "space-between",
               alignItems: "center",
               transform: [{ translateY: -22.5 }], // Adjust for the button's height (half of 45)
-              paddingHorizontal: "28%", // Add some padding to the left and right
+              paddingHorizontal: settings?.volumeAndBrightnessSlidersEnabled
+                ? "28%"
+                : "20%", // Add some padding to the left and right
             }}
             pointerEvents={showControls ? "box-none" : "none"}
           >
-            <View
-              style={{
-                position: "absolute",
-                alignItems: "center",
-                transform: [{ rotate: "270deg" }], // Rotate the slider to make it vertical
-                left: 0,
-                bottom: 30,
-                opacity: showControls ? 1 : 0,
-              }}
-            >
-              <BrightnessSlider />
-            </View>
+            {settings?.volumeAndBrightnessSlidersEnabled && (
+              <View
+                style={{
+                  position: "absolute",
+                  alignItems: "center",
+                  transform: [{ rotate: "270deg" }], // Rotate the slider to make it vertical
+                  left: 0,
+                  bottom: 30,
+                  opacity: showControls ? 1 : 0,
+                }}
+              >
+                <BrightnessSlider />
+              </View>
+            )}
             <TouchableOpacity onPress={handleSkipBackward}>
               <View
                 style={{
@@ -741,18 +745,20 @@ export const Controls: FC<Props> = ({
               </View>
             </TouchableOpacity>
 
-            <View
-              style={{
-                position: "absolute",
-                alignItems: "center",
-                transform: [{ rotate: "270deg" }], // Rotate the slider to make it vertical
-                bottom: 30,
-                right: 0,
-                opacity: showAudioSlider || showControls ? 1 : 0,
-              }}
-            >
-              <AudioSlider setVisibility={setShowAudioSlider} />
-            </View>
+            {settings?.volumeAndBrightnessSlidersEnabled && (
+              <View
+                style={{
+                  position: "absolute",
+                  alignItems: "center",
+                  transform: [{ rotate: "270deg" }], // Rotate the slider to make it vertical
+                  bottom: 30,
+                  right: 0,
+                  opacity: showAudioSlider || showControls ? 1 : 0,
+                }}
+              >
+                <AudioSlider setVisibility={setShowAudioSlider} />
+              </View>
+            )}
           </View>
 
           <View

--- a/translations/de.json
+++ b/translations/de.json
@@ -139,7 +139,8 @@
         "select_liraries_you_want_to_hide": "Wähl die Bibliotheken aus, die du im Bibliothekstab und auf der Startseite ausblenden möchtest.",
         "disable_haptic_feedback": "Haptisches Feedback deaktivieren",
         "default_quality": "Standardqualität",
-        "disabled": "Deaktiviert"
+        "disabled": "Deaktiviert",
+        "volume_and_brightness_sliders": "Lautstärke- und Helligkeitsregler"
       },
       "downloads": {
         "downloads_title": "Downloads",

--- a/translations/en.json
+++ b/translations/en.json
@@ -140,7 +140,8 @@
         "disable_haptic_feedback": "Disable Haptic Feedback",
         "default_quality": "Default quality",
         "max_auto_play_episode_count": "Max auto play episode count",
-        "disabled": "Disabled"
+        "disabled": "Disabled",
+        "volume_and_brightness_sliders": "Volume and Brightness Sliders"
       },
       "downloads": {
         "downloads_title": "Downloads",

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -169,6 +169,7 @@ export type Settings = {
   defaultPlayer: VideoPlayer;
   maxAutoPlayEpisodeCount: MaxAutoPlayEpisodeCount;
   autoPlayEpisodeCount: number;
+  volumeAndBrightnessSlidersEnabled: boolean;
 };
 
 export interface Lockable<T> {
@@ -226,6 +227,7 @@ const defaultValues: Settings = {
   defaultPlayer: VideoPlayer.VLC_3, // ios-only setting. does not matter what this is for android
   maxAutoPlayEpisodeCount: { key: "3", value: 3 },
   autoPlayEpisodeCount: 0,
+  volumeAndBrightnessSlidersEnabled: true,
 };
 
 const loadSettings = (): Partial<Settings> => {


### PR DESCRIPTION
This PR introduces a new setting that allows users to disable the volume and brightness sliders in the video player UI.

Motivation:
I often accidentally changed the brightness or volume while watching content, which was frustrating and disruptive. This setting helps avoid unintended input by removing the sliders from the UI when not needed.

Behavior:
- When enabled, the volume and brightness sliders are hidden from the interface.
- When enabled, the skip forward/backward buttons are spaced out more.
- The default behavior (sliders visible) remains unchanged.
- Ideal for users who prefer external controls or a cleaner interface.

Let me know if the setting should be renamed or placed somewhere else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle in settings to enable or disable volume and brightness sliders.
  * Volume and brightness sliders in the video player can now be shown or hidden based on user preference.

* **Localization**
  * Added translations for the new "Volume and Brightness Sliders" setting in English and German.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->