### PR TITLE
fix(navigation): prevent duplicate screen pushes on rapid taps

### DIFF
--- a/hooks/useAppRouter.ts
+++ b/hooks/useAppRouter.ts
@@ -1,6 +1,8 @@
 import { useRouter } from "expo-router";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useOfflineMode } from "@/providers/OfflineModeProvider";
+
+const NAVIGATION_DEBOUNCE_MS = 500;
 
 /**
  * Drop-in replacement for expo-router's useRouter that automatically
@@ -18,9 +20,16 @@ import { useOfflineMode } from "@/providers/OfflineModeProvider";
 export function useAppRouter() {
   const router = useRouter();
   const isOffline = useOfflineMode();
+  const isNavigatingRef = useRef(false);
 
   const push = useCallback(
     (href: Parameters<typeof router.push>[0]) => {
+      if (isNavigatingRef.current) return;
+      isNavigatingRef.current = true;
+      setTimeout(() => {
+        isNavigatingRef.current = false;
+      }, NAVIGATION_DEBOUNCE_MS);
+
       if (typeof href === "string") {
         router.push(href as any);
       } else {

--- a/hooks/useAppRouter.ts
+++ b/hooks/useAppRouter.ts
@@ -2,7 +2,7 @@ import { useRouter } from "expo-router";
 import { useCallback, useMemo, useRef } from "react";
 import { useOfflineMode } from "@/providers/OfflineModeProvider";
 
-const NAVIGATION_DEBOUNCE_MS = 500;
+const NAVIGATION_DEBOUNCE_MS = 300;
 
 /**
  * Drop-in replacement for expo-router's useRouter that automatically


### PR DESCRIPTION
<!--
  Pull Request Template for Streamyfin
  ====================================
  Use this template to help reviewers understand the purpose of your PR
  and to ensure all necessary checks are completed before merging.
-->

# 📦 Pull Request

## 🔖 Summary
<!--
A concise description of the changes introduced by this PR.
Example:
“Add real-time currency conversion widget to dashboard.”
-->
Prevent duplicate screens from being pushed when the user taps a navigation 
element multiple times rapidly, particularly on slow devices.

## 🏷️ Ticket / Issue
<!--
Link to the related ticket, issue or user story.
You can also indicate if this PR supersedes a previous one.
Example:
- Closes #123
- Fixes STREAMYFIN-456
- Resolves #789
- Supersedes #120
- Related: #130
-->

## 🛠️ What’s Changed
- Type: fix |
- Scope: navigation
- Short summary: `useAppRouter`: add a 300ms debounce guard on `push` to silently discard 
  duplicate calls within the same navigation action. `replace` is intentionally 
  excluded as replacing the current screen is always a deliberate action.


## 📋 Details
<!--
Provide more context or background. Explain any non-obvious decisions.
Include screenshots or GIFs for UI changes if applicable.
-->
On slow Android devices, tapping a navigation element quickly could trigger 
multiple `push` calls before the first screen had finished rendering, resulting 
in duplicate screens on the navigation stack.

The fix adds a `isNavigatingRef` flag that blocks any additional `push` calls 
for 500ms after the first one. This window is long enough to cover rendering 
time on low-end hardware, but short enough to be imperceptible as a limitation 
to the user.

`replace` does not need the guard — replacing the current screen is always 
intentional and semantically different from pushing a new one.

### ⚠️ Breaking Changes
<!-- List any breaking API/contract changes and migration guidance. If none, write “None”. -->

### 🔐 Security & Privacy Impact
<!-- Data touched, new permissions/scopes, PII, secrets, threat considerations. If none, write “None”. -->

### ⚡ Performance Impact
<!-- Hot paths, memory/CPU/latency implications, benchmarks if available. -->

### 🖼️ Screenshots / GIFs (if UI)
<!-- Before/After, dark mode, responsive states. -->
Before:

https://github.com/user-attachments/assets/bb0b27bf-b974-4679-920e-522290cf5fa0


After:

https://github.com/user-attachments/assets/48956f08-d9d1-412b-8b58-bd91a17a9f70


## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [ ] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [ ] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions
<!--
Describe how reviewers can test your changes.
Example:
1. `git fetch origin pull/<PR_ID>/head:branchname && git checkout branchname`
2. Install deps: `npm|pnpm|yarn|bun install`
3. Start service/app: `npm|pnpm|yarn|bun run [target]` (e.g., `npm run ios` or `bun run android:tv`)
4. Run tests: `npm|pnpm|yarn|bun test`
5. Verification steps:
   - [ ] Expected UI/endpoint behavior
   - [ ] Logs show no errors
   - [ ] Edge cases covered (list)
-->
1. Tap the same item multiple times rapidly
2. Verify only one screen is pushed, no duplicates on the stack
3. Verify that `replace`-based navigation (e.g. player screen changes) 
   still works normally

## ⚙️ Deployment Notes
<!--
Describe any deployment considerations such as config, environment vars, or native builds.
-->

## 📝 Additional Notes
<!--
Any other information or references related to this PR.
-->
300ms was chosen as the debounce window, long enough to cover slow device 
rendering, short enough to be unnoticeable. Can be adjusted via the 
`NAVIGATION_DEBOUNCE_MS` constant in `hooks/useAppRouter.ts`.