### PR TITLE
fix: Close modal when back button is pressed on Android

### DIFF
--- a/providers/GlobalModalProvider.tsx
+++ b/providers/GlobalModalProvider.tsx
@@ -5,9 +5,12 @@ import {
   type ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from "react";
+
+import { BackHandler, Platform } from "react-native";
 
 interface ModalOptions {
   enableDynamicSizing?: boolean;
@@ -72,6 +75,25 @@ export const GlobalModalProvider: React.FC<GlobalModalProviderProps> = ({
       setModalState({ content: null, options: undefined });
     });
   }, []);
+
+  useEffect(() => {
+    if (Platform.OS !== "android") return;
+
+    const onBackPress = () => {
+      if (isVisible) {
+        hideModal();
+        return true;
+      }
+      return false;
+    };
+
+    const subscription = BackHandler.addEventListener(
+      "hardwareBackPress",
+      onBackPress,
+    );
+
+    return () => subscription.remove();
+  }, [isVisible, hideModal]);
 
   const value = {
     showModal,


### PR DESCRIPTION
<!--
  Pull Request Template for Streamyfin
  ====================================
  Use this template to help reviewers understand the purpose of your PR
  and to ensure all necessary checks are completed before merging.
-->

# 📦 Pull Request

## 🔖 Summary
<!--
A concise description of the changes introduced by this PR.
Example:
“Add real-time currency conversion widget to dashboard.”
-->
Makes the back action in Android to actually close the currently open modal instead of leaving it open and navigating back the page it has underneath.

## 🏷️ Ticket / Issue
<!--
Link to the related ticket, issue or user story.
You can also indicate if this PR supersedes a previous one.
Example:
- Closes #123
- Fixes STREAMYFIN-456
- Resolves #789
- Supersedes #120
- Related: #130
-->

## 🛠️ What’s Changed
<!-- Use a Conventional Commit in the PR title, e.g., `feat(auth): add MFA`. 
If this PR introduces a breaking change, include a `BREAKING CHANGE:` block in the description.
Spec: https://www.conventionalcommits.org/ -->

- Type: fix
- Scope: navigation, Android
- Short summary: `GlobalModalProvider` now detects the `hardwareBackPress` event in Android and closes itself if it's open.

## 📋 Details
<!--
Provide more context or background. Explain any non-obvious decisions.
Include screenshots or GIFs for UI changes if applicable.
-->
This code change does nothing in iPhone because these devices doesn't have physical back buttons or a OS level "back action" (I'm not 100% sure because I don't own one). 
These changes make the back action not affect the page navigation when a model is open, closing the modal instead.

### ⚠️ Breaking Changes
<!-- List any breaking API/contract changes and migration guidance. If none, write “None”. -->
None

### 🔐 Security & Privacy Impact
<!-- Data touched, new permissions/scopes, PII, secrets, threat considerations. If none, write “None”. -->
None

### ⚡ Performance Impact
<!-- Hot paths, memory/CPU/latency implications, benchmarks if available. -->
None

### 🖼️ Screenshots / GIFs (if UI)
<!-- Before/After, dark mode, responsive states. -->
Before: 
[Videocaptura de pantalla_20260310_223322.webm](https://github.com/user-attachments/assets/59f07d38-ebf0-41bb-8516-205867a1490f)

After:
[Videocaptura de pantalla_20260310_223242.webm](https://github.com/user-attachments/assets/d2152dca-8835-43ee-922b-08c09cd5fb8a)


## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [X ] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ X] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [ X] Type checks pass (tsc/biome/etc.)
- [ ] Docs updated (README/ADR/usage/API)
- [X ] No secrets/credentials included; env vars documented
- [ ] Release notes/CHANGELOG entry added (if applicable)
- [ X] Verified locally that changes behave as expected

## 🔍 Testing Instructions
<!--
Describe how reviewers can test your changes.
Example:
1. `git fetch origin pull/<PR_ID>/head:branchname && git checkout branchname`
2. Install deps: `npm|pnpm|yarn|bun install`
3. Start service/app: `npm|pnpm|yarn|bun run [target]` (e.g., `npm run ios` or `bun run android:tv`)
4. Run tests: `npm|pnpm|yarn|bun test`
5. Verification steps:
   - [ ] Expected UI/endpoint behavior
   - [ ] Logs show no errors
   - [ ] Edge cases covered (list)
-->
1. `git fetch origin pull/1487/head:branch && git checkout branch`
2. Install deps: `npm|pnpm|yarn|bun install`
3. Start service/app: `npm|pnpm|yarn|bun run android
4. Run tests: `npm|pnpm|yarn|bun test`
5. Verification steps:
   - [ ] Open a modal
   - [ ] Trigger the back action (physical button, back gesture, navigation bar)
   - [ ] Modal should close, the page shouldn't have changed.

## ⚙️ Deployment Notes
<!--
Describe any deployment considerations such as config, environment vars, or native builds.
-->

## 📝 Additional Notes
<!--
Any other information or references related to this PR.
-->