### PR TITLE
fix: settings storage calc

### DIFF
--- a/app/(auth)/(tabs)/(home)/settings.tsx
+++ b/app/(auth)/(tabs)/(home)/settings.tsx
@@ -2,7 +2,7 @@ import { useNavigation, useRouter } from "expo-router";
 import { t } from "i18next";
 import { useAtom } from "jotai";
 import { useEffect } from "react";
-import { ScrollView, TouchableOpacity, View } from "react-native";
+import { Platform, ScrollView, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/common/Text";
 import { ListGroup } from "@/components/list/ListGroup";
@@ -73,13 +73,13 @@ export default function settings() {
 
         <OtherSettings />
 
-        <DownloadSettings />
+        {!Platform.isTV && <DownloadSettings />}
 
         <PluginSettings />
 
         <AppLanguageSelector />
 
-        <ChromecastSettings />
+        {!Platform.isTV && <ChromecastSettings />}
 
         <ListGroup title={"Intro"}>
           <ListItem
@@ -112,7 +112,7 @@ export default function settings() {
           </ListGroup>
         </View>
 
-        <StorageSettings />
+        {!Platform.isTV && <StorageSettings />}
       </View>
     </ScrollView>
   );

--- a/components/settings/StorageSettings.tsx
+++ b/components/settings/StorageSettings.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import * as FileSystem from "expo-file-system";
 import { useTranslation } from "react-i18next";
-import { View } from "react-native";
+import { Platform, View } from "react-native";
 import { toast } from "sonner-native";
 import { Text } from "@/components/common/Text";
 import { Colors } from "@/constants/Colors";
@@ -21,10 +20,12 @@ export const StorageSettings = () => {
     queryFn: async () => {
       const app = await appSizeUsage();
 
-      const remaining = await FileSystem.getFreeDiskStorageAsync();
-      const total = await FileSystem.getTotalDiskCapacityAsync();
-
-      return { app, remaining, total, used: (total - remaining) / total };
+      return {
+        appSize: app.appSize,
+        total: app.total,
+        remaining: app.remaining,
+        used: (app.total - app.remaining) / app.total,
+      };
     },
   });
 
@@ -39,6 +40,7 @@ export const StorageSettings = () => {
   };
 
   const calculatePercentage = (value: number, total: number) => {
+    console.log("usage", value, total);
     return ((value / total) * 100).toFixed(2);
   };
 
@@ -61,13 +63,13 @@ export const StorageSettings = () => {
             <View className='flex flex-row'>
               <View
                 style={{
-                  width: `${(size.app / size.total) * 100}%`,
+                  width: `${(size.appSize / size.total) * 100}%`,
                   backgroundColor: Colors.primaryRGB,
                 }}
               />
               <View
                 style={{
-                  width: `${((size.total - size.remaining - size.app) / size.total) * 100}%`,
+                  width: `${((size.total - size.remaining - size.appSize) / size.total) * 100}%`,
                   backgroundColor: Colors.primaryLightRGB,
                 }}
               />
@@ -81,7 +83,7 @@ export const StorageSettings = () => {
                 <View className='w-3 h-3 rounded-full bg-purple-600 mr-1' />
                 <Text className='text-white text-xs'>
                   {t("home.settings.storage.app_usage", {
-                    usedSpace: calculatePercentage(size.app, size.total),
+                    usedSpace: calculatePercentage(size.appSize, size.total),
                   })}
                 </Text>
               </View>
@@ -90,7 +92,7 @@ export const StorageSettings = () => {
                 <Text className='text-white text-xs'>
                   {t("home.settings.storage.device_usage", {
                     availableSpace: calculatePercentage(
-                      size.total - size.remaining - size.app,
+                      size.total - size.remaining - size.appSize,
                       size.total,
                     ),
                   })}
@@ -100,13 +102,15 @@ export const StorageSettings = () => {
           )}
         </View>
       </View>
-      <ListGroup>
-        <ListItem
-          textColor='red'
-          onPress={onDeleteClicked}
-          title={t("home.settings.storage.delete_all_downloaded_files")}
-        />
-      </ListGroup>
+      {!Platform.isTV && (
+        <ListGroup>
+          <ListItem
+            textColor='red'
+            onPress={onDeleteClicked}
+            title={t("home.settings.storage.delete_all_downloaded_files")}
+          />
+        </ListGroup>
+      )}
     </View>
   );
 };

--- a/providers/DownloadProvider.tsx
+++ b/providers/DownloadProvider.tsx
@@ -687,7 +687,7 @@ function useDownloadProvider() {
         appSize += fileInfo.size;
       }
     }
-    return { total, remaining, app: appSize };
+    return { total, remaining, appSize: appSize };
   };
 
   return {
@@ -731,7 +731,7 @@ export function useDownload() {
       APP_CACHE_DOWNLOAD_DIRECTORY: "",
       cleanCacheDirectory: async () => {},
       updateDownloadedItem: () => {},
-      appSizeUsage: async () => ({ total: 0, remaining: 0, app: 0 }),
+      appSizeUsage: async () => ({ total: 0, remaining: 0, appSize: 0 }),
     };
   }
 


### PR DESCRIPTION
Fixed an issue with storage calc showing NAN
Added some checks for settings to not be shown if on TV

Fixes: https://github.com/streamyfin/streamyfin/issues/941
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - TV-optimized Settings: Hides Downloads, Chromecast, and Storage sections on TV devices for a cleaner experience.
- Bug Fixes
  - Storage usage display updated for clearer, more accurate breakdowns and usage bars.
  - Labels and calculations now reflect app size separately for improved readability.
- Refactor
  - Internal adjustments to storage data handling to support the updated display.
  - Conditional rendering added to limit certain actions (e.g., Delete All Downloads) on TV devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->