### PR TITLE
change discord invite link to working link since it expired

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Key points of the MPL-2.0:
 
 ## 🌐 Connect with Us
 
-Join our Discord: [https://discord.gg/aJvAYeycyY](https://discord.gg/aJvAYeycyY)
+Join our Discord: [https://discord.com/invite/bJUUVgdsGe](https://discord.com/invite/bJUUVgdsGe)
 
 Need support or have questions:
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Key points of the MPL-2.0:
 
 ## 🌐 Connect with Us
 
-Join our Discord: [https://discord.com/invite/bJUUVgdsGe](https://discord.com/invite/bJUUVgdsGe)
+Join our Discord: [![](https://dcbadge.limes.pink/api/server/https://discord.gg/BuGG9ZNhaE)](https://discord.gg/BuGG9ZNhaE)
 
 Need support or have questions:
 


### PR DESCRIPTION
this is just a small change to the readme file that only changes the discord link for a working discord link 😄 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the "Connect with Us" entry in the README: replaced the old plain Discord invite with a new invite URL presented as a clickable image badge that links to the new server. Visible change only; no other content or formatting updates were made elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->