### PR TITLE
fix(player): restore playback position for downloaded files on Android

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -534,6 +534,8 @@ export default function page() {
   const videoSource = useMemo<MpvVideoSource | undefined>(() => {
     if (!stream?.url) return undefined;
 
+    if (offline && !item) return undefined;
+
     const mediaSource = stream.mediaSource;
     const isTranscoding = Boolean(mediaSource?.TranscodingUrl);
 
@@ -601,6 +603,7 @@ export default function page() {
     stream?.url,
     stream?.mediaSource,
     item?.UserData?.PlaybackPositionTicks,
+    item,
     playbackPositionFromUrl,
     api?.basePath,
     api?.accessToken,

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MPVLayerRenderer.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MPVLayerRenderer.kt
@@ -54,6 +54,8 @@ class MPVLayerRenderer(private val context: Context) : MPVLib.EventObserver {
     private var _isLoading: Boolean = false
     private var _playbackSpeed: Double = 1.0
     private var isReadyToSeek: Boolean = false
+    private var initialSeekDone: Boolean = false
+    private var pendingStartPosition: Double? = null
 
     // Progress update throttling - CRITICAL for performance!
     // DO NOT REMOVE THIS THROTTLE - it is essential for battery life and CPU efficiency.
@@ -273,6 +275,9 @@ class MPVLayerRenderer(private val context: Context) : MPVLib.EventObserver {
         pendingExternalSubtitles = externalSubtitles ?: emptyList()
         this.initialSubtitleId = initialSubtitleId
         this.initialAudioId = initialAudioId
+
+        pendingStartPosition = if (startPosition != null && startPosition > 0) startPosition else null
+        initialSeekDone = false
         
         _isLoading = true
         isReadyToSeek = false
@@ -665,6 +670,14 @@ class MPVLayerRenderer(private val context: Context) : MPVLib.EventObserver {
                 }
             }
             MPVLib.MPV_EVENT_PLAYBACK_RESTART -> {
+                if (!initialSeekDone) {
+                    pendingStartPosition?.let { pos ->
+                        MPVLib.setPropertyDouble("time-pos", pos)
+                        pendingStartPosition = null
+                    }
+                    initialSeekDone = true
+                }
+
                 // Video playback has started/restarted (including after seek)
                 _isSeeking = false
                 if (_isLoading) {


### PR DESCRIPTION
<!--
  Pull Request Template for Streamyfin
  ====================================
  Use this template to help reviewers understand the purpose of your PR
  and to ensure all necessary checks are completed before merging.
-->

# 📦 Pull Request

## 🔖 Summary
Playback always starting from the beginning instead of 
resuming from the saved position. Affected Android physical devices only 
— not reproducible on emulator.

## 🛠️ What’s Changed

- Type: fix 
- Scope: player
- Short summary: Playback of downloaded files always started from the beginning instead of resuming from the saved position.

## 📋 Details
<!--
Provide more context or background. Explain any non-obvious decisions.
Include screenshots or GIFs for UI changes if applicable.
-->
- fix(player): use `setPropertyDouble("time-pos")` instead of seek 
  command in Android MPV module — seek commands are silently ignored 
  by MPV during player initialization

- fix(player): prevent `videoSource` from recalculating `startPosition` 
  from `playbackPositionFromUrl` changes during playback

### 🖼️ Screenshots / GIFs (if UI)
<!-- Before/After, dark mode, responsive states. -->
Before:

https://github.com/user-attachments/assets/6d74abe1-bd49-4f62-aff1-4082b3b0977d

After:

https://github.com/user-attachments/assets/5ea836a0-be9d-4884-b477-3b19b4248658


## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x ] Type checks pass (tsc/biome/etc.)
- [ ] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [ ] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions
<!--
Describe how reviewers can test your changes.
Example:
1. `git fetch origin pull/<PR_ID>/head:branchname && git checkout branchname`
2. Install deps: `npm|pnpm|yarn|bun install`
3. Start service/app: `npm|pnpm|yarn|bun run [target]` (e.g., `npm run ios` or `bun run android:tv`)
4. Run tests: `npm|pnpm|yarn|bun test`
5. Verification steps:
   - [ ] Expected UI/endpoint behavior
   - [ ] Logs show no errors
   - [ ] Edge cases covered (list)
-->
Tested on: Nothing Phone 2a Android 16
Not reproducible on Android emulator — requires physical device.

1. Download any media item
2. Play it past the 5% mark, then exit
3. Re-open and play using "Play downloaded file"
4. Verify playback resumes from the correct position

## ⚙️ Deployment Notes
<!--
Describe any deployment considerations such as config, environment vars, or native builds.
-->

## 📝 Additional Notes
<!--
Any other information or references related to this PR.
-->