### PR TITLE
fix(player): restore offline playback resume progress

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -381,24 +381,6 @@ export default function page() {
     revalidateProgressCache,
   ]);
 
-  const stop = useCallback(() => {
-    // Update URL with final playback position before stopping
-    router.setParams({
-      playbackPosition: msToTicks(progress.get()).toString(),
-    });
-    reportPlaybackStopped();
-    setIsPlaybackStopped(true);
-    videoRef.current?.pause();
-    revalidateProgressCache();
-  }, [videoRef, reportPlaybackStopped, progress]);
-
-  useEffect(() => {
-    const beforeRemoveListener = navigation.addListener("beforeRemove", stop);
-    return () => {
-      beforeRemoveListener();
-    };
-  }, [navigation, stop]);
-
   const currentPlayStateInfo = useCallback(():
     | PlaybackProgressInfo
     | undefined => {
@@ -428,6 +410,46 @@ export default function page() {
     isPlaying,
     isMuted,
   ]);
+
+  const persistOfflinePlaybackProgress = useCallback(() => {
+    if (!offline || !item?.Id) return;
+
+    const progressInfo: PlaybackProgressInfo = currentPlayStateInfo() ?? {
+      ItemId: item.Id,
+      PositionTicks: msToTicks(progress.get()),
+      IsPaused: true,
+      CanSeek: true,
+      RepeatMode: RepeatMode.RepeatNone,
+      PlaybackOrder: PlaybackOrder.Default,
+    };
+
+    void playbackManager.reportPlaybackProgress(progressInfo);
+  }, [offline, item?.Id, currentPlayStateInfo, progress, playbackManager]);
+
+  const stop = useCallback(() => {
+    persistOfflinePlaybackProgress();
+    // Update URL with final playback position before stopping
+    router.setParams({
+      playbackPosition: msToTicks(progress.get()).toString(),
+    });
+    reportPlaybackStopped();
+    setIsPlaybackStopped(true);
+    videoRef.current?.pause();
+    revalidateProgressCache();
+  }, [
+    videoRef,
+    reportPlaybackStopped,
+    persistOfflinePlaybackProgress,
+    progress,
+    revalidateProgressCache,
+  ]);
+
+  useEffect(() => {
+    const beforeRemoveListener = navigation.addListener("beforeRemove", stop);
+    return () => {
+      beforeRemoveListener();
+    };
+  }, [navigation, stop]);
 
   const lastUrlUpdateTime = useSharedValue(0);
   const wasJustSeeking = useSharedValue(false);

--- a/components/PlayButton.tsx
+++ b/components/PlayButton.tsx
@@ -299,14 +299,15 @@ export const PlayButton: React.FC<Props> = ({
 
     // Check if item is downloaded
     const downloadedItem = item.Id ? getDownloadedItemById(item.Id) : undefined;
+    const downloadedPlaybackPosition =
+      downloadedItem?.item.UserData?.PlaybackPositionTicks?.toString() ?? "0";
 
     // If already in offline mode, play downloaded file directly
     if (isOffline && downloadedItem) {
       const queryParams = new URLSearchParams({
         itemId: item.Id!,
         offline: "true",
-        playbackPosition:
-          item.UserData?.PlaybackPositionTicks?.toString() ?? "0",
+        playbackPosition: downloadedPlaybackPosition,
       });
       goToPlayer(queryParams.toString());
       return;
@@ -334,8 +335,7 @@ export const PlayButton: React.FC<Props> = ({
                     const queryParams = new URLSearchParams({
                       itemId: item.Id!,
                       offline: "true",
-                      playbackPosition:
-                        item.UserData?.PlaybackPositionTicks?.toString() ?? "0",
+                      playbackPosition: downloadedPlaybackPosition,
                     });
                     goToPlayer(queryParams.toString());
                   }}
@@ -377,8 +377,7 @@ export const PlayButton: React.FC<Props> = ({
                 const queryParams = new URLSearchParams({
                   itemId: item.Id!,
                   offline: "true",
-                  playbackPosition:
-                    item.UserData?.PlaybackPositionTicks?.toString() ?? "0",
+                  playbackPosition: downloadedPlaybackPosition,
                 });
                 goToPlayer(queryParams.toString());
               },

--- a/hooks/usePlaybackManager.ts
+++ b/hooks/usePlaybackManager.ts
@@ -5,7 +5,7 @@ import type {
 import { getPlaystateApi, getTvShowsApi } from "@jellyfin/sdk/lib/utils/api";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useDownload } from "@/providers/DownloadProvider";
 import { DownloadedItem } from "@/providers/Downloads/types";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
@@ -134,6 +134,20 @@ export const usePlaybackManager = ({
     return adjacentItems[2];
   }, [adjacentItems, item]);
 
+  const invalidateLocalPlaybackQueries = useCallback(
+    (itemId: string, seriesId?: string) => {
+      queryClient.invalidateQueries({ queryKey: ["item", itemId] });
+      queryClient.invalidateQueries({ queryKey: ["episodes"] });
+      queryClient.invalidateQueries({ queryKey: ["AllEpisodes"] });
+      queryClient.invalidateQueries({ queryKey: ["adjacentItems"] });
+
+      if (seriesId) {
+        queryClient.invalidateQueries({ queryKey: ["series", seriesId] });
+      }
+    },
+    [queryClient],
+  );
+
   /**
    * Reports playback progress.
    *
@@ -187,9 +201,10 @@ export const usePlaybackManager = ({
           },
         },
       });
-      // Force invalidate queries so they refetch from updated local database
-      queryClient.invalidateQueries({ queryKey: ["item", itemId] });
-      queryClient.invalidateQueries({ queryKey: ["episodes"] });
+      invalidateLocalPlaybackQueries(
+        itemId,
+        localItem.item.SeriesId ?? undefined,
+      );
     }
 
     // Handle remote state update if online
@@ -230,9 +245,10 @@ export const usePlaybackManager = ({
           },
         },
       });
-      // Force invalidate queries so they refetch from updated local database
-      queryClient.invalidateQueries({ queryKey: ["item", itemId] });
-      queryClient.invalidateQueries({ queryKey: ["episodes"] });
+      invalidateLocalPlaybackQueries(
+        itemId,
+        localItem.item.SeriesId ?? undefined,
+      );
     }
 
     // Handle remote state update if online
@@ -275,9 +291,10 @@ export const usePlaybackManager = ({
           },
         },
       });
-      // Force invalidate queries so they refetch from updated local database
-      queryClient.invalidateQueries({ queryKey: ["item", itemId] });
-      queryClient.invalidateQueries({ queryKey: ["episodes"] });
+      invalidateLocalPlaybackQueries(
+        itemId,
+        localItem.item.SeriesId ?? undefined,
+      );
     }
 
     // Handle remote state update if online


### PR DESCRIPTION
## Summary

This fixes offline playback resume progress not being restored reliably after closing and reopening playback.

I hit this on a flight, while using the app the way it is meant to be used, with downloaded media in airplane mode. It was a real annoyance, and enough of a bummer that I dug in and fixed it.

## What changed

- use the downloaded item's local `PlaybackPositionTicks` when launching offline playback
- persist offline playback progress one final time when stopping playback
- invalidate local item, episode, adjacent, and series queries after local playback updates so resume state refreshes correctly

## Testing

- verified manually on a real Pixel 10 device
- tested with real downloaded media playback in airplane mode
- confirmed downloaded media now resumes from the saved position after pausing, closing the app, and reopening it
- ran:

```bash
./node_modules/.bin/biome check hooks/usePlaybackManager.ts components/PlayButton.tsx 'app/(auth)/player/direct-player.tsx'
```

## Notes

Full repo `typecheck` was not used as signoff because the repo currently has unrelated pre-existing Jellyseerr type errors outside this change set.

## AI Assistance Disclosure

This PR was prepared with AI assistance. I reviewed the code changes and tested the fix manually on-device.
