### PR TITLE
fix(android): keep foreground service alive between queued downloads

### DIFF
--- a/modules/background-downloader/android/src/main/java/expo/modules/backgrounddownloader/BackgroundDownloaderModule.kt
+++ b/modules/background-downloader/android/src/main/java/expo/modules/backgrounddownloader/BackgroundDownloaderModule.kt
@@ -252,7 +252,9 @@ class BackgroundDownloaderModule : Module() {
     ))
     
     downloadTasks.remove(taskId)
-    downloadService?.stopDownload()
+    if (downloadQueue.isEmpty()) {
+        downloadService?.stopDownload()
+    }
     
     // Process next item in queue
     processNextInQueue()
@@ -269,7 +271,9 @@ class BackgroundDownloaderModule : Module() {
     ))
     
     downloadTasks.remove(taskId)
-    downloadService?.stopDownload()
+    if (downloadQueue.isEmpty()) {
+        downloadService?.stopDownload()
+    }
     
     // Process next item in queue even on error
     processNextInQueue()


### PR DESCRIPTION
<!--
  Pull Request Template for Streamyfin
  ====================================
  Use this template to help reviewers understand the purpose of your PR
  and to ensure all necessary checks are completed before merging.
-->

# 📦 Pull Request

## 🔖 Summary
<!--
A concise description of the changes introduced by this PR.
Example:
“Add real-time currency conversion widget to dashboard.”
-->
Fix queued downloads being interrupted on Android when downloading multiple items. The foreground service was stopped after each individual download completed, allowing Android to kill the process before the next item in the queue could start.

## 🏷️ Ticket / Issue
<!--
Link to the related ticket, issue or user story.
You can also indicate if this PR supersedes a previous one.
Example:
- Closes #123
- Fixes STREAMYFIN-456
- Resolves #789
- Supersedes #120
- Related: #130
-->
- Fixes #1246 

## 🛠️ What’s Changed
<!-- Use a Conventional Commit in the PR title, e.g., `feat(auth): add MFA`. 
If this PR introduces a breaking change, include a `BREAKING CHANGE:` block in the description.
Spec: https://www.conventionalcommits.org/ -->

- Type: fix
- Scope: downloads, android
- Short summary: Only stop the foreground service when the download queue is actually 
  empty, instead of after every completed or failed download.

## 📋 Details
<!--
Provide more context or background. Explain any non-obvious decisions.
Include screenshots or GIFs for UI changes if applicable.
-->
`handleDownloadComplete` and `handleError` in `BackgroundDownloaderModule.kt` 
were calling `downloadService?.stopDownload()` unconditionally after each 
task finished. This stopped the foreground service between downloads, 
giving Android permission to kill the process before `processNextInQueue()` 
could start the next item.

The fix defers `stopDownload()` until `downloadQueue.isEmpty()`, keeping 
the foreground service alive for the entire duration of a batch download.

### ⚠️ Breaking Changes
<!-- List any breaking API/contract changes and migration guidance. If none, write “None”. -->

### 🔐 Security & Privacy Impact
<!-- Data touched, new permissions/scopes, PII, secrets, threat considerations. If none, write “None”. -->

### ⚡ Performance Impact
<!-- Hot paths, memory/CPU/latency implications, benchmarks if available. -->
The foreground service now stays alive longer when multiple downloads are 
queued, which is the intended behavior. No impact on single-item downloads.

### 🖼️ Screenshots / GIFs (if UI)
<!-- Before/After, dark mode, responsive states. -->
Before: 
<img width="1084" height="2412" alt="Screenshot_20260314-004311" src="https://github.com/user-attachments/assets/3a3e33be-ffba-4e73-9e71-a1f7484920fa" />

After:
<img width="1084" height="2412" alt="Screenshot_20260314-005458" src="https://github.com/user-attachments/assets/c55556cf-e544-4e26-9953-e86c2df4e149" />


## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [ ] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [ ] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions
<!--
Describe how reviewers can test your changes.
Example:
1. `git fetch origin pull/<PR_ID>/head:branchname && git checkout branchname`
2. Install deps: `npm|pnpm|yarn|bun install`
3. Start service/app: `npm|pnpm|yarn|bun run [target]` (e.g., `npm run ios` or `bun run android:tv`)
4. Run tests: `npm|pnpm|yarn|bun test`
5. Verification steps:
   - [ ] Expected UI/endpoint behavior
   - [ ] Logs show no errors
   - [ ] Edge cases covered (list)
-->
1. Queue 3+ items for download simultaneously
2. Observe that all items complete successfully without interruption
3. Verify that cancelling a single item does not affect the remaining queue

### Edge cases covered:
- [ ] Single item download still stops the service correctly when done
- [ ] Failed download does not block remaining items in the queue
- [ ] Cancelling mid-queue leaves the service running for remaining items

## ⚙️ Deployment Notes
<!--
Describe any deployment considerations such as config, environment vars, or native builds.
-->

## 📝 Additional Notes
<!--
Any other information or references related to this PR.
-->