### PR TITLE
feat: Add https/http testing for removing the need for adding them manually

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -137,7 +137,10 @@ const Login: React.FC = () => {
     const protocols = ["https", "http"];
     try {
       return checkHttp(baseUrl, protocols);
-    } catch {
+    } catch (e) {
+      if (e instanceof Error && e.message === "Server too old") {
+        throw e;
+      }
       return undefined;
     } finally {
       setLoadingServerCheck(false);
@@ -147,7 +150,6 @@ const Login: React.FC = () => {
   async function checkHttp(baseUrl: string, protocols: string[]) {
     for (const protocol of protocols) {
       try {
-        console.log("tmp");
         const response = await fetch(
           `${protocol}://${baseUrl}/System/Info/Public`,
           {
@@ -156,11 +158,23 @@ const Login: React.FC = () => {
         );
         if (response.ok) {
           const data = (await response.json()) as PublicSystemInfo;
+          const serverVersion = data.Version?.split(".");
+          if (serverVersion && +serverVersion[0] <= 10) {
+            if (+serverVersion[1] < 10) {
+              Alert.alert(
+                t("login.too_old_server_text"),
+                t("login.too_old_server_description"),
+              );
+              throw new Error("Server too old");
+            }
+          }
           setServerName(data.ServerName || "");
           return `${protocol}://${baseUrl}`;
         }
-      } catch {
-        console.log("failed");
+      } catch (e) {
+        if (e instanceof Error && e.message === "Server too old") {
+          throw e;
+        }
       }
     }
     return undefined;
@@ -183,18 +197,17 @@ const Login: React.FC = () => {
    */
   const handleConnect = useCallback(async (url: string) => {
     url = url.trim().replace(/\/$/, "");
-    const result = await checkUrl(url);
-
-    if (result === undefined) {
-      Alert.alert(
-        t("login.connection_failed"),
-        t("login.could_not_connect_to_server"),
-      );
-      return;
-    }
-    console.log("result");
-    console.log(result);
-    await setServer({ address: result });
+    try {
+      const result = await checkUrl(url);
+      if (result === undefined) {
+        Alert.alert(
+          t("login.connection_failed"),
+          t("login.could_not_connect_to_server"),
+        );
+        return;
+      }
+      await setServer({ address: result });
+    } catch {}
   }, []);
 
   const handleQuickConnect = async () => {

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -133,20 +133,11 @@ const Login: React.FC = () => {
    */
   const checkUrl = useCallback(async (url: string) => {
     setLoadingServerCheck(true);
-
+    const baseUrl = url.replace(/^https?:\/\//i, "");
+    const protocols = ["https", "http"];
     try {
-      const response = await fetch(`${url}/System/Info/Public`, {
-        mode: "cors",
-      });
-
-      if (response.ok) {
-        const data = (await response.json()) as PublicSystemInfo;
-
-        setServerName(data.ServerName || "");
-        return url;
-      }
-
-      return undefined;
+      const verifiedServerUrl = checkHttp(baseUrl, protocols);
+      return verifiedServerUrl;
     } catch {
       return undefined;
     } finally {
@@ -154,6 +145,30 @@ const Login: React.FC = () => {
     }
   }, []);
 
+  async function checkHttp(baseUrl: string, protocols: string[]) {
+    for (const protocol of protocols) {
+      try {
+        console.log("tmp");
+        const response = await fetch(
+          `${protocol}://${baseUrl}/System/Info/Public`,
+          {
+            mode: "cors",
+          },
+        );
+        if (response.ok) {
+          const data = (await response.json()) as PublicSystemInfo;
+          console.log(protocol);
+          console.log(`${protocol}://${baseUrl}`);
+          console.log(data);
+          setServerName(data.ServerName || "");
+          return `${protocol}://${baseUrl}`;
+        }
+      } catch {
+        console.log("failed");
+      }
+    }
+    return undefined;
+  }
   /**
    * Handles the connection attempt to a Jellyfin server.
    *
@@ -181,8 +196,9 @@ const Login: React.FC = () => {
       );
       return;
     }
-
-    await setServer({ address: url });
+    console.log("result");
+    console.log(result);
+    await setServer({ address: result });
   }, []);
 
   const handleQuickConnect = async () => {

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -136,8 +136,7 @@ const Login: React.FC = () => {
     const baseUrl = url.replace(/^https?:\/\//i, "");
     const protocols = ["https", "http"];
     try {
-      const verifiedServerUrl = checkHttp(baseUrl, protocols);
-      return verifiedServerUrl;
+      return checkHttp(baseUrl, protocols);
     } catch {
       return undefined;
     } finally {
@@ -157,9 +156,6 @@ const Login: React.FC = () => {
         );
         if (response.ok) {
           const data = (await response.json()) as PublicSystemInfo;
-          console.log(protocol);
-          console.log(`${protocol}://${baseUrl}`);
-          console.log(data);
           setServerName(data.ServerName || "");
           return `${protocol}://${baseUrl}`;
         }

--- a/translations/en.json
+++ b/translations/en.json
@@ -22,7 +22,7 @@
     "there_is_a_server_error": "There is a server error",
     "an_unexpected_error_occured_did_you_enter_the_correct_url": "An unexpected error occurred. Did you enter the server URL correctly?",
     "too_old_server_text": "Unsupported jellyfin server discovered",
-    "too_old_server_description": "Streamyfin does not support too old servers. Please update jellyfin to the latest version"
+    "too_old_server_description": "Please update jellyfin to the latest version"
   },
   "server": {
     "enter_url_to_jellyfin_server": "Enter the URL to your Jellyfin server",

--- a/translations/en.json
+++ b/translations/en.json
@@ -20,7 +20,9 @@
     "server_is_taking_too_long_to_respond_try_again_later": "Server is taking too long to respond, try again later",
     "server_received_too_many_requests_try_again_later": "Server received too many requests, try again later.",
     "there_is_a_server_error": "There is a server error",
-    "an_unexpected_error_occured_did_you_enter_the_correct_url": "An unexpected error occurred. Did you enter the server URL correctly?"
+    "an_unexpected_error_occured_did_you_enter_the_correct_url": "An unexpected error occurred. Did you enter the server URL correctly?",
+    "too_old_server_text": "Too old server discovered",
+    "too_old_server_description": "Streamyfin does not support too old servers. Please update jellyfin to the latest version"
   },
   "server": {
     "enter_url_to_jellyfin_server": "Enter the URL to your Jellyfin server",

--- a/translations/en.json
+++ b/translations/en.json
@@ -21,7 +21,7 @@
     "server_received_too_many_requests_try_again_later": "Server received too many requests, try again later.",
     "there_is_a_server_error": "There is a server error",
     "an_unexpected_error_occured_did_you_enter_the_correct_url": "An unexpected error occurred. Did you enter the server URL correctly?",
-    "too_old_server_text": "Too old server discovered",
+    "too_old_server_text": "Unsupported jellyfin server discovered",
     "too_old_server_description": "Streamyfin does not support too old servers. Please update jellyfin to the latest version"
   },
   "server": {


### PR DESCRIPTION
<!--
  Pull Request Template for Streamyfin
  ====================================
  Use this template to help reviewers understand the purpose of your PR
  and to ensure all necessary checks are completed before merging.
-->

# 📦 Pull Request

## 🔖 Summary
<!--
A concise description of the changes introduced by this PR.
Example:
“Add real-time currency conversion widget to dashboard.”
-->

adds a small test for http vs https (preferring https) so users no longer need to add the http(s)://.
and a warning for old jellyfin servers

## 🏷️ Ticket / Issue
<!--
Link to the related ticket, issue or user story.
You can also indicate if this PR supersedes a previous one.
Example:
- Closes #123
- Fixes STREAMYFIN-456
- Resolves #789
- Supersedes #120
- Related: #130
-->

## 🛠️ What’s Changed
<!-- Use a Conventional Commit in the PR title, e.g., `feat(auth): add MFA`. 
If this PR introduces a breaking change, include a `BREAKING CHANGE:` block in the description.
Spec: https://www.conventionalcommits.org/ -->

- Type: feat | fix | docs | style | refactor | perf | test | chore | build | ci | revert
- Scope (optional): e.g., auth, billing, mobile
- Short summary: what changed and why (1–2 lines)
-->

## 📋 Details
<!--
Provide more context or background. Explain any non-obvious decisions.
Include screenshots or GIFs for UI changes if applicable.
-->

### ⚠️ Breaking Changes
<!-- List any breaking API/contract changes and migration guidance. If none, write “None”. -->

### 🔐 Security & Privacy Impact
<!-- Data touched, new permissions/scopes, PII, secrets, threat considerations. If none, write “None”. -->

### ⚡ Performance Impact
<!-- Hot paths, memory/CPU/latency implications, benchmarks if available. -->

### 🖼️ Screenshots / GIFs (if UI)
<!-- Before/After, dark mode, responsive states. -->

## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [x] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [x] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions
<!--
Describe how reviewers can test your changes.
Example:
1. `git fetch origin pull/<PR_ID>/head:branchname && git checkout branchname`
2. Install deps: `npm|pnpm|yarn|bun install`
3. Start service/app: `npm|pnpm|yarn|bun run [target]` (e.g., `npm run ios` or `bun run android:tv`)
4. Run tests: `npm|pnpm|yarn|bun test`
5. Verification steps:
   - [ ] Expected UI/endpoint behavior
   - [ ] Logs show no errors
   - [ ] Edge cases covered (list)
-->
1. checkout the pr (or the branch)
2. try to log in to jellyfin through streamyfin, but omit the http(s)://
3. see that you are able to log in

## ⚙️ Deployment Notes
<!--
Describe any deployment considerations such as config, environment vars, or native builds.
-->

## 📝 Additional Notes
<!--
Any other information or references related to this PR.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Login now auto-detects and probes both HTTPS and HTTP, connecting to the first available server.
  - Displays the discovered server name during connection.
  - Adds alerts for unsupported/too-old servers with localized messaging.
  - Improved error handling during connection attempts, continuing with alternate protocols on failure.
- Translations
  - Added English strings for outdated server alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Screenshots:
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/4a42d8a1-7af1-4aab-871d-cb6149be89be" />
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/243e5e70-e2ed-4a97-b760-a550ba83c457" />
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/14087303-0f2e-41ab-8a87-a9a3f343c9f2" />

