### PR TITLE
fix: Upnext poster is missing for some episodes

### DIFF
--- a/components/ContinueWatchingPoster.tsx
+++ b/components/ContinueWatchingPoster.tsx
@@ -35,8 +35,8 @@ const ContinueWatchingPoster: React.FC<ContinueWatchingPosterProps> = ({
       return `${api?.basePath}/Items/${item.Id}/Images/Primary?fillHeight=389&quality=80`;
     }
     if (item.Type === "Episode") {
-      if (item.ParentBackdropItemId && item.ParentThumbImageTag) {
-        return `${api?.basePath}/Items/${item.ParentBackdropItemId}/Images/Thumb?fillHeight=389&quality=80&tag=${item.ParentThumbImageTag}`;
+      if (item.ParentThumbItemId && item.ParentThumbImageTag) {
+        return `${api?.basePath}/Items/${item.ParentThumbItemId}/Images/Thumb?fillHeight=389&quality=80&tag=${item.ParentThumbImageTag}`;
       }
 
       return `${api?.basePath}/Items/${item.Id}/Images/Primary?fillHeight=389&quality=80`;
@@ -63,8 +63,9 @@ const ContinueWatchingPoster: React.FC<ContinueWatchingPosterProps> = ({
     return `${api?.basePath}/Items/${item.Id}/Images/Primary?fillHeight=389&quality=80`;
   }, [item]);
 
-  if (!url)
+  if (!url) {
     return <View className='aspect-video border border-neutral-800 w-44' />;
+  }
 
   return (
     <View

--- a/components/posters/EpisodePoster.tsx
+++ b/components/posters/EpisodePoster.tsx
@@ -19,7 +19,7 @@ export const EpisodePoster: React.FC<MoviePosterProps> = ({
 
   const url = useMemo(() => {
     if (item.Type === "Episode") {
-      return `${api?.basePath}/Items/${item.ParentBackdropItemId}/Images/Thumb?fillHeight=389&quality=80&tag=${item.ParentThumbImageTag}`;
+      return `${api?.basePath}/Items/${item.ParentThumbItemId}/Images/Thumb?fillHeight=389&quality=80&tag=${item.ParentThumbImageTag}`;
     }
   }, [item]);
 


### PR DESCRIPTION
<!--
  Pull Request Template for Streamyfin
  ====================================
  Use this template to help reviewers understand the purpose of your PR
  and to ensure all necessary checks are completed before merging.
-->

# 📦 Pull Request

## 🔖 Summary
<!--
A concise description of the changes introduced by this PR.
Example:
“Add real-time currency conversion widget to dashboard.”
-->

## 🏷️ Ticket / Issue

Closes #1464 
Related: #1450 for tv-interface branch

## 🛠️ What’s Changed
- Type: fix
- Short summary: Upnext poster is missing for some episodes

## 📋 Details

When an episode’s season has a Backdrop image but not a Thumb image, and the episode’s show has both a Backdrop image and a Thumb image, display the show's backdrop image as the episode's thumb image in the Upnext row.

(This is the same behavior that currently happens when the episode's season does not have a Backdrop image.)


### ⚠️ Breaking Changes
None

### 🔐 Security & Privacy Impact
None

### ⚡ Performance Impact
None

### 🖼️ Screenshots / GIFs (if UI)
<!-- Before/After, dark mode, responsive states. -->

## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [ ] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [ ] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions
<!--
Describe how reviewers can test your changes.
Example:
1. `git fetch origin pull/1465/head:branchname && git checkout branchname`
2. Install deps: `npm|pnpm|yarn|bun install`
3. Start service/app: `npm|pnpm|yarn|bun run [target]` (e.g., `npm run ios` or `bun run android:tv`)
4. Run tests: `npm|pnpm|yarn|bun test`
5. Verification steps:
   - [ ] Expected UI/endpoint behavior
   - [ ] Logs show no errors
   - [ ] Edge cases covered (list)
-->

Reproduce the issue:

1. Go to the Jellyfin web interface and login as an admin user
2. Look at Nextup and find an episode to experiment with
3. From the Jellyfin sidebar, under ‘Administration’, select ‘Metadata Manager’
    1. Navigate to the TV Show library and the TV show for the episode from step 2
        1. With the Show in edit mode, click the “three dots” menu and select “Edit images”
        2. Add or remove images, to ensure the Season has a “Primary” image, a “Backdrop” image, and a “Thumb” image
    2. Next, still in the Metadata Manager, navigate to the season for the episode from step 2.
        1. With the Season in edit mode, click the “three dots” menu and select “Edit images”
        2. Add or remove images, to ensure the Season has a “Primary” image and a “Backdrop” image, but does not have a “Thumb” image

Build the fix

1. `git fetch origin pull/<PR_ID>/head:fix-nextup-episode-poster && git checkout fix-nextup-episode-poster`
2. Install deps: `npm|pnpm|yarn|bun install`
3. Start service/app: `npm|pnpm|yarn|bun run [target]` (e.g., `npm run ios` or `bun run android:tv`)
4. Run tests: `npm|pnpm|yarn|bun test`
5. Verification steps:
   - [ ] Open Streamyfin and look at the episode in Nextup
      - If necessary, Force Quit Streamyfin, relaunch it, and then reload the home screen to ensure that the Nextup images are refreshed
      - [ ] Verify that the episode is included in Nextup, and does have a thumbnail displayed
   - [ ] Logs show no errors

## ⚙️ Deployment Notes
<!--
Describe any deployment considerations such as config, environment vars, or native builds.
-->

## 📝 Additional Notes
<!--
Any other information or references related to this PR.
-->