### PR TITLE
ci: add iOS 18.0 SDK installation step

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -68,11 +68,11 @@ jobs:
       - name: ⚙️ Ensure iOS/tvOS SDKs installed
         run: |
           if [ "${{ matrix.target }}" = "tv" ]; then
-            sudo xcodebuild -downloadPlatform tvOS
+            xcodebuild -downloadPlatform tvOS
           else
-            sudo xcodebuild -downloadPlatform iOS
+            xcodebuild -downloadPlatform iOS
           fi
-   
+
       - name: 🚀 Build iOS app
         env:
           EXPO_TV: ${{ matrix.target == 'tv' && 1 || 0 }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -58,13 +58,21 @@ jobs:
           else
             bun run prebuild
           fi
-      
+
       - name: 🏗️ Setup EAS
         uses: expo/expo-github-action@main
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
+      - name: ⚙️ Ensure iOS/tvOS SDKs installed
+        run: |
+          if [ "${{ matrix.target }}" = "tv" ]; then
+            sudo xcodebuild -downloadPlatform tvOS
+          else
+            sudo xcodebuild -downloadPlatform iOS
+          fi
+   
       - name: 🚀 Build iOS app
         env:
           EXPO_TV: ${{ matrix.target == 'tv' && 1 || 0 }}

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
       "exclude": [
         "react-native",
         "@shopify/flash-list",
-        "react-native-reanimated"
+        "react-native-reanimated",
+        "react-native-pager-view"
       ]
     },
     "doctor": {


### PR DESCRIPTION
Ensures iOS 18.0 SDK is available during the build process by downloading the platform before EAS setup.

This prevents potential build failures when targeting newer iOS versions that require the latest SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - CI update: adds an automated step to ensure the Apple SDK (iOS/tvOS) is installed and enables the iOS build command during CI, improving build reliability.
  - Dependency tooling: excludes react-native-pager-view from automatic Expo installs to stabilize dependency management.
  - No direct user-facing UI changes in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->