### PR TITLE
fix(ci): use default GITHUB_TOKEN for Crowdin workflow

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -45,6 +45,6 @@ jobs:
           # Commit customization
           commit_message: "feat(i18n): update translations from Crowdin"
         env:
-          GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
Replaces custom CROWDIN_GITHUB_TOKEN secret with the default GITHUB_TOKEN provided by GitHub Actions.

This simplifies the authentication setup by leveraging the automatically available token instead of requiring a separate secret to be configured.
