### PR TITLE
fix: Adds conditional check to validate PR title job

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   validate_pr_title:
     name: "📝 Validate PR Title"
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write


### PR DESCRIPTION
Prevents the PR title validation job from running on non-pull request events, ensuring the workflow only executes when appropriate and avoiding potential failures or unnecessary runs on other trigger events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow to ensure PR title validation runs only on pull request events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->