### PR TITLE
fix: remove fixed overlay size so it covers the whole screen

### DIFF
--- a/components/video-player/controls/GestureOverlay.tsx
+++ b/components/video-player/controls/GestureOverlay.tsx
@@ -254,8 +254,6 @@ export const GestureOverlay = ({
         onPress={onToggleControls}
         style={{
           position: "absolute",
-          width: screenWidth,
-          height: screenHeight,
           backgroundColor: "black",
           left: 0,
           right: 0,
@@ -276,8 +274,6 @@ export const GestureOverlay = ({
         onTouchEnd={handleTouchEnd}
         style={{
           position: "absolute",
-          width: screenWidth,
-          height: screenHeight,
           backgroundColor: "transparent",
           left: 0,
           right: 0,


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary
Fixes the video gesture overlay UI not taking up the whole screen.

## 🏷️ Ticket / Issue
None

## 🛠️ What’s Changed
- Type: fix
- Scope: UI
- Short summary: Fixes the video gesture overlay UI not taking up the whole screen.

## 📋 Details
This PR fixes an issue where the bottom part of the screen was not covered by the gesture overlay background and appeared transparent.

### 🖼️ Screenshots / GIFs (if UI)
Before:
![d6fbe71f-f8fe-4993-8141-ccba53fe46ec](https://github.com/user-attachments/assets/34b4ac14-31f2-446d-a50f-7321cc91f058)
After:
![2d7d3de3-d985-46e3-9d4e-63ac6b2137f9](https://github.com/user-attachments/assets/785bdf25-612a-48e8-8814-e3eb020de80f)


## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [ ] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [ ] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions
1. Run the app
2. Play a video
3. Tap the screen and look for the fixed overlay size (easier to see in landscape mode)
