### PR TITLE
fix: remove Android emulator detection from MPV player

### DIFF
--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt
@@ -33,23 +33,6 @@ class MpvPlayerView(context: Context, appContext: AppContext) : ExpoView(context
     
     companion object {
         private const val TAG = "MpvPlayerView"
-
-        /**
-         * Detect if running on an Android emulator.
-         * MPV player has EGL/OpenGL compatibility issues on emulators.
-         */
-        private fun isEmulator(): Boolean {
-            return (Build.FINGERPRINT.startsWith("generic")
-                    || Build.FINGERPRINT.startsWith("unknown")
-                    || Build.MODEL.contains("google_sdk")
-                    || Build.MODEL.contains("Emulator")
-                    || Build.MODEL.contains("Android SDK built for x86")
-                    || Build.MANUFACTURER.contains("Genymotion")
-                    || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
-                    || "google_sdk" == Build.PRODUCT
-                    || Build.HARDWARE.contains("goldfish")
-                    || Build.HARDWARE.contains("ranchu"))
-        }
     }
     
     // Event dispatchers
@@ -104,21 +87,14 @@ class MpvPlayerView(context: Context, appContext: AppContext) : ExpoView(context
             }
         }
         
-        // Start the renderer (skip on emulators to avoid EGL crashes)
-        if (isEmulator()) {
-            Log.w(TAG, "Running on emulator - MPV player disabled due to EGL/OpenGL compatibility issues")
-            // Don't start renderer on emulator, will show error when trying to play
-        } else {
-            try {
-                renderer?.start()
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to start renderer: ${e.message}")
-                onError(mapOf("error" to "Failed to start renderer: ${e.message}"))
-            }
+        // Start the renderer
+        try {
+            renderer?.start()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start renderer: ${e.message}")
+            onError(mapOf("error" to "Failed to start renderer: ${e.message}"))
         }
     }
-
-    private var isOnEmulator: Boolean = isEmulator()
     
     // MARK: - SurfaceHolder.Callback
     
@@ -149,13 +125,6 @@ class MpvPlayerView(context: Context, appContext: AppContext) : ExpoView(context
     // MARK: - Video Loading
 
     fun loadVideo(config: VideoLoadConfig) {
-        // Block video loading on emulators
-        if (isOnEmulator) {
-            Log.w(TAG, "Cannot load video on emulator - MPV player not supported")
-            onError(mapOf("error" to "MPV player is not supported on emulators. Please test on a real device."))
-            return
-        }
-
         // Skip reload if same URL is already playing
         if (currentUrl == config.url) {
             return


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary

Removes Android emulator detection that was preventing MPV player testing on emulators.

## 🏷️ Ticket / Issue

N/A - Developer experience improvement

## 🛠️ What's Changed

- Type: **fix**
- Scope: **mpv-player**
- Short summary: Removed emulator detection allowing MPV player to work on Android emulators

## 📋 Details

### Changes

Removed emulator detection code from [modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt](modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt):

1. **Deleted `isEmulator()` function** (18 lines) that checked for:
   - Generic fingerprints
   - Google SDK models
   - Emulator identifiers
   - Genymotion
   - Goldfish/Ranchu hardware

2. **Removed emulator checks** that prevented:
   - MPV renderer initialization
   - Video loading

3. **Removed error messages**:
   - "MPV player disabled due to EGL/OpenGL compatibility issues"
   - "MPV player is not supported on emulators"

### Rationale

Modern Android emulators (API 29+) have proper OpenGL/EGL support and can run MPV player without issues. The emulator detection was:
- Preventing developers from testing video playback
- No longer necessary with improved emulator graphics
- Blocking legitimate testing workflows

### ⚠️ Breaking Changes

None - Only removes restrictions

### 🔐 Security & Privacy Impact

None

### ⚡ Performance Impact

**Positive:**
- Removes unnecessary runtime checks (isEmulator() on every init)

**No Degradation:**
- Emulators that can't handle MPV will fail gracefully with existing error handling

## ✅ Checklist

- [x] Code follows project style and passes lint/format
- [x] Type checks pass
- [x] No secrets/credentials included
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions

### Prerequisites
```bash
git checkout fix/remove-mpv-emulator-check
bun install
```

### Testing on Android Emulator

1. Start an Android emulator (API 29+)
2. Run the app: `bun run android`
3. Navigate to a video
4. Tap play
5. Verify video plays without "emulator not supported" errors

**Expected**: Video playback works on emulator

### Testing on Real Device

1. Run app on physical Android device
2. Play a video
3. Verify playback still works normally

**Expected**: No regression, video plays as before

## ⚙️ Deployment Notes

No special deployment steps required

## 📝 Additional Notes

- Total lines removed: 37
- Total lines added: 6
- Net reduction: 31 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video playback on Android emulators that was previously restricted.
  * Improved error reporting when the video player fails to initialize.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->