### PR TITLE
fix(ci): code scanning alert no. 219

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -203,9 +203,6 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
           eas-cache: true
 
-      - name: ⚙️ Ensure iOS SDKs installed
-        run: xcodebuild -downloadPlatform iOS
-
       - name: 🚀 Build iOS app
         env:
           EXPO_TV: 0
@@ -271,8 +268,6 @@ jobs:
   #         token: ${{ secrets.EXPO_TOKEN }}
   #         eas-cache: true
   #
-  #     - name: ⚙️ Ensure tvOS SDKs installed
-  #       run: xcodebuild -downloadPlatform tvOS
   #
   #     - name: 🚀 Build iOS app
   #       env:

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -1,4 +1,5 @@
 name: 🛎️ Discord Notification
+permissions: {}
 
 on:
   pull_request:

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "streamyfin",


### PR DESCRIPTION
Potential fix for [https://github.com/streamyfin/streamyfin/security/code-scanning/219](https://github.com/streamyfin/streamyfin/security/code-scanning/219)

To fix the issue, add an explicit `permissions` block at the top level of the workflow file. This restricts the permissions granted by the `GITHUB_TOKEN` to the least necessary for the workflow to function. Since this workflow only sends notifications based on repository events and does not push, pull, or modify repository contents nor interact with issues, a minimal block such as `permissions: {}` (which disables all permissions) or `permissions: contents: read` is sufficient. Place the block immediately below the workflow name, above `on:`. No other code changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined mobile platform build configuration by removing redundant SDK installation steps
  * Updated workflow permissions settings to enhance security controls

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->