### PR TITLE
fix(ci): Disables fail-fast for CI build matrices

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -19,6 +19,7 @@ jobs:
       contents: read
 
     strategy:
+      fail-fast: false
       matrix:
         target: [phone, tv]
 

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -20,6 +20,7 @@ jobs:
       contents: read
 
     strategy:
+      fail-fast: false
       matrix:
         target: [phone, tv]
 


### PR DESCRIPTION
Allows all matrix jobs to complete even if one fails, providing better visibility into which specific targets are broken and enabling partial CI results rather than early termination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflows so that all Android and iOS build jobs run to completion, even if one job fails. This ensures that results for all targets are available regardless of individual failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->