### PR TITLE
fix: external deep links not working

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,8 +20,8 @@ import {
 } from "@/utils/background-tasks";
 import {
   LogProvider,
-  writeDebugLog,
   writeErrorLog,
+  writeInfoLog,
   writeToLog,
 } from "@/utils/log";
 import { storage } from "@/utils/mmkv";
@@ -84,18 +84,18 @@ SplashScreen.setOptions({
   fade: true,
 });
 
+function redirect(notification: typeof Notifications.Notification) {
+  const url = notification.request.content.data?.url;
+  if (url) {
+    router.push(url);
+  }
+}
+
 function useNotificationObserver() {
   useEffect(() => {
     if (Platform.isTV) return;
 
     let isMounted = true;
-
-    function redirect(notification: typeof Notifications.Notification) {
-      const url = notification.request.content.data?.url;
-      if (url) {
-        router.push(url);
-      }
-    }
 
     Notifications.getLastNotificationResponseAsync().then(
       (response: { notification: any }) => {
@@ -106,15 +106,8 @@ function useNotificationObserver() {
       },
     );
 
-    const subscription = Notifications.addNotificationResponseReceivedListener(
-      (response: { notification: any }) => {
-        redirect(response.notification);
-      },
-    );
-
     return () => {
       isMounted = false;
-      subscription.remove();
     };
   }, []);
 }
@@ -317,9 +310,12 @@ function Layout() {
       responseListener.current =
         Notifications?.addNotificationResponseReceivedListener(
           (response: NotificationResponse) => {
+            // redirect if internal notification
+            redirect(response?.notification);
+
             // Currently the notifications supported by the plugin will send data for deep links.
             const { title, data } = response.notification.request.content;
-            writeDebugLog(
+            writeInfoLog(
               `Notification ${title} opened`,
               response.notification.request.content,
             );


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary
limited to only one addNotificationResponseReceivedListener and changed notification log from debug to info since this test only works in production builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Faster, smoother deep-link navigation when opening the app from a notification, across foreground, background, and cold-start states.
* **Bug Fixes**
  * Fixed cases where tapping a notification didn’t navigate or navigated to the wrong screen.
  * Eliminated occasional duplicate redirects after opening a notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->