### PR TITLE
fix(logs): change the mimeType and UTI to the proper types for log ex…

### DIFF
--- a/app/(auth)/(tabs)/(home)/settings/logs/page.tsx
+++ b/app/(auth)/(tabs)/(home)/settings/logs/page.tsx
@@ -61,7 +61,10 @@ export default function Page() {
     setLoading(true);
     try {
       logsFile.write(JSON.stringify(filteredLogs));
-      await Sharing.shareAsync(logsFile.uri, { mimeType: "txt", UTI: "txt" });
+      await Sharing.shareAsync(logsFile.uri, {
+        mimeType: "text/plain",
+        UTI: "public.plain-text",
+      });
     } catch (e: any) {
       writeErrorLog("Something went wrong attempting to export", e);
     } finally {


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary

Fix the "Export Logs" button by changing the mimeType and UTI to the proper type.

- Fixes #1223 

## 📋 Details

The previous values (just "txt") are not valid so the OS didn't know how to share the text file.

### 🖼️ Screenshots / GIFs (if UI)

![export_logs](https://github.com/user-attachments/assets/908acb40-7f77-4c25-8026-061921939053)

## ✅ Checklist

- [X] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [X] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [X] Type checks pass (tsc/biome/etc.)
- [X] Docs updated (README/ADR/usage/API)
- [X] No secrets/credentials included; env vars documented
- [X] Release notes/CHANGELOG entry added (if applicable)
- [X] Verified locally that changes behave as expected

## 🔍 Testing Instructions

1. Checkout branch
2. Generate some logs
3. Go to settings -> logs
4. Click the "Export Logs" button
