### PR TITLE
fix: omit includeItemTypes in getLatestMedia if possible

### DIFF
--- a/components/settings/HomeIndex.tsx
+++ b/components/settings/HomeIndex.tsx
@@ -216,7 +216,9 @@ export const HomeIndex = () => {
 
     const latestMediaViews = collections.map((c) => {
       const includeItemTypes: BaseItemKind[] =
-        c.CollectionType === "tvshows" ? ["Series"] : ["Movie"];
+        c.CollectionType === "tvshows" || c.CollectionType === "movies"
+          ? []
+          : ["Movie"];
       const title = t("home.recently_added_in", { libraryName: c.Name });
       const queryKey = [
         "home",


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary
This PR ensures that the `includeItemTypes` parameter is only used when it's actually required.
If the collection type is already `tvshows` or `movies`, it can be dropped.

## 🛠️ What’s Changed
The `includeItemTypes` is now only used if the collection type does not already have a distinct media type.

## 📋 Details

This is a work around for a bug introduced in jellyfin 10.11, which causes the `/Items/Latest` API endpoint to be incredibly slow and make the server unusable for several minutes. 

See: https://github.com/jellyfin/jellyfin/issues/15014#issuecomment-3439142126

### ⚡ Performance Impact

Before this patch the app was completely unusable, does this count as a performance impact? 

## ✅ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [x] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [ ] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions

I don't have libraries with mixed item types. I don't think it should make any difference but this is probably an edge case which isn't fully tested.

## ⚙️ Deployment Notes

No AI was used for this pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted content filtering logic for recently added media collections to refine which item types appear across different collection categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->