### PR TITLE
ci(crowdin): include untranslated files in exports

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -41,6 +41,7 @@ jobs:
           pull_request_labels: "🌐 translation"
           # Quality control options
           skip_untranslated_strings: false
+          skip_untranslated_files: false
           export_only_approved: false
           # Commit customization
           commit_message: "feat(i18n): update translations from Crowdin"


### PR DESCRIPTION
Ensures that files containing untranslated strings are exported from Crowdin instead of being skipped.

This allows for better visibility of translation progress and ensures all language files are present in the repository, even if not fully translated yet.