### PR TITLE
fix: missing optional chaining for plugin setting

### DIFF
--- a/components/settings/DownloadSettings.tsx
+++ b/components/settings/DownloadSettings.tsx
@@ -13,7 +13,7 @@ export default function DownloadSettings({ ...props }) {
   const allDisabled = useMemo(
     () =>
       pluginSettings?.remuxConcurrentLimit?.locked === true &&
-      pluginSettings?.autoDownload.locked === true,
+      pluginSettings?.autoDownload?.locked === true,
     [pluginSettings],
   );
 


### PR DESCRIPTION
## 🔖 Summary
crash when autoDownload wasnt set from plugin side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a rare error in Download Settings when auto-download configuration was missing, preventing unexpected crashes.
  * Ensured disable/lock states behave correctly: controls are disabled only when both relevant settings are locked, and they function normally if auto-download details are unavailable.
  * Improved overall stability without changing visible options or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->