### PR TITLE
fix: Resumes playback from saved position in Chromecast

### DIFF
--- a/components/PlayButton.tsx
+++ b/components/PlayButton.tsx
@@ -31,7 +31,7 @@ import { getPrimaryImageUrl } from "@/utils/jellyfin/image/getPrimaryImageUrl";
 import { getStreamUrl } from "@/utils/jellyfin/media/getStreamUrl";
 import { chromecast } from "@/utils/profiles/chromecast";
 import { chromecasth265 } from "@/utils/profiles/chromecasth265";
-import { runtimeTicksToMinutes } from "@/utils/time";
+import { runtimeTicksToMinutes, ticksToSeconds } from "@/utils/time";
 import type { Button } from "./Button";
 import type { SelectedOptions } from "./ItemContent";
 
@@ -202,7 +202,9 @@ export const PlayButton: React.FC<Props> = ({
                                   ],
                                 },
                       },
-                      startTime: 0,
+                      startTime: ticksToSeconds(
+                        item?.UserData?.PlaybackPositionTicks || 0,
+                      ),
                     })
                     .then(() => {
                       // state is already set when reopening current media, so skip it here.


### PR DESCRIPTION
Uses the user's saved playback position from UserData instead of always starting from the beginning.

Imports ticksToSeconds utility to convert Jellyfin ticks format to seconds for Chromecast compatibility.

Reference to this issue: https://github.com/streamyfin/streamyfin/issues/858

Supercedes: #868 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media playback now resumes from your last watched position instead of always starting from the beginning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->