### PR TITLE
feat(player): allow modifying subtitle timing offsets

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -883,6 +883,17 @@ export default function page() {
     applyInitialPlaybackSpeed();
   }, [isVideoLoaded, initialPlaybackSpeed]);
 
+  // Apply subtitle offset when it changes
+  useEffect(() => {
+    if (!isVideoLoaded || !videoRef.current) return;
+
+    const applySubtitleOffset = async () => {
+      await videoRef.current?.setSubtitleTimingOffset?.(currentSubtitleOffset);
+    };
+
+    applySubtitleOffset();
+  }, [currentSubtitleOffset]);
+
   // Show error UI first, before checking loading/missing‐data
   if (itemStatus.isError || streamStatus.isError) {
     return (

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -83,6 +83,8 @@ export default function page() {
   const [hasPlaybackStarted, setHasPlaybackStarted] = useState(false);
   const [currentPlaybackSpeed, setCurrentPlaybackSpeed] = useState(1.0);
   const [showTechnicalInfo, setShowTechnicalInfo] = useState(false);
+  const [showSubtitleOffset, setShowSubtitleOffset] = useState(false);
+  const [currentSubtitleOffset, setCurrentSubtitleOffset] = useState(0);
 
   const progress = useSharedValue(0);
   const isSeeking = useSharedValue(false);
@@ -737,6 +739,14 @@ export default function page() {
     videoRef.current?.seekTo?.(position / 1000);
   }, []);
 
+  const handleToggleSubtitleOffset = useCallback((toggle: boolean) => {
+    setShowSubtitleOffset(toggle);
+  }, []);
+
+  const handleSetSubtitleOffset = useCallback((offset: number) => {
+    setCurrentSubtitleOffset(offset);
+  }, []);
+
   // Technical info toggle handler
   const handleToggleTechnicalInfo = useCallback(() => {
     setShowTechnicalInfo((prev) => !prev);
@@ -988,6 +998,10 @@ export default function page() {
                 downloadedFiles={downloadedFiles}
                 playbackSpeed={currentPlaybackSpeed}
                 setPlaybackSpeed={handleSetPlaybackSpeed}
+                showSubtitleOffset={showSubtitleOffset}
+                onToggleSubtitleOffset={handleToggleSubtitleOffset}
+                subtitleOffset={currentSubtitleOffset}
+                setSubtitleOffset={handleSetSubtitleOffset}
                 showTechnicalInfo={showTechnicalInfo}
                 onToggleTechnicalInfo={handleToggleTechnicalInfo}
                 getTechnicalInfo={getTechnicalInfo}

--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -493,6 +493,13 @@ export const Controls: FC<Props> = ({
               transcodeReasons={transcodeReasons}
             />
           )}
+          {showSubtitleOffset && (
+            <SubtitleOffsetSlider
+              currentSubtitleOffset={subtitleOffset}
+              setVisibility={onToggleSubtitleOffset}
+              handleSubtitleOffsetChange={setSubtitleOffset}
+            />
+          )}
           <Animated.View
             style={headerAnimatedStyle}
             pointerEvents={showControls ? "auto" : "none"}
@@ -517,13 +524,6 @@ export const Controls: FC<Props> = ({
               showTechnicalInfo={showTechnicalInfo}
               onToggleTechnicalInfo={onToggleTechnicalInfo}
             />
-            {showSubtitleOffset && (
-              <SubtitleOffsetSlider
-                currentSubtitleOffset={subtitleOffset}
-                setVisibility={onToggleSubtitleOffset}
-                handleSubtitleOffsetChange={setSubtitleOffset}
-              />
-            )}
           </Animated.View>
           <Animated.View
             style={centerAnimatedStyle}

--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -37,6 +37,7 @@ import { useRemoteControl } from "./hooks/useRemoteControl";
 import { useVideoNavigation } from "./hooks/useVideoNavigation";
 import { useVideoSlider } from "./hooks/useVideoSlider";
 import { useVideoTime } from "./hooks/useVideoTime";
+import { SubtitleOffsetSlider } from "./SubtitleOffsetSlider";
 import { TechnicalInfoOverlay } from "./TechnicalInfoOverlay";
 import { useControlsTimeout } from "./useControlsTimeout";
 import { PlaybackSpeedScope } from "./utils/playback-speed-settings";
@@ -66,6 +67,11 @@ interface Props {
   // Playback speed props
   playbackSpeed?: number;
   setPlaybackSpeed?: (speed: number, scope: PlaybackSpeedScope) => void;
+  // Subtitle offset props
+  showSubtitleOffset: boolean;
+  onToggleSubtitleOffset: (toggle: boolean) => void;
+  subtitleOffset: number;
+  setSubtitleOffset: (offset: number) => void;
   // Technical info props
   showTechnicalInfo?: boolean;
   onToggleTechnicalInfo?: () => void;
@@ -96,6 +102,10 @@ export const Controls: FC<Props> = ({
   downloadedFiles = undefined,
   playbackSpeed = 1.0,
   setPlaybackSpeed,
+  showSubtitleOffset = false,
+  onToggleSubtitleOffset,
+  subtitleOffset = 0,
+  setSubtitleOffset,
   showTechnicalInfo = false,
   onToggleTechnicalInfo,
   getTechnicalInfo,
@@ -503,9 +513,17 @@ export const Controls: FC<Props> = ({
               onZoomToggle={onZoomToggle}
               playbackSpeed={playbackSpeed}
               setPlaybackSpeed={setPlaybackSpeed}
+              onToggleSubtitleOffset={onToggleSubtitleOffset}
               showTechnicalInfo={showTechnicalInfo}
               onToggleTechnicalInfo={onToggleTechnicalInfo}
             />
+            {showSubtitleOffset && (
+              <SubtitleOffsetSlider
+                currentSubtitleOffset={subtitleOffset}
+                setVisibility={onToggleSubtitleOffset}
+                handleSubtitleOffsetChange={setSubtitleOffset}
+              />
+            )}
           </Animated.View>
           <Animated.View
             style={centerAnimatedStyle}

--- a/components/video-player/controls/HeaderControls.tsx
+++ b/components/video-player/controls/HeaderControls.tsx
@@ -34,6 +34,8 @@ interface HeaderControlsProps {
   // Playback speed props
   playbackSpeed?: number;
   setPlaybackSpeed?: (speed: number, scope: PlaybackSpeedScope) => void;
+  // Subtitle offset props
+  onToggleSubtitleOffset: (toggle: boolean) => void;
   // Technical info props
   showTechnicalInfo?: boolean;
   onToggleTechnicalInfo?: () => void;
@@ -55,6 +57,7 @@ export const HeaderControls: FC<HeaderControlsProps> = ({
   onZoomToggle,
   playbackSpeed = 1.0,
   setPlaybackSpeed,
+  onToggleSubtitleOffset,
   showTechnicalInfo = false,
   onToggleTechnicalInfo,
 }) => {
@@ -115,6 +118,7 @@ export const HeaderControls: FC<HeaderControlsProps> = ({
             <DropdownView
               playbackSpeed={playbackSpeed}
               setPlaybackSpeed={setPlaybackSpeed}
+              onToggleSubtitleOffset={onToggleSubtitleOffset}
               showTechnicalInfo={showTechnicalInfo}
               onToggleTechnicalInfo={onToggleTechnicalInfo}
             />

--- a/components/video-player/controls/SubtitleOffsetSlider.tsx
+++ b/components/video-player/controls/SubtitleOffsetSlider.tsx
@@ -48,19 +48,19 @@ export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
   };
 
   return (
-    <SafeAreaView className='flex items-center justify-center w-full'>
+    <SafeAreaView className='absolute inset-0 flex items-center justify-center w-full top-14 z-50'>
       <BlurView
         intensity={100}
         tint={"dark"}
-        className='flex flex-col justify-center p-4 top-12 w-full max-w-3xl min-w-[256px] px-4'
+        className='flex flex-col justify-center p-4 w-full max-w-3xl min-w-[256px] px-4'
       >
         <View className='flex flex-row justify-center'>
           <Text className='text-white text-xl'>
-            Subtitle Offset: {(currentSubtitleOffset * -1).toFixed(1)}s
+            Subtitle Offset: {Number((currentSubtitleOffset * -1).toFixed(1))}s
           </Text>
           <TouchableOpacity
             onPress={handleClose}
-            className='absolute justify-center right-0 -mr-1 -mt-1'
+            className='absolute justify-center right-0'
           >
             <Ionicons name='close' size={ICON_SIZES.HEADER} color='white' />
           </TouchableOpacity>
@@ -68,7 +68,7 @@ export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
         <View className='flex flex-row'>
           <TouchableOpacity
             onPress={handleDecrement}
-            className='absolute justify-center left-1 h-4 w-4'
+            className='absolute justify-center left-1'
           >
             <Ionicons name='remove' size={ICON_SIZES.HEADER} color='white' />
           </TouchableOpacity>

--- a/components/video-player/controls/SubtitleOffsetSlider.tsx
+++ b/components/video-player/controls/SubtitleOffsetSlider.tsx
@@ -60,7 +60,7 @@ export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
           </Text>
           <TouchableOpacity
             onPress={handleClose}
-            className='absolute justify-center right-0'
+            className='absolute justify-center right-0 -mr-1 -mt-1'
           >
             <Ionicons name='close' size={ICON_SIZES.HEADER} color='white' />
           </TouchableOpacity>
@@ -68,7 +68,7 @@ export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
         <View className='flex flex-row'>
           <TouchableOpacity
             onPress={handleDecrement}
-            className='absolute justify-center left-1'
+            className='absolute justify-center left-1 h-4 w-4'
           >
             <Ionicons name='remove' size={ICON_SIZES.HEADER} color='white' />
           </TouchableOpacity>

--- a/components/video-player/controls/SubtitleOffsetSlider.tsx
+++ b/components/video-player/controls/SubtitleOffsetSlider.tsx
@@ -53,7 +53,7 @@ export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
     >
       <View className='flex flex-row justify-center'>
         <Text className='text-white text-2xl'>
-          Subtitle Offset: {subtitleOffset.value.toFixed(1)}s
+          Subtitle Offset: {currentSubtitleOffset.toFixed(1)}s
         </Text>
         <TouchableOpacity
           onPress={handleClose}

--- a/components/video-player/controls/SubtitleOffsetSlider.tsx
+++ b/components/video-player/controls/SubtitleOffsetSlider.tsx
@@ -3,6 +3,7 @@ import { BlurView } from "expo-blur";
 import { Text, TouchableOpacity, View } from "react-native";
 import { Slider } from "react-native-awesome-slider";
 import { useSharedValue } from "react-native-reanimated";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { ICON_SIZES } from "./constants";
 
 interface SubtitleOffsetSliderProps {
@@ -47,46 +48,48 @@ export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
   };
 
   return (
-    <BlurView
-      intensity={100}
-      tint={"dark"}
-      className='absolute top-24 left-6 right-6 flex flex-col p-4'
-    >
-      <View className='flex flex-row justify-center'>
-        <Text className='text-white text-2xl'>
-          Subtitle Offset: {(currentSubtitleOffset * -1).toFixed(1)}s
-        </Text>
-        <TouchableOpacity
-          onPress={handleClose}
-          className='absolute justify-center right-0'
-        >
-          <Ionicons name='close' size={ICON_SIZES.HEADER} color='white' />
-        </TouchableOpacity>
-      </View>
-      <View className='flex flex-row'>
-        <TouchableOpacity
-          onPress={handleDecrement}
-          className='absolute justify-center left-1'
-        >
-          <Ionicons name='remove' size={ICON_SIZES.HEADER} color='white' />
-        </TouchableOpacity>
-        <Slider
-          style={{ marginTop: 10, marginHorizontal: 32 }}
-          minimumValue={minimumValue}
-          maximumValue={maximumValue}
-          steps={steps}
-          progress={subtitleOffset}
-          forceSnapToStep={true}
-          onValueChange={handleValueChange}
-          bubble={(val) => `${val.toFixed(1)}s`}
-        ></Slider>
-        <TouchableOpacity
-          onPress={handleIncrement}
-          className='absolute justify-center right-1'
-        >
-          <Ionicons name='add' size={ICON_SIZES.HEADER} color='white' />
-        </TouchableOpacity>
-      </View>
-    </BlurView>
+    <SafeAreaView className='flex items-center justify-center w-full'>
+      <BlurView
+        intensity={100}
+        tint={"dark"}
+        className='flex flex-col justify-center p-4 top-12 w-full max-w-3xl min-w-[256px] px-4'
+      >
+        <View className='flex flex-row justify-center'>
+          <Text className='text-white text-xl'>
+            Subtitle Offset: {(currentSubtitleOffset * -1).toFixed(1)}s
+          </Text>
+          <TouchableOpacity
+            onPress={handleClose}
+            className='absolute justify-center right-0'
+          >
+            <Ionicons name='close' size={ICON_SIZES.HEADER} color='white' />
+          </TouchableOpacity>
+        </View>
+        <View className='flex flex-row'>
+          <TouchableOpacity
+            onPress={handleDecrement}
+            className='absolute justify-center left-1'
+          >
+            <Ionicons name='remove' size={ICON_SIZES.HEADER} color='white' />
+          </TouchableOpacity>
+          <Slider
+            style={{ marginTop: 10, marginHorizontal: 32 }}
+            minimumValue={minimumValue}
+            maximumValue={maximumValue}
+            steps={steps}
+            progress={subtitleOffset}
+            forceSnapToStep={true}
+            onValueChange={handleValueChange}
+            bubble={(val) => `${val.toFixed(1)}s`}
+          ></Slider>
+          <TouchableOpacity
+            onPress={handleIncrement}
+            className='absolute justify-center right-1'
+          >
+            <Ionicons name='add' size={ICON_SIZES.HEADER} color='white' />
+          </TouchableOpacity>
+        </View>
+      </BlurView>
+    </SafeAreaView>
   );
 };

--- a/components/video-player/controls/SubtitleOffsetSlider.tsx
+++ b/components/video-player/controls/SubtitleOffsetSlider.tsx
@@ -26,23 +26,24 @@ export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
   };
 
   const handleDecrement = () => {
-    subtitleOffset.value = Math.max(
-      subtitleOffset.value - 0.1,
+    const newValue = Math.max(
+      currentSubtitleOffset * -1 - 0.1,
       minimumValue.value,
     );
-    handleValueChange(subtitleOffset.value);
+    handleValueChange(newValue);
   };
 
   const handleIncrement = () => {
-    subtitleOffset.value = Math.min(
-      subtitleOffset.value + 0.1,
+    const newValue = Math.min(
+      currentSubtitleOffset * -1 + 0.1,
       maximumValue.value,
     );
-    handleValueChange(subtitleOffset.value);
+    handleValueChange(newValue);
   };
 
   const handleValueChange = (value: number) => {
-    handleSubtitleOffsetChange(value);
+    // Negate the value to match the expected offset direction
+    handleSubtitleOffsetChange(value * -1);
   };
 
   return (
@@ -53,7 +54,7 @@ export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
     >
       <View className='flex flex-row justify-center'>
         <Text className='text-white text-2xl'>
-          Subtitle Offset: {currentSubtitleOffset.toFixed(1)}s
+          Subtitle Offset: {(currentSubtitleOffset * -1).toFixed(1)}s
         </Text>
         <TouchableOpacity
           onPress={handleClose}

--- a/components/video-player/controls/SubtitleOffsetSlider.tsx
+++ b/components/video-player/controls/SubtitleOffsetSlider.tsx
@@ -25,6 +25,22 @@ export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
     setVisibility(false);
   };
 
+  const handleDecrement = () => {
+    subtitleOffset.value = Math.max(
+      subtitleOffset.value - 0.1,
+      minimumValue.value,
+    );
+    handleValueChange(subtitleOffset.value);
+  };
+
+  const handleIncrement = () => {
+    subtitleOffset.value = Math.min(
+      subtitleOffset.value + 0.1,
+      maximumValue.value,
+    );
+    handleValueChange(subtitleOffset.value);
+  };
+
   const handleValueChange = (value: number) => {
     handleSubtitleOffsetChange(value);
   };
@@ -41,21 +57,35 @@ export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
         </Text>
         <TouchableOpacity
           onPress={handleClose}
-          className='absolute justify-center right-1'
+          className='absolute justify-center right-0'
         >
           <Ionicons name='close' size={ICON_SIZES.HEADER} color='white' />
         </TouchableOpacity>
       </View>
-      <Slider
-        style={{ marginTop: 16 }}
-        minimumValue={minimumValue}
-        maximumValue={maximumValue}
-        steps={steps}
-        progress={subtitleOffset}
-        forceSnapToStep={true}
-        onValueChange={handleValueChange}
-        bubble={(val) => `${val.toFixed(1)}s`}
-      ></Slider>
+      <View className='flex flex-row'>
+        <TouchableOpacity
+          onPress={handleDecrement}
+          className='absolute justify-center left-1'
+        >
+          <Ionicons name='remove' size={ICON_SIZES.HEADER} color='white' />
+        </TouchableOpacity>
+        <Slider
+          style={{ marginTop: 10, marginHorizontal: 32 }}
+          minimumValue={minimumValue}
+          maximumValue={maximumValue}
+          steps={steps}
+          progress={subtitleOffset}
+          forceSnapToStep={true}
+          onValueChange={handleValueChange}
+          bubble={(val) => `${val.toFixed(1)}s`}
+        ></Slider>
+        <TouchableOpacity
+          onPress={handleIncrement}
+          className='absolute justify-center right-1'
+        >
+          <Ionicons name='add' size={ICON_SIZES.HEADER} color='white' />
+        </TouchableOpacity>
+      </View>
     </BlurView>
   );
 };

--- a/components/video-player/controls/SubtitleOffsetSlider.tsx
+++ b/components/video-player/controls/SubtitleOffsetSlider.tsx
@@ -1,0 +1,61 @@
+import { Ionicons } from "@expo/vector-icons";
+import { BlurView } from "expo-blur";
+import { Text, TouchableOpacity, View } from "react-native";
+import { Slider } from "react-native-awesome-slider";
+import { useSharedValue } from "react-native-reanimated";
+import { ICON_SIZES } from "./constants";
+
+interface SubtitleOffsetSliderProps {
+  currentSubtitleOffset: number;
+  setVisibility: (show: boolean) => void;
+  handleSubtitleOffsetChange: (offset: number) => void;
+}
+
+export const SubtitleOffsetSlider: React.FC<SubtitleOffsetSliderProps> = ({
+  currentSubtitleOffset,
+  setVisibility,
+  handleSubtitleOffsetChange,
+}) => {
+  const subtitleOffset = useSharedValue<number>(currentSubtitleOffset);
+  const minimumValue = useSharedValue<number>(-30);
+  const maximumValue = useSharedValue<number>(30);
+  const steps = 600;
+
+  const handleClose = () => {
+    setVisibility(false);
+  };
+
+  const handleValueChange = (value: number) => {
+    handleSubtitleOffsetChange(value);
+  };
+
+  return (
+    <BlurView
+      intensity={100}
+      tint={"dark"}
+      className='absolute top-24 left-6 right-6 flex flex-col p-4'
+    >
+      <View className='flex flex-row justify-center'>
+        <Text className='text-white text-2xl'>
+          Subtitle Offset: {subtitleOffset.value.toFixed(1)}s
+        </Text>
+        <TouchableOpacity
+          onPress={handleClose}
+          className='absolute justify-center right-1'
+        >
+          <Ionicons name='close' size={ICON_SIZES.HEADER} color='white' />
+        </TouchableOpacity>
+      </View>
+      <Slider
+        style={{ marginTop: 16 }}
+        minimumValue={minimumValue}
+        maximumValue={maximumValue}
+        steps={steps}
+        progress={subtitleOffset}
+        forceSnapToStep={true}
+        onValueChange={handleValueChange}
+        bubble={(val) => `${val.toFixed(1)}s`}
+      ></Slider>
+    </BlurView>
+  );
+};

--- a/components/video-player/controls/dropdown/DropdownView.tsx
+++ b/components/video-player/controls/dropdown/DropdownView.tsx
@@ -127,11 +127,11 @@ const DropdownView = ({
       });
 
       groups.push({
-        title: "Subtitle Offset",
+        title: "Subtitle Timing Offset",
         options: [
           {
             type: "action" as const,
-            label: "Adjust Subtitle Offset",
+            label: "Adjust Subtitle Timing Offset",
             onPress: () => onToggleSubtitleOffset(true),
           },
         ],

--- a/components/video-player/controls/dropdown/DropdownView.tsx
+++ b/components/video-player/controls/dropdown/DropdownView.tsx
@@ -32,6 +32,7 @@ interface DropdownViewProps {
   setPlaybackSpeed?: (speed: number, scope: PlaybackSpeedScope) => void;
   showTechnicalInfo?: boolean;
   onToggleTechnicalInfo?: () => void;
+  onToggleSubtitleOffset: (toggle: boolean) => void;
 }
 
 const DropdownView = ({
@@ -39,6 +40,7 @@ const DropdownView = ({
   setPlaybackSpeed,
   showTechnicalInfo = false,
   onToggleTechnicalInfo,
+  onToggleSubtitleOffset,
 }: DropdownViewProps) => {
   const { subtitleTracks, audioTracks } = useVideoContext();
   const { item, mediaSource } = usePlayerContext();
@@ -122,6 +124,17 @@ const DropdownView = ({
           selected: subtitleIndex === sub.index.toString(),
           onPress: () => sub.setTrack(),
         })),
+      });
+
+      groups.push({
+        title: "Subtitle Offset",
+        options: [
+          {
+            type: "action" as const,
+            label: "Adjust Subtitle Offset",
+            onPress: () => onToggleSubtitleOffset(true),
+          },
+        ],
       });
 
       // Subtitle Size Section

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MPVLayerRenderer.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MPVLayerRenderer.kt
@@ -422,6 +422,11 @@ class MPVLayerRenderer(private val context: Context) : MPVLib.EventObserver {
         MPVLib.command(arrayOf("sub-add", url, flag))
     }
     
+    fun setSubtitleTimingOffset(offset: Double) {
+        Log.i(TAG, "setSubtitleTimingOffset: setting sub-delay to $offset")
+        MPVLib.setPropertyDouble("sub-delay", offset)
+    }
+    
     // MARK: - Subtitle Positioning
     
     fun setSubtitlePosition(position: Int) {
@@ -681,4 +686,5 @@ class MPVLayerRenderer(private val context: Context) : MPVLib.EventObserver {
         }
     }
 }
+
 

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerModule.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerModule.kt
@@ -126,6 +126,10 @@ class MpvPlayerModule : Module() {
                 view.addSubtitleFile(url, select)
             }
 
+            AsyncFunction("setSubtitleTimingOffset") { view: MpvPlayerView, offset: Double ->
+                view.setSubtitleTimingOffset(offset)
+            }
+
             // Subtitle positioning functions
             AsyncFunction("setSubtitlePosition") { view: MpvPlayerView, position: Int ->
                 view.setSubtitlePosition(position)

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt
@@ -246,6 +246,10 @@ class MpvPlayerView(context: Context, appContext: AppContext) : ExpoView(context
         renderer?.addSubtitleFile(url, select)
     }
     
+    fun setSubtitleTimingOffset(offset: Double) {
+        renderer?.setSubtitleTimingOffset(offset)
+    }
+    
     // MARK: - Subtitle Positioning
     
     fun setSubtitlePosition(position: Int) {

--- a/modules/mpv-player/ios/MPVLayerRenderer.swift
+++ b/modules/mpv-player/ios/MPVLayerRenderer.swift
@@ -713,6 +713,15 @@ final class MPVLayerRenderer {
         commandSync(handle, ["sub-add", url, flag])
     }
     
+    func setSubtitleTimingOffset(_ offset: Double) {
+        guard let handle = mpv else {
+            Logger.shared.log("setSubtitleTimingOffset: mpv handle is nil!", type: "Error")
+            return
+        }
+        Logger.shared.log("setSubtitleTimingOffset: setting sub-delay to \(offset)", type: "Info")
+        setProperty(name: "sub-delay", value: String(offset))
+    }
+    
     // MARK: - Subtitle Positioning
     
     func setSubtitlePosition(_ position: Int) {

--- a/modules/mpv-player/ios/MpvPlayerModule.swift
+++ b/modules/mpv-player/ios/MpvPlayerModule.swift
@@ -126,6 +126,10 @@ public class MpvPlayerModule: Module {
         view.addSubtitleFile(url: url, select: select)
       }
       
+      AsyncFunction("setSubtitleTimingOffset") { (view: MpvPlayerView, offset: Double) in
+        view.setSubtitleTimingOffset(offset)
+      }
+
       // Subtitle positioning functions
       AsyncFunction("setSubtitlePosition") { (view: MpvPlayerView, position: Int) in
         view.setSubtitlePosition(position)

--- a/modules/mpv-player/ios/MpvPlayerView.swift
+++ b/modules/mpv-player/ios/MpvPlayerView.swift
@@ -231,6 +231,10 @@ class MpvPlayerView: ExpoView {
 		renderer?.addSubtitleFile(url: url, select: select)
 	}
 	
+	func setSubtitleTimingOffset(_ offset: Double) {
+		renderer?.setSubtitleTimingOffset(offset)
+	}
+	
 	// MARK: - Audio Track Controls
 	
 	func getAudioTracks() -> [[String: Any]] {

--- a/modules/mpv-player/src/MpvPlayer.types.ts
+++ b/modules/mpv-player/src/MpvPlayer.types.ts
@@ -77,6 +77,8 @@ export interface MpvPlayerViewRef {
   disableSubtitles: () => Promise<void>;
   getCurrentSubtitleTrack: () => Promise<number>;
   addSubtitleFile: (url: string, select?: boolean) => Promise<void>;
+  // Subtitle timing offset
+  setSubtitleTimingOffset: (offset: number) => Promise<void>;
   // Subtitle positioning
   setSubtitlePosition: (position: number) => Promise<void>;
   setSubtitleScale: (scale: number) => Promise<void>;

--- a/modules/mpv-player/src/MpvPlayerView.tsx
+++ b/modules/mpv-player/src/MpvPlayerView.tsx
@@ -84,6 +84,9 @@ export default React.forwardRef<MpvPlayerViewRef, MpvPlayerViewProps>(
       setSubtitleFontSize: async (size: number) => {
         await nativeRef.current?.setSubtitleFontSize(size);
       },
+      setSubtitleTimingOffset: async (offset: number) => {
+        await nativeRef.current?.setSubtitleTimingOffset(offset);
+      },
       // Audio controls
       getAudioTracks: async () => {
         return await nativeRef.current?.getAudioTracks();


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary

Add support for subtitle timing offsets.

## 🏷️ Ticket / Issue

Resolves #385

## 🛠️ What’s Changed

- Type: feat
- Scope: player
- Short summary: Subtitle timing offsets can now be modified directly in the video player so no need to redownload subtitle files if the timings are a bit off

## 📋 Details

- Added a subtitle offset slider component
- Slider is toggled through the DropDownView and persists over the player until closed
- User can modify the subtitle timing offsets by dragging the slider or using the increment/decrement buttons
- Setting the value calls a native function that sets the 'sub-delay' property in mpv

### ⚠️ Breaking Changes

None

### 🔐 Security & Privacy Impact

None

### 🖼️ Screenshots / GIFs (if UI)

<img width="514" height="333" alt="image" src="https://github.com/user-attachments/assets/da75c0c9-0039-4454-876b-4890aa784b21" />

![subtitles](https://github.com/user-attachments/assets/4dee836a-08c8-45b1-b46e-a3554702de42)

## ✅ Checklist

- [X] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [X] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [X] Type checks pass (tsc/biome/etc.)
- [X] Docs updated (README/ADR/usage/API)
- [X] No secrets/credentials included; env vars documented
- [X] Release notes/CHANGELOG entry added (if applicable)
- [X] Verified locally that changes behave as expected

## 🔍 Testing Instructions

1. Pull and install the build from the branch
2. Play a video that has subtitles
3. Open the drop down view with the subtitle settings
4. Click the 'Adjust Subtitle Timing Offset' button
5. Modify the subtitle offset and notice that subtitles will appear earlier/later

## ⚙️ Deployment Notes

None

## 📝 Additional Notes

Would be great if somebody could test on Apple. The relevant files have been changed but I have no access to an Apple device.