### PR TITLE
chore(i18n): include untranslated strings in Crowdin sync

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -40,7 +40,7 @@ jobs:
           pull_request_base_branch_name: "develop"
           pull_request_labels: "🌐 translation"
           # Quality control options
-          skip_untranslated_strings: true
+          skip_untranslated_strings: false
           export_only_approved: false
           # Commit customization
           commit_message: "feat(i18n): update translations from Crowdin"


### PR DESCRIPTION
Allows untranslated strings to be pulled from Crowdin by setting skip_untranslated_strings to false.

Ensures all translation strings are synchronized, even if they haven't been fully translated yet, providing better visibility of translation progress and completeness.