### PR TITLE
fix: Adds Biome version management to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
     "docker:enableMajor",
     "group:testNonMajor",
     "group:monorepos",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    "customManagers:biomeVersions"
   ],
   "addLabels": ["dependencies"],
   "rebaseWhen": "conflicted",


### PR DESCRIPTION
Enables automatic dependency updates for Biome versions by including the customManagers:biomeVersions preset.

This allows Renovate to detect and update Biome tool versions consistently across the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to include enhanced handling for Biome version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->