### PR TITLE
feat: replace content item dropdowns with sheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ streamyfin-4fec1-firebase-adminsdk.json
 .env.local
 *.aab
 /version-backup-*
+bun.lockb

--- a/components/BitRateSheet.tsx
+++ b/components/BitRateSheet.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Platform, TouchableOpacity, View } from "react-native";
+import { Text } from "./common/Text";
+import { FilterSheet } from "./filters/FilterSheet";
+
+export type Bitrate = {
+  key: string;
+  value: number | undefined;
+};
+
+export const BITRATES: Bitrate[] = [
+  {
+    key: "Max",
+    value: undefined,
+  },
+  {
+    key: "8 Mb/s",
+    value: 8000000,
+    height: 1080,
+  },
+  {
+    key: "4 Mb/s",
+    value: 4000000,
+    height: 1080,
+  },
+  {
+    key: "2 Mb/s",
+    value: 2000000,
+  },
+  {
+    key: "1 Mb/s",
+    value: 1000000,
+  },
+  {
+    key: "500 Kb/s",
+    value: 500000,
+  },
+  {
+    key: "250 Kb/s",
+    value: 250000,
+  },
+].sort(
+  (a, b) =>
+    (b.value || Number.POSITIVE_INFINITY) -
+    (a.value || Number.POSITIVE_INFINITY),
+);
+
+interface Props extends React.ComponentProps<typeof View> {
+  onChange: (value: Bitrate) => void;
+  selected?: Bitrate | null;
+  inverted?: boolean | null;
+}
+
+export const BitrateSheet: React.FC<Props> = ({
+  onChange,
+  selected,
+  inverted,
+  ...props
+}) => {
+  const isTv = Platform.isTV;
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const sorted = useMemo(() => {
+    if (inverted)
+      return BITRATES.slice().sort(
+        (a, b) =>
+          (a.value || Number.POSITIVE_INFINITY) -
+          (b.value || Number.POSITIVE_INFINITY),
+      );
+    return BITRATES.slice().sort(
+      (a, b) =>
+        (b.value || Number.POSITIVE_INFINITY) -
+        (a.value || Number.POSITIVE_INFINITY),
+    );
+  }, [inverted]);
+
+  if (isTv) return null;
+
+  return (
+    <View
+      className='flex shrink'
+      style={{
+        minWidth: 60,
+        maxWidth: 200,
+      }}
+    >
+      <View className='flex flex-col' {...props}>
+        <Text className='opacity-50 mb-1 text-xs'>
+          {t("item_card.quality")}
+        </Text>
+        <TouchableOpacity
+          className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'
+          onPress={() => setOpen(true)}
+        >
+          <Text numberOfLines={1}>
+            {BITRATES.find((b) => b.value === selected?.value)?.key}
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      <FilterSheet
+        open={open}
+        setOpen={setOpen}
+        title={t("item_card.quality")}
+        data={sorted}
+        values={selected ? [selected] : []}
+        multiple={false}
+        searchFilter={(item, query) => {
+          const label = (item as any).key || "";
+          return label.toLowerCase().includes(query.toLowerCase());
+        }}
+        renderItemLabel={(item) => <Text>{(item as any).key || ""}</Text>}
+        set={(vals) => {
+          const chosen = vals[0] as Bitrate | undefined;
+          if (chosen) onChange(chosen);
+        }}
+      />
+    </View>
+  );
+};

--- a/components/ItemContent.tsx
+++ b/components/ItemContent.tsx
@@ -6,6 +6,7 @@ import { Image } from "expo-image";
 import { useNavigation } from "expo-router";
 import { useAtom } from "jotai";
 import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { type Bitrate } from "@/components/BitrateSelector";
@@ -58,6 +59,7 @@ export const ItemContent: React.FC<ItemContentProps> = React.memo(
     const navigation = useNavigation();
     const insets = useSafeAreaInsets();
     const [user] = useAtom(userAtom);
+    const { t } = useTranslation();
 
     useImageColors({ item });
 
@@ -215,6 +217,7 @@ export const ItemContent: React.FC<ItemContentProps> = React.memo(
                   <TrackSheet
                     className='mr-1'
                     streamType='Audio'
+                    title={t("item_card.audio")}
                     source={selectedOptions.mediaSource}
                     onChange={(val) => {
                       setSelectedOptions(
@@ -230,6 +233,7 @@ export const ItemContent: React.FC<ItemContentProps> = React.memo(
                   <TrackSheet
                     source={selectedOptions.mediaSource}
                     streamType='Subtitle'
+                    title={t("item_card.subtitles")}
                     onChange={(val) =>
                       setSelectedOptions(
                         (prev) =>

--- a/components/ItemContent.tsx
+++ b/components/ItemContent.tsx
@@ -8,8 +8,7 @@ import { useAtom } from "jotai";
 import React, { useEffect, useMemo, useState } from "react";
 import { Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { AudioTrackSelector } from "@/components/AudioTrackSelector";
-import { type Bitrate, BitrateSelector } from "@/components/BitrateSelector";
+import { type Bitrate } from "@/components/BitrateSelector";
 import { ItemImage } from "@/components/common/ItemImage";
 import { DownloadSingleItem } from "@/components/DownloadItem";
 import { OverviewText } from "@/components/OverviewText";
@@ -18,7 +17,6 @@ import { ParallaxScrollView } from "@/components/ParallaxPage";
 import { PlayButton } from "@/components/PlayButton";
 import { PlayedStatus } from "@/components/PlayedStatus";
 import { SimilarItems } from "@/components/SimilarItems";
-import { SubtitleTrackSelector } from "@/components/SubtitleTrackSelector";
 import { CastAndCrew } from "@/components/series/CastAndCrew";
 import { CurrentSeries } from "@/components/series/CurrentSeries";
 import { SeasonEpisodesCarousel } from "@/components/series/SeasonEpisodesCarousel";
@@ -30,11 +28,13 @@ import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { useSettings } from "@/utils/atoms/settings";
 import { getLogoImageUrlById } from "@/utils/jellyfin/image/getLogoImageUrlById";
 import { AddToFavorites } from "./AddToFavorites";
+import { BitrateSheet } from "./BitRateSheet";
 import { ItemHeader } from "./ItemHeader";
 import { ItemTechnicalDetails } from "./ItemTechnicalDetails";
-import { MediaSourceSelector } from "./MediaSourceSelector";
+import { MediaSourceSheet } from "./MediaSourceSheet";
 import { MoreMoviesWithActor } from "./MoreMoviesWithActor";
 import { PlayInRemoteSessionButton } from "./PlayInRemoteSession";
+import { TrackSheet } from "./TrackSheet";
 
 const Chromecast = !Platform.isTV ? require("./Chromecast") : null;
 
@@ -189,7 +189,7 @@ export const ItemContent: React.FC<ItemContentProps> = React.memo(
               <ItemHeader item={item} className='mb-2' />
               {item.Type !== "Program" && !Platform.isTV && !isOffline && (
                 <View className='flex flex-row items-center justify-start w-full h-16'>
-                  <BitrateSelector
+                  <BitrateSheet
                     className='mr-1'
                     onChange={(val) =>
                       setSelectedOptions(
@@ -198,7 +198,7 @@ export const ItemContent: React.FC<ItemContentProps> = React.memo(
                     }
                     selected={selectedOptions.bitrate}
                   />
-                  <MediaSourceSelector
+                  <MediaSourceSheet
                     className='mr-1'
                     item={item}
                     onChange={(val) =>
@@ -212,8 +212,9 @@ export const ItemContent: React.FC<ItemContentProps> = React.memo(
                     }
                     selected={selectedOptions.mediaSource}
                   />
-                  <AudioTrackSelector
+                  <TrackSheet
                     className='mr-1'
+                    streamType='Audio'
                     source={selectedOptions.mediaSource}
                     onChange={(val) => {
                       setSelectedOptions(
@@ -226,8 +227,9 @@ export const ItemContent: React.FC<ItemContentProps> = React.memo(
                     }}
                     selected={selectedOptions.audioIndex}
                   />
-                  <SubtitleTrackSelector
+                  <TrackSheet
                     source={selectedOptions.mediaSource}
+                    streamType='Subtitle'
                     onChange={(val) =>
                       setSelectedOptions(
                         (prev) =>

--- a/components/MediaSourceSheet.tsx
+++ b/components/MediaSourceSheet.tsx
@@ -39,7 +39,7 @@ export const MediaSourceSheet: React.FC<Props> = ({
   if (isTv || (item.MediaStreams && item.MediaStreams.length <= 1)) return null;
 
   return (
-    <View className='flex shrink' style={{ minWidth: 50 }}>
+    <View className='flex shrink' style={{ minWidth: 75 }}>
       <View className='flex flex-col' {...props}>
         <Text className='opacity-50 mb-1 text-xs'>{t("item_card.video")}</Text>
         <TouchableOpacity

--- a/components/MediaSourceSheet.tsx
+++ b/components/MediaSourceSheet.tsx
@@ -1,0 +1,75 @@
+import type {
+  BaseItemDto,
+  MediaSourceInfo,
+} from "@jellyfin/sdk/lib/generated-client/models";
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Platform, TouchableOpacity, View } from "react-native";
+import { Text } from "./common/Text";
+import { FilterSheet } from "./filters/FilterSheet";
+
+interface Props extends React.ComponentProps<typeof View> {
+  item: BaseItemDto;
+  onChange: (value: MediaSourceInfo) => void;
+  selected?: MediaSourceInfo | null;
+}
+
+export const MediaSourceSheet: React.FC<Props> = ({
+  item,
+  onChange,
+  selected,
+  ...props
+}) => {
+  const isTv = Platform.isTV;
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const getDisplayName = useCallback((source: MediaSourceInfo) => {
+    const videoStream = source.MediaStreams?.find((x) => x.Type === "Video");
+    if (videoStream?.DisplayTitle) return videoStream.DisplayTitle;
+    if (source.Name) return source.Name;
+    return `Source ${source.Id}`;
+  }, []);
+
+  const selectedName = useMemo(() => {
+    if (!selected) return "";
+    return getDisplayName(selected);
+  }, [selected, getDisplayName]);
+
+  if (isTv || (item.MediaStreams && item.MediaStreams.length <= 1)) return null;
+
+  return (
+    <View className='flex shrink' style={{ minWidth: 50 }}>
+      <View className='flex flex-col' {...props}>
+        <Text className='opacity-50 mb-1 text-xs'>{t("item_card.video")}</Text>
+        <TouchableOpacity
+          className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center'
+          onPress={() => setOpen(true)}
+        >
+          <Text numberOfLines={1}>{selectedName}</Text>
+        </TouchableOpacity>
+      </View>
+
+      <FilterSheet
+        open={open}
+        setOpen={setOpen}
+        title={t("item_card.video")}
+        data={item.MediaSources || []}
+        values={selected ? [selected] : []}
+        multiple={false}
+        searchFilter={(src, query) =>
+          getDisplayName(src as MediaSourceInfo)
+            .toLowerCase()
+            .includes(query.toLowerCase())
+        }
+        renderItemLabel={(src) => (
+          <Text>{getDisplayName(src as MediaSourceInfo)}</Text>
+        )}
+        set={(vals) => {
+          const chosen = vals[0] as MediaSourceInfo | undefined;
+          if (chosen) onChange(chosen);
+        }}
+      />
+    </View>
+  );
+};

--- a/components/TrackSheet.tsx
+++ b/components/TrackSheet.tsx
@@ -10,7 +10,7 @@ interface Props extends React.ComponentProps<typeof View> {
   onChange: (value: number) => void;
   selected?: number | undefined;
   streamType?: string;
-  title?: string;
+  title: string;
 }
 
 export const TrackSheet: React.FC<Props> = ({
@@ -22,6 +22,7 @@ export const TrackSheet: React.FC<Props> = ({
   ...props
 }) => {
   const isTv = Platform.isTV;
+  const { t } = useTranslation();
 
   const streams = useMemo(
     () => source?.MediaStreams?.filter((x) => x.Type === streamType),
@@ -32,11 +33,9 @@ export const TrackSheet: React.FC<Props> = ({
     () => streams?.find((x) => x.Index === selected),
     [streams, selected],
   );
-
-  const { t } = useTranslation();
-
   const [open, setOpen] = useState(false);
-  if (isTv) return null;
+
+  if (isTv || (streams && streams.length === 0)) return null;
 
   return (
     <View className='flex shrink' style={{ minWidth: 50 }} {...props}>
@@ -54,7 +53,7 @@ export const TrackSheet: React.FC<Props> = ({
       <FilterSheet
         open={open}
         setOpen={setOpen}
-        title={t("item_card.audio")}
+        title={title}
         data={streams || []}
         values={selectedSteam ? [selectedSteam] : []}
         multiple={false}

--- a/components/TrackSheet.tsx
+++ b/components/TrackSheet.tsx
@@ -38,7 +38,7 @@ export const TrackSheet: React.FC<Props> = ({
   if (isTv || (streams && streams.length === 0)) return null;
 
   return (
-    <View className='flex shrink' style={{ minWidth: 50 }} {...props}>
+    <View className='flex shrink' style={{ minWidth: 25 }} {...props}>
       <View className='flex flex-col'>
         <Text className='opacity-50 mb-1 text-xs'>{title}</Text>
         <TouchableOpacity

--- a/components/TrackSheet.tsx
+++ b/components/TrackSheet.tsx
@@ -1,0 +1,77 @@
+import type { MediaSourceInfo } from "@jellyfin/sdk/lib/generated-client/models";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Platform, TouchableOpacity, View } from "react-native";
+import { Text } from "./common/Text";
+import { FilterSheet } from "./filters/FilterSheet";
+
+interface Props extends React.ComponentProps<typeof View> {
+  source?: MediaSourceInfo;
+  onChange: (value: number) => void;
+  selected?: number | undefined;
+  streamType?: string;
+  title?: string;
+}
+
+export const TrackSheet: React.FC<Props> = ({
+  source,
+  onChange,
+  selected,
+  streamType,
+  title,
+  ...props
+}) => {
+  const isTv = Platform.isTV;
+
+  const streams = useMemo(
+    () => source?.MediaStreams?.filter((x) => x.Type === streamType),
+    [source],
+  );
+
+  const selectedSteam = useMemo(
+    () => streams?.find((x) => x.Index === selected),
+    [streams, selected],
+  );
+
+  const { t } = useTranslation();
+
+  const [open, setOpen] = useState(false);
+  if (isTv) return null;
+
+  return (
+    <View className='flex shrink' style={{ minWidth: 50 }} {...props}>
+      <View className='flex flex-col'>
+        <Text className='opacity-50 mb-1 text-xs'>{title}</Text>
+        <TouchableOpacity
+          className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'
+          onPress={() => setOpen(true)}
+        >
+          <Text numberOfLines={1}>
+            {selectedSteam?.DisplayTitle || t("common.select", "Select")}
+          </Text>
+        </TouchableOpacity>
+      </View>
+      <FilterSheet
+        open={open}
+        setOpen={setOpen}
+        title={t("item_card.audio")}
+        data={streams || []}
+        values={selectedSteam ? [selectedSteam] : []}
+        multiple={false}
+        searchFilter={(item, query) => {
+          const label = (item as any).DisplayTitle || "";
+          return label.toLowerCase().includes(query.toLowerCase());
+        }}
+        renderItemLabel={(item) => (
+          <Text>{(item as any).DisplayTitle || ""}</Text>
+        )}
+        set={(vals) => {
+          const chosen = vals[0] as any;
+          if (chosen && chosen.Index !== null && chosen.Index !== undefined) {
+            onChange(chosen.Index);
+          }
+        }}
+      />
+    </View>
+  );
+};

--- a/components/filters/FilterSheet.tsx
+++ b/components/filters/FilterSheet.tsx
@@ -74,7 +74,7 @@ export const FilterSheet = <T,>({
   multiple = false,
 }: Props<T>) => {
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
-  const snapPoints = useMemo(() => ["80%"], []);
+  const snapPoints = useMemo(() => ["85%"], []);
   const { t } = useTranslation();
 
   const [data, setData] = useState<T[]>([]);

--- a/components/filters/FilterSheet.tsx
+++ b/components/filters/FilterSheet.tsx
@@ -5,6 +5,7 @@ import {
   BottomSheetModal,
   BottomSheetScrollView,
 } from "@gorhom/bottom-sheet";
+import { isEqual } from "lodash";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -168,7 +169,7 @@ export const FilterSheet = <T,>({
           {showSearch && (
             <Input
               placeholder={t("search.search")}
-              className='my-2'
+              className='my-2 border-neutral-800 border'
               value={search}
               onChangeText={(text) => {
                 setSearch(text);
@@ -206,7 +207,7 @@ export const FilterSheet = <T,>({
                   className=' bg-neutral-800 px-4 py-3 flex flex-row items-center justify-between'
                 >
                   <Text className='flex shrink'>{renderItemLabel(item)}</Text>
-                  {values.some((i) => i === item) ? (
+                  {values.some((i) => isEqual(i, item)) ? (
                     <Ionicons name='radio-button-on' size={24} color='white' />
                   ) : (
                     <Ionicons name='radio-button-off' size={24} color='white' />

--- a/components/filters/FilterSheet.tsx
+++ b/components/filters/FilterSheet.tsx
@@ -27,7 +27,7 @@ interface Props<T> extends ViewProps {
   title: string;
   searchFilter?: (item: T, query: string) => boolean;
   renderItemLabel: (item: T) => React.ReactNode;
-  showSearch?: boolean;
+  disableSearch?: boolean;
   multiple?: boolean;
 }
 
@@ -49,7 +49,7 @@ const LIMIT = 100;
  * @param {string} props.title - The title of the bottom sheet
  * @param {function} props.searchFilter - Function to filter items based on search query
  * @param {function} props.renderItemLabel - Function to render the label for each item
- * @param {boolean} [props.showSearch=true] - Whether to show the search input
+ * @param {boolean} [props.disableSearch=false] - Whether to disable the search input
  *
  * @returns {React.ReactElement} The FilterSheet component
  *
@@ -70,7 +70,7 @@ export const FilterSheet = <T,>({
   title,
   searchFilter,
   renderItemLabel,
-  showSearch = true,
+  disableSearch = false,
   multiple = false,
 }: Props<T>) => {
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
@@ -82,6 +82,8 @@ export const FilterSheet = <T,>({
 
   const [search, setSearch] = useState<string>("");
 
+  const [showSearch, setShowSearch] = useState<boolean>(false);
+
   const filteredData = useMemo(() => {
     if (!search) return _data;
     const results = [];
@@ -92,6 +94,13 @@ export const FilterSheet = <T,>({
     }
     return results.slice(0, 100);
   }, [search, _data, searchFilter]);
+
+  useEffect(() => {
+    if (!data || data.length === 0 || disableSearch) return;
+    if (data.length > 15) {
+      setShowSearch(true);
+    }
+  }, [data]);
 
   // Loads data in batches of LIMIT size, starting from offset,
   // to implement efficient "load more" functionality

--- a/components/filters/FilterSheet.tsx
+++ b/components/filters/FilterSheet.tsx
@@ -205,7 +205,7 @@ export const FilterSheet = <T,>({
                   }}
                   className=' bg-neutral-800 px-4 py-3 flex flex-row items-center justify-between'
                 >
-                  <Text>{renderItemLabel(item)}</Text>
+                  <Text className='flex shrink'>{renderItemLabel(item)}</Text>
                   {values.some((i) => i === item) ? (
                     <Ionicons name='radio-button-on' size={24} color='white' />
                   ) : (

--- a/components/video-player/controls/dropdown/DropdownView.tsx
+++ b/components/video-player/controls/dropdown/DropdownView.tsx
@@ -116,30 +116,32 @@ const DropdownView = () => {
             ))}
           </DropdownMenu.SubContent>
         </DropdownMenu.Sub>
-        <DropdownMenu.Sub>
-          <DropdownMenu.SubTrigger key='audio-trigger'>
-            Audio
-          </DropdownMenu.SubTrigger>
-          <DropdownMenu.SubContent
-            alignOffset={-10}
-            avoidCollisions={true}
-            collisionPadding={0}
-            loop={true}
-            sideOffset={10}
-          >
-            {audioTracks?.map((track, idx: number) => (
-              <DropdownMenu.CheckboxItem
-                key={`audio-item-${idx}`}
-                value={audioIndex === track.index.toString()}
-                onValueChange={() => track.setTrack()}
-              >
-                <DropdownMenu.ItemTitle key={`audio-item-title-${idx}`}>
-                  {track.name}
-                </DropdownMenu.ItemTitle>
-              </DropdownMenu.CheckboxItem>
-            ))}
-          </DropdownMenu.SubContent>
-        </DropdownMenu.Sub>
+        {(audioTracks?.length ?? 0) > 0 && (
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger key='audio-trigger'>
+              Audio
+            </DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent
+              alignOffset={-10}
+              avoidCollisions={true}
+              collisionPadding={0}
+              loop={true}
+              sideOffset={10}
+            >
+              {audioTracks?.map((track, idx: number) => (
+                <DropdownMenu.CheckboxItem
+                  key={`audio-item-${idx}`}
+                  value={audioIndex === track.index.toString()}
+                  onValueChange={() => track.setTrack()}
+                >
+                  <DropdownMenu.ItemTitle key={`audio-item-title-${idx}`}>
+                    {track.name}
+                  </DropdownMenu.ItemTitle>
+                </DropdownMenu.CheckboxItem>
+              ))}
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
+        )}
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   );

--- a/hooks/useDefaultPlaySettings.ts
+++ b/hooks/useDefaultPlaySettings.ts
@@ -26,7 +26,11 @@ const useDefaultPlaySettings = (
     )?.Index;
 
     // 4. Get default bitrate from settings or fallback to max
-    const bitrate = settings?.defaultBitrate ?? BITRATES[0];
+    let bitrate = settings?.defaultBitrate ?? BITRATES[0];
+    // value undefined seems to get lost in settings. This is just a failsafe
+    if (bitrate.key === BITRATES[0].key) {
+      bitrate = BITRATES[0];
+    }
 
     return {
       defaultAudioIndex:


### PR DESCRIPTION
- Replaced drop-downs on item content page with bottom sheets. Reusing the existing filtersheet.
- Search now only automatically enabled if more then 15 items.

Did not replace drop downs on other places like download sheet. Should we?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - UI now uses sheet-style pickers for quality, video source, audio and subtitle tracks for a consistent selection experience.

- **Bug Fixes**
  - Audio submenu is omitted when no audio tracks exist to reduce clutter.

- **Documentation**
  - Filter search now auto-displays for long lists and can be disabled; docs updated to reflect the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->