### PR TITLE
fix: correct invalid BCP 47 language tag in Jellyseerr components

### DIFF
--- a/app/(auth)/(tabs)/(home,libraries,search,favorites)/jellyseerr/person/[personId].tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites)/jellyseerr/person/[personId].tsx
@@ -88,14 +88,11 @@ export default function page() {
           <Text className='opacity-50'>
             {t("jellyseerr.born")}{" "}
             {data?.details?.birthday &&
-              new Date(data.details.birthday).toLocaleDateString(
-                `${locale}-${region}`,
-                {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                },
-              )}{" "}
+              new Date(data.details.birthday).toLocaleDateString(locale, {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}{" "}
             | {data?.details?.placeOfBirth}
           </Text>
         </>

--- a/components/jellyseerr/DetailFacts.tsx
+++ b/components/jellyseerr/DetailFacts.tsx
@@ -81,10 +81,7 @@ const DetailFacts: React.FC<
   const firstAirDate = useMemo(() => {
     const firstAirDate = (details as TvDetails)?.firstAirDate;
     if (firstAirDate) {
-      return new Date(firstAirDate).toLocaleDateString(
-        `${locale}-${region}`,
-        dateOpts,
-      );
+      return new Date(firstAirDate).toLocaleDateString(locale, dateOpts);
     }
   }, [details]);
 
@@ -92,28 +89,25 @@ const DetailFacts: React.FC<
     const firstAirDate = (details as TvDetails)?.firstAirDate;
     const nextAirDate = (details as TvDetails)?.nextEpisodeToAir?.airDate;
     if (nextAirDate && firstAirDate !== nextAirDate) {
-      return new Date(nextAirDate).toLocaleDateString(
-        `${locale}-${region}`,
-        dateOpts,
-      );
+      return new Date(nextAirDate).toLocaleDateString(locale, dateOpts);
     }
   }, [details]);
 
   const revenue = useMemo(
     () =>
-      (details as MovieDetails)?.revenue?.toLocaleString?.(
-        `${locale}-${region}`,
-        { style: "currency", currency: "USD" },
-      ),
+      (details as MovieDetails)?.revenue?.toLocaleString?.(locale, {
+        style: "currency",
+        currency: "USD",
+      }),
     [details],
   );
 
   const budget = useMemo(
     () =>
-      (details as MovieDetails)?.budget?.toLocaleString?.(
-        `${locale}-${region}`,
-        { style: "currency", currency: "USD" },
-      ),
+      (details as MovieDetails)?.budget?.toLocaleString?.(locale, {
+        style: "currency",
+        currency: "USD",
+      }),
     [details],
   );
 
@@ -171,7 +165,7 @@ const DetailFacts: React.FC<
                 )}
                 <Text>
                   {new Date(r.release_date).toLocaleDateString(
-                    `${locale}-${region}`,
+                    locale,
                     dateOpts,
                   )}
                 </Text>

--- a/components/series/JellyseerrSeasons.tsx
+++ b/components/series/JellyseerrSeasons.tsx
@@ -69,7 +69,7 @@ const RenderItem = ({ item }: any) => {
     if (airDate) {
       const airDateObj = new Date(airDate);
       if (new Date() < airDateObj) {
-        return airDateObj.toLocaleDateString(`${locale}-${region}`, dateOpts);
+        return airDateObj.toLocaleDateString(locale, dateOpts);
       }
     }
   }, [item, locale, region]);

--- a/hooks/useJellyseerr.ts
+++ b/hooks/useJellyseerr.ts
@@ -533,8 +533,13 @@ export const useJellyseerr = () => {
   );
 
   const jellyseerrLocale = useMemo(() => {
-    return jellyseerrUser?.settings?.locale || "en";
-  }, [jellyseerrUser]);
+    const locale = jellyseerrUser?.settings?.locale || "en";
+    // Use regex to check if locale already contains region code (e.g., zh-CN, pt-BR)
+    // If not, append the region to create a valid BCP 47 locale string
+    return /^[a-z]{2,3}-/i.test(locale)
+      ? locale
+      : `${locale}-${jellyseerrRegion}`;
+  }, [jellyseerrUser, jellyseerrRegion]);
 
   return {
     jellyseerrApi,


### PR DESCRIPTION
## Description

This PR fixes a crash in the Discovery feature when viewing item details, caused by invalid BCP 47 language tags in multiple Seerr components (formerly Jellyseerr).

### Problem
When users with certain locale settings (e.g., `zh-CN`) view Discovery item details, the app crashes with:
```
RangeError: Invalid language tag: zh-CN-US
```

The issue occurs in several Seerr components where the code incorrectly concatenates `locale` and `region` to form `${locale}-${region}` (e.g., `zh-CN-US`), which is not a valid BCP 47 language tag.

### Root Cause
The `locale` variable from `useSeerr()` already contains a complete BCP 47 language tag (e.g., `zh-CN`, `en-US`). The `region` variable is intended for other purposes (like TMDB API region filtering), not for constructing locale tags. Concatenating them produces invalid tags like `zh-CN-US`.

### Solution
Implemented a smart locale handler in `useSeerr()` that:
1. Checks if the locale already contains a region code using regex (`/^[a-z]{2,3}-/i`)
2. Only appends region if locale doesn't already have one
3. Returns properly formatted BCP 47 locale string

This ensures all date and currency formatting operations receive valid locale tags.

### Changes Made

**Main Fix:**
- **`hooks/useSeerr.ts`**: Added regex-based locale validation that intelligently handles region codes
  - For locales like `zh-CN` → returns `zh-CN` (already valid)
  - For locales like `en` → returns `en-US` (appends region)

**Already Fixed in Seerr Rebranding:**
The following components already use `locale` directly (fixed during the Jellyseerr → Seerr migration):
- `components/seerr/DetailFacts.tsx` (5 occurrences in date/currency formatting)
- `components/series/SeerrSeasons.tsx` (1 occurrence in upcoming air date)
- `app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/seerr/person/[personId].tsx` (1 occurrence in birthday formatting)

**Additional Cleanup:**
- Removed unused `region` variable from person page

### Testing
- ✅ Code compiles without errors
- ✅ Lint checks pass
- ✅ TypeScript checks pass
- ✅ All locale formatting uses valid BCP 47 tags
- ✅ Merged with `remove-optimized-server` branch (Seerr rebranding)

### Note
This PR has been rebased onto the `remove-optimized-server` branch which includes the complete Jellyseerr → Seerr rebranding. All file paths and component names have been updated to reflect the new naming.

Closes #1130

---

## AI Assistance Disclosure

> [!IMPORTANT]  
> This PR was written primarily by **Claude Code**.

The issue analysis, root cause investigation, codebase exploration, code changes, and merge conflict resolution were generated with AI assistance. The contributor reviewed and tested the changes before submission.