### PR TITLE
feat: Adds separate Android TV and iOS TV build workflows

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,4 +1,4 @@
-name: 🤖 Android APK Build
+name: 🤖 Android APK Build (Phone + TV)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,11 +12,15 @@ on:
     branches: [develop, master]
 
 jobs:
-  build:
+  build-android:
     runs-on: ubuntu-24.04
     name: 🏗️ Build Android APK
     permissions:
       contents: read
+
+    strategy:
+      matrix:
+        target: [phone, tv]
 
     steps:
       - name: 📥 Checkout code
@@ -32,38 +36,38 @@ jobs:
         with:
           bun-version: latest
 
-      - name: ☕ Setup JDK
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
       - name: 💾 Cache Bun dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-cache-${{ hashFiles('bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-cache-
 
-      - name: 📦 Install dependencies
+      - name: 📦 Install dependencies and reload submodules
         run: |
           bun install --frozen-lockfile
           bun run submodule-reload
 
       - name: 💾 Cache Android dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: |
-            android/.gradle
-          key: ${{ runner.os }}-android-deps-${{ hashFiles('android/**/build.gradle') }}
+          path: android/.gradle
+          key: ${{ runner.os }}-android-deps-${{ hashFiles('android/**/build.gradle', 'android/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-android-deps-
 
       - name: 🛠️ Generate project files
-        run: bun run prebuild
+        run: |
+          if [ "${{ matrix.target }}" = "tv" ]; then
+            bun run prebuild:tv
+          else
+            bun run prebuild
+          fi
 
-      - name: 🚀 Build APK via Bun
+      - name: 🚀 Build APK
+        env:
+          EXPO_TV: ${{ matrix.target == 'tv' && 1 || 0 }}
         run: bun run build:android:local
 
       - name: 📅 Set date tag
@@ -72,8 +76,9 @@ jobs:
       - name: 📤 Upload APK artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: streamyfin-apk-${{ env.DATE_TAG }}
+          name: streamyfin-android-${{ matrix.target }}-apk-${{ env.DATE_TAG }}
           path: |
             android/app/build/outputs/apk/release/*.apk
             android/app/build/outputs/bundle/release/*.aab
           retention-days: 7
+

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,4 +1,4 @@
-name: 🤖 iOS IPA Build
+name: 🤖 iOS IPA Build (Phone + TV)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,15 +12,19 @@ on:
     branches: [develop, master]
 
 jobs:
-  build:
+  build-ios:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'streamyfin/streamyfin'
     runs-on: macos-15
     name: 🏗️ Build iOS IPA
     permissions:
       contents: read
 
+    strategy:
+      matrix:
+        target: [phone, tv]
+
     steps:
-      - name: 📥 Check out repository
+      - name: 📥 Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -34,20 +38,25 @@ jobs:
           bun-version: latest
 
       - name: 💾 Cache Bun dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-cache-${{ hashFiles('bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-cache-
 
-      - name: 📦 Install & Prepare
+      - name: 📦 Install dependencies and reload submodules
         run: |
           bun install --frozen-lockfile
           bun run submodule-reload
 
       - name: 🛠️ Generate project files
-        run: bun run prebuild
+        run: |
+          if [ "${{ matrix.target }}" = "tv" ]; then
+            bun run prebuild:tv
+          else
+            bun run prebuild
+          fi
 
       - name: 🏗 Setup EAS
         uses: expo/expo-github-action@main
@@ -56,8 +65,9 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 🏗️ Build iOS app
-        run: |
-          eas build -p ios --local --non-interactive
+        env:
+          EXPO_TV: ${{ matrix.target == 'tv' && 1 || 0 }}
+        run: eas build -p ios --local --non-interactive
 
       - name: 📅 Set date tag
         run: echo "DATE_TAG=$(date +%d-%m-%Y_%H-%M-%S)" >> $GITHUB_ENV
@@ -65,7 +75,7 @@ jobs:
       - name: 📤 Upload IPA artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: streamyfin-ipa-${{ env.DATE_TAG }}
-          path: |
-            build-*.ipa
+          name: streamyfin-ios-${{ matrix.target }}-ipa-${{ env.DATE_TAG }}
+          path: build-*.ipa
           retention-days: 7
+


### PR DESCRIPTION
Splits build workflows to support both phone and TV variants for Android and iOS platforms.

Creates dedicated jobs for TV builds that use specific prebuild commands and environment variables. Updates workflow names to reflect dual-platform support and improves artifact naming to distinguish between phone and TV builds.

Removes JDK setup from Android workflow as it's handled by build scripts. Updates cache action versions and standardizes step descriptions across workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android and iOS build workflows to separately build and upload artifacts for both Phone and TV platforms.
  * Renamed and split build jobs for clearer distinction between Phone and TV targets.
  * Improved artifact naming and workflow step clarity for easier identification of build outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->