### PR TITLE
Fix selecting bit rate on whole series downloads

### DIFF
--- a/components/DownloadItem.tsx
+++ b/components/DownloadItem.tsx
@@ -106,20 +106,17 @@ export const DownloadItems: React.FC<DownloadProps> = ({
 
   // Initialize selectedOptions with default values
   useEffect(() => {
-    if (itemsNotDownloaded.length === 1) {
-      setSelectedOptions(() => ({
-        bitrate: defaultBitrate,
-        mediaSource: defaultMediaSource,
-        subtitleIndex: defaultSubtitleIndex ?? -1,
-        audioIndex: defaultAudioIndex,
-      }));
-    }
+    setSelectedOptions(() => ({
+      bitrate: defaultBitrate,
+      mediaSource: defaultMediaSource,
+      subtitleIndex: defaultSubtitleIndex ?? -1,
+      audioIndex: defaultAudioIndex,
+    }));
   }, [
     defaultAudioIndex,
     defaultBitrate,
     defaultSubtitleIndex,
     defaultMediaSource,
-    itemsNotDownloaded.length,
   ]);
 
   const itemsToDownload = useMemo(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Default download options are now consistently preselected when opening the download dialog, regardless of how many items are pending.
  * Options no longer reset unexpectedly when the number of not-downloaded items changes; they only update when default preferences change.
* **Behavior Improvement**
  * More predictable and stable initialization of download settings, reducing confusion and preventing accidental changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->