### PR TITLE
fix: subtitle scaling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,7 @@
   "[javascriptreact]": {
     "editor.defaultFormatter": "biomejs.biome",
     "editor.formatOnSave": true
-  }
+  },
+  "python-envs.defaultEnvManager": "ms-python.python:system",
+  "python-envs.pythonProjects": []
 }

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -97,7 +97,7 @@ export default function page() {
     /** Playback position in ticks. */
     playbackPosition?: string;
   }>();
-  useSettings();
+  const { settings } = useSettings();
 
   const offline = offlineStr === "true";
   const playbackManager = usePlaybackManager();
@@ -565,7 +565,11 @@ export default function page() {
   /** Whether the stream we're playing is not transcoding*/
   const notTranscoding = !stream?.mediaSource.TranscodingUrl;
   /** The initial options to pass to the VLC Player */
-  const initOptions = [``];
+  const initOptions = [
+    `--sub-text-scale=${settings.subtitleSize}`,
+    "--sub-margin=40",
+  ];
+
   if (
     chosenSubtitleTrack &&
     (notTranscoding || chosenSubtitleTrack.IsTextSubtitleStream)


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary

Fixed the subtitle scaling issue, tested on simulator but i assume it will work on real devices and android since we used the vlc argument before.


## 🏷️ Ticket / Issue
None


## 🛠️ What’s Changed
direct-player.tsx:


## 📋 Details
- Grabbing { settings } out of useSettings()
- Setting --sub-text-scale and --sub-margin=40 in the VLC initOptions

### ⚠️ Breaking Changes
None

### 🔐 Security & Privacy Impact
None

### ⚡ Performance Impact
None

### 🖼️ Screenshots / GIFs (if UI)
None

## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [ ] Type checks pass (tsc/biome/etc.)
- [ ] Docs updated (README/ADR/usage/API)
- [ ] No secrets/credentials included; env vars documented
- [ ] Release notes/CHANGELOG entry added (if applicable)
- [ ] Verified locally that changes behave as expected

## 🔍 Testing Instructions
Subtitle scaling should be fixed, and changing the size in the settings should also reflect the change.

## ⚙️ Deployment Notes
<!--
Describe any deployment considerations such as config, environment vars, or native builds.
-->

## 📝 Additional Notes
<!--
Any other information or references related to this PR.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Player subtitles now respect your subtitle size setting and have improved on-screen positioning for better readability during playback.

* Chores
  * Updated editor settings to improve local Python environment handling (developer-only; no impact on app behavior).
  * Synchronized an internal dependency to the latest revision for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->