### PR TITLE
refactor: simplify renovate configuration and revert kotlin

### DIFF
--- a/modules/vlc-player/android/build.gradle
+++ b/modules/vlc-player/android/build.gradle
@@ -8,7 +8,7 @@ group = 'expo.modules.vlcplayer'
 version = '0.6.0'
 
 def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
-def kotlinVersion = findProperty('android.kotlinVersion') ?: '2.0.21'
+def kotlinVersion = findProperty('android.kotlinVersion') ?: '1.9.25'
 
 apply from: expoModulesCorePlugin
 

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   ],
   "addLabels": ["dependencies"],
   "rebaseWhen": "conflicted",
-  "ignorePaths": ["**/node_modules/**", "**/bower_components/**"],
+  "ignorePaths": ["**/bower_components/**"],
   "lockFileMaintenance": {
     "enabled": true,
     "groupName": "lockfiles",

--- a/renovate.json
+++ b/renovate.json
@@ -23,10 +23,6 @@
   },
   "packageRules": [
     {
-      "matchDepTypes": ["dependencies", "devDependencies"],
-      "enabled": true
-    },
-    {
       "description": "Add 'ci' and 'github-actions' labels to GitHub Action update PRs",
       "matchManagers": ["github-actions"],
       "addLabels": ["ci", "github-actions"]
@@ -49,6 +45,5 @@
       "matchPackagePatterns": ["expo", "react-native"],
       "addLabels": ["expo", "react-native"]
     }
-  ],
-  "enabledManagers": ["bun"]
+  ]
 }


### PR DESCRIPTION
Removes redundant package rules and manager configurations that were unnecessary for the current setup.

The explicit enabling of dependencies and devDependencies was redundant since they are enabled by default, and the bun manager specification was not needed for the current dependency management approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Group minor/patch GitHub Actions updates into a single CI dependency PR to reduce noise from automated updates.
  * Removed an unused package manager integration from dependency automation.
  * Adjusted dependency-update ignore paths to be more focused.
  * Updated Android module's default Kotlin tooling version to 1.9.25.
  * No user-facing functionality changes; maintenance-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->