### PR TITLE
feat(settings): add toggle to disable auto-play next episode

### DIFF
--- a/components/settings/PlaybackControlsSettings.tsx
+++ b/components/settings/PlaybackControlsSettings.tsx
@@ -211,7 +211,23 @@ export const PlaybackControlsSettings: React.FC = () => {
           />
         </ListItem>
 
-        <ListItem title={t("home.settings.other.max_auto_play_episode_count")}>
+        <ListItem
+          title={t("home.settings.other.auto_play_next_episode")}
+          disabled={pluginSettings?.autoPlayNextEpisode?.locked}
+        >
+          <Switch
+            value={settings.autoPlayNextEpisode}
+            disabled={pluginSettings?.autoPlayNextEpisode?.locked}
+            onValueChange={(autoPlayNextEpisode) =>
+              updateSettings({ autoPlayNextEpisode })
+            }
+          />
+        </ListItem>
+
+        <ListItem
+          title={t("home.settings.other.max_auto_play_episode_count")}
+          disabled={!settings.autoPlayNextEpisode}
+        >
           <PlatformDropdown
             groups={autoPlayEpisodeOptions}
             trigger={

--- a/components/video-player/controls/BottomControls.tsx
+++ b/components/video-player/controls/BottomControls.tsx
@@ -148,21 +148,22 @@ export const BottomControls: FC<BottomControlsProps> = ({
             onPress={skipCredit}
             buttonText='Skip Credits'
           />
-          {(settings.maxAutoPlayEpisodeCount.value === -1 ||
-            settings.autoPlayEpisodeCount <
-              settings.maxAutoPlayEpisodeCount.value) && (
-            <NextEpisodeCountDownButton
-              show={
-                !nextItem
-                  ? false
-                  : // Show during credits if no content after, OR near end of video
-                    (showSkipCreditButton && !hasContentAfterCredits) ||
-                    remainingTime < 10000
-              }
-              onFinish={handleNextEpisodeAutoPlay}
-              onPress={handleNextEpisodeManual}
-            />
-          )}
+          {settings.autoPlayNextEpisode !== false &&
+            (settings.maxAutoPlayEpisodeCount.value === -1 ||
+              settings.autoPlayEpisodeCount <
+                settings.maxAutoPlayEpisodeCount.value) && (
+              <NextEpisodeCountDownButton
+                show={
+                  !nextItem
+                    ? false
+                    : // Show during credits if no content after, OR near end of video
+                      (showSkipCreditButton && !hasContentAfterCredits) ||
+                      remainingTime < 10000
+                }
+                onFinish={handleNextEpisodeAutoPlay}
+                onPress={handleNextEpisodeManual}
+              />
+            )}
         </View>
       </View>
       <View

--- a/translations/en.json
+++ b/translations/en.json
@@ -278,6 +278,7 @@
         "disable_haptic_feedback": "Disable Haptic Feedback",
         "default_quality": "Default Quality",
         "default_playback_speed": "Default Playback Speed",
+        "auto_play_next_episode": "Auto-play Next Episode",
         "max_auto_play_episode_count": "Max Auto Play Episode Count",
         "disabled": "Disabled"
       },

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -180,6 +180,7 @@ export type Settings = {
   enableH265ForChromecast: boolean;
   maxAutoPlayEpisodeCount: MaxAutoPlayEpisodeCount;
   autoPlayEpisodeCount: number;
+  autoPlayNextEpisode: boolean;
   // Playback speed settings
   defaultPlaybackSpeed: number;
   playbackSpeedPerMedia: Record<string, number>;
@@ -264,6 +265,7 @@ export const defaultValues: Settings = {
   enableH265ForChromecast: false,
   maxAutoPlayEpisodeCount: { key: "3", value: 3 },
   autoPlayEpisodeCount: 0,
+  autoPlayNextEpisode: true,
   // Playback speed defaults
   defaultPlaybackSpeed: 1.0,
   playbackSpeedPerMedia: {},


### PR DESCRIPTION
## Summary
- Adds new `autoPlayNextEpisode` setting to completely disable auto-play
- When disabled, the next episode countdown button is hidden
- The "Max Auto Play Episode Count" dropdown appears greyed out when auto-play is off