### PR TITLE
feat(network): add Wake-on-LAN support

### DIFF
--- a/app/(auth)/(tabs)/(home)/settings/network/page.tsx
+++ b/app/(auth)/(tabs)/(home)/settings/network/page.tsx
@@ -5,6 +5,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ListGroup } from "@/components/list/ListGroup";
 import { ListItem } from "@/components/list/ListItem";
 import { LocalNetworkSettings } from "@/components/settings/LocalNetworkSettings";
+import { WakeOnLanSettings } from "@/components/settings/WakeOnLanSettings";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { storage } from "@/utils/mmkv";
 
@@ -41,6 +42,10 @@ export default function NetworkSettingsPage() {
 
         <View className='mt-4'>
           <LocalNetworkSettings />
+        </View>
+
+        <View className='mt-4'>
+          <WakeOnLanSettings />
         </View>
       </View>
     </ScrollView>

--- a/components/settings/WakeOnLanSettings.tsx
+++ b/components/settings/WakeOnLanSettings.tsx
@@ -1,0 +1,137 @@
+import type React from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Switch, View } from "react-native";
+import { toast } from "sonner-native";
+import { storage } from "@/utils/mmkv";
+import {
+  getServerWolConfig,
+  updateServerWolConfig,
+  type WakeOnLanConfig,
+} from "@/utils/secureCredentials";
+import { sendWolPacket, validateMacAddress } from "@/utils/wol";
+import { Button } from "../Button";
+import { Input } from "../common/Input";
+import { Text } from "../common/Text";
+import { ListGroup } from "../list/ListGroup";
+import { ListItem } from "../list/ListItem";
+
+const DEFAULT_CONFIG: WakeOnLanConfig = {
+  enabled: false,
+  macAddress: "",
+};
+
+export function WakeOnLanSettings(): React.ReactElement | null {
+  const { t } = useTranslation();
+
+  const remoteUrl = storage.getString("serverUrl");
+  const [config, setConfig] = useState<WakeOnLanConfig>(DEFAULT_CONFIG);
+  const [isSending, setIsSending] = useState(false);
+
+  useEffect(() => {
+    if (remoteUrl) {
+      const existingConfig = getServerWolConfig(remoteUrl);
+      if (existingConfig) {
+        setConfig(existingConfig);
+      }
+    }
+  }, [remoteUrl]);
+
+  const saveConfig = useCallback(
+    (newConfig: WakeOnLanConfig) => {
+      if (!remoteUrl) return;
+      setConfig(newConfig);
+      updateServerWolConfig(remoteUrl, newConfig);
+    },
+    [remoteUrl],
+  );
+
+  const handleToggleEnabled = useCallback(
+    (enabled: boolean) => {
+      saveConfig({ ...config, enabled });
+    },
+    [config, saveConfig],
+  );
+
+  const handleMacAddressChange = useCallback(
+    (macAddress: string) => {
+      saveConfig({ ...config, macAddress });
+    },
+    [config, saveConfig],
+  );
+
+  const handleTestPacket = useCallback(async () => {
+    if (!validateMacAddress(config.macAddress)) {
+      toast.error(t("home.settings.network.wake_on_lan.mac_address_invalid"));
+      return;
+    }
+
+    setIsSending(true);
+    try {
+      await sendWolPacket(config.macAddress);
+      toast.success(t("home.settings.network.wake_on_lan.test_success"));
+    } catch {
+      toast.error(t("home.settings.network.wake_on_lan.test_error"));
+    } finally {
+      setIsSending(false);
+    }
+  }, [config.macAddress, t]);
+
+  if (!remoteUrl) return null;
+
+  const macIsValid =
+    config.macAddress.length === 0 || validateMacAddress(config.macAddress);
+
+  return (
+    <View>
+      <ListGroup title={t("home.settings.network.wake_on_lan.title")}>
+        <ListItem
+          title={t("home.settings.network.wake_on_lan.enable")}
+          subtitle={t("home.settings.network.wake_on_lan.enable_description")}
+        >
+          <Switch value={config.enabled} onValueChange={handleToggleEnabled} />
+        </ListItem>
+      </ListGroup>
+
+      {config.enabled && (
+        <View className='pt-4'>
+          <ListGroup
+            title={t("home.settings.network.wake_on_lan.mac_address")}
+            description={
+              <Text className='text-[#8E8D91] text-xs'>
+                {t("home.settings.network.wake_on_lan.mac_address_hint")}
+              </Text>
+            }
+          >
+            <View>
+              <Input
+                placeholder={t(
+                  "home.settings.network.wake_on_lan.mac_address_placeholder",
+                )}
+                value={config.macAddress}
+                onChangeText={handleMacAddressChange}
+                autoCapitalize='characters'
+                autoCorrect={false}
+              />
+            </View>
+          </ListGroup>
+
+          {!macIsValid && (
+            <Text className='text-xs text-red-500 px-4 pt-1'>
+              {t("home.settings.network.wake_on_lan.mac_address_invalid")}
+            </Text>
+          )}
+
+          <View className='py-2'>
+            <Button
+              onPress={handleTestPacket}
+              disabled={!validateMacAddress(config.macAddress) || isSending}
+            >
+              {t("home.settings.network.wake_on_lan.test_packet")}
+            </Button>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -38,6 +38,7 @@ import {
   updateAccountToken,
 } from "@/utils/secureCredentials";
 import { store } from "@/utils/store";
+import { wakeServerIfNeeded } from "@/utils/wol";
 
 interface Server {
   address: string;
@@ -204,6 +205,10 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (nextAppState) => {
       if (nextAppState === "active") {
+        const serverUrl = getServerUrlFromStorage();
+        if (serverUrl) {
+          wakeServerIfNeeded(serverUrl);
+        }
         refreshStreamyfinPluginSettings();
       }
     });
@@ -500,6 +505,11 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         const token = getTokenFromStorage();
         const serverUrl = getServerUrlFromStorage();
         const storedUser = getUserFromStorage();
+
+        // Send Wake-on-LAN packet if configured for this server
+        if (serverUrl) {
+          await wakeServerIfNeeded(serverUrl);
+        }
 
         if (serverUrl && token) {
           const apiInstance = jellyfin.createApi(serverUrl, token);

--- a/translations/en.json
+++ b/translations/en.json
@@ -149,7 +149,19 @@
         "network_already_added": "Network already added",
         "no_wifi_connected": "Not connected to WiFi",
         "permission_denied": "Location permission denied",
-        "permission_denied_explanation": "Location permission is required to detect WiFi network for auto-switching. Please enable it in Settings."
+        "permission_denied_explanation": "Location permission is required to detect WiFi network for auto-switching. Please enable it in Settings.",
+        "wake_on_lan": {
+          "title": "Wake on LAN",
+          "enable": "Wake server on startup",
+          "enable_description": "Send a magic packet to wake your server when the app starts or resumes",
+          "mac_address": "Server MAC Address",
+          "mac_address_placeholder": "AA:BB:CC:DD:EE:FF",
+          "mac_address_hint": "Enter the MAC address of your Jellyfin server's network interface",
+          "mac_address_invalid": "Invalid MAC address format",
+          "test_packet": "Send Test Packet",
+          "test_success": "Magic packet sent",
+          "test_error": "Failed to send magic packet"
+        }
       },
       "user_info": {
         "user_info_title": "User Info",

--- a/utils/secureCredentials.ts
+++ b/utils/secureCredentials.ts
@@ -44,6 +44,14 @@ export interface LocalNetworkConfig {
 }
 
 /**
+ * Wake-on-LAN configuration for waking a server before connecting.
+ */
+export interface WakeOnLanConfig {
+  enabled: boolean;
+  macAddress: string; // Format: "AA:BB:CC:DD:EE:FF"
+}
+
+/**
  * Server with multiple saved accounts.
  */
 export interface SavedServer {
@@ -51,6 +59,7 @@ export interface SavedServer {
   name?: string;
   accounts: SavedServerAccount[];
   localNetworkConfig?: LocalNetworkConfig;
+  wolConfig?: WakeOnLanConfig;
 }
 
 /**
@@ -384,6 +393,37 @@ export function getServerLocalConfig(
   const servers = getPreviousServers();
   const server = servers.find((s) => s.address === serverUrl);
   return server?.localNetworkConfig;
+}
+
+/**
+ * Update Wake-on-LAN configuration for a server.
+ */
+export function updateServerWolConfig(
+  serverUrl: string,
+  config: WakeOnLanConfig | undefined,
+): void {
+  const servers = getPreviousServers();
+  const updatedServers = servers.map((server) => {
+    if (server.address === serverUrl) {
+      return {
+        ...server,
+        wolConfig: config,
+      };
+    }
+    return server;
+  });
+  storage.set("previousServers", JSON.stringify(updatedServers));
+}
+
+/**
+ * Get Wake-on-LAN configuration for a server.
+ */
+export function getServerWolConfig(
+  serverUrl: string,
+): WakeOnLanConfig | undefined {
+  const servers = getPreviousServers();
+  const server = servers.find((s) => s.address === serverUrl);
+  return server?.wolConfig;
 }
 
 /**

--- a/utils/wol.ts
+++ b/utils/wol.ts
@@ -1,0 +1,130 @@
+import dgram from "react-native-udp";
+import { getSSIDSync } from "@/modules/wifi-ssid";
+import { writeErrorLog, writeInfoLog } from "@/utils/log";
+import {
+  getServerLocalConfig,
+  getServerWolConfig,
+} from "@/utils/secureCredentials";
+
+const WOL_PORT = 9;
+const WOL_BROADCAST = "255.255.255.255";
+const MAC_REGEX = /^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$/;
+
+/**
+ * Validate a MAC address string (e.g., "AA:BB:CC:DD:EE:FF").
+ */
+export function validateMacAddress(mac: string): boolean {
+  return MAC_REGEX.test(mac.trim());
+}
+
+/**
+ * Build a Wake-on-LAN magic packet for the given MAC address.
+ * Format: 6 bytes of 0xFF followed by the MAC address repeated 16 times (102 bytes total).
+ */
+export function buildMagicPacket(macAddress: string): Uint8Array {
+  const macBytes = macAddress
+    .trim()
+    .split(/[:-]/)
+    .map((hex) => Number.parseInt(hex, 16));
+
+  const packet = new Uint8Array(102);
+
+  // 6 bytes of 0xFF
+  for (let i = 0; i < 6; i++) {
+    packet[i] = 0xff;
+  }
+
+  // MAC address repeated 16 times
+  for (let i = 0; i < 16; i++) {
+    for (let j = 0; j < 6; j++) {
+      packet[6 + i * 6 + j] = macBytes[j];
+    }
+  }
+
+  return packet;
+}
+
+/**
+ * Send a Wake-on-LAN magic packet via UDP broadcast.
+ */
+export function sendWolPacket(macAddress: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const packet = buildMagicPacket(macAddress);
+
+    const socket = dgram.createSocket({
+      type: "udp4",
+      reusePort: true,
+    });
+
+    socket.on("error", (err) => {
+      socket.close();
+      reject(err);
+    });
+
+    socket.bind(0, () => {
+      socket.setBroadcast(true);
+      socket.send(packet, 0, packet.length, WOL_PORT, WOL_BROADCAST, (err) => {
+        socket.close();
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+}
+
+/**
+ * Check if the device is on a configured home WiFi network for the given server.
+ * Returns true if:
+ * - No local network config exists (no WiFi restriction configured)
+ * - No home WiFi SSIDs are configured
+ * - SSID detection is unavailable (Android)
+ * - Current SSID matches a configured home WiFi network
+ */
+function isOnHomeNetwork(serverUrl: string): boolean {
+  const localConfig = getServerLocalConfig(serverUrl);
+
+  // No local network config or no SSIDs configured — don't restrict WoL
+  if (!localConfig?.homeWifiSSIDs?.length) {
+    return true;
+  }
+
+  const currentSSID = getSSIDSync();
+
+  // SSID detection unavailable (Android) — don't restrict WoL
+  if (currentSSID === null) {
+    return true;
+  }
+
+  return localConfig.homeWifiSSIDs.includes(currentSSID);
+}
+
+/**
+ * Send a Wake-on-LAN packet if configured and on the home network.
+ * Failures are logged but never block app startup.
+ */
+export async function wakeServerIfNeeded(serverUrl: string): Promise<void> {
+  try {
+    const config = getServerWolConfig(serverUrl);
+
+    if (!config?.enabled || !validateMacAddress(config.macAddress)) {
+      return;
+    }
+
+    if (!isOnHomeNetwork(serverUrl)) {
+      return;
+    }
+
+    writeInfoLog(`[WakeOnLan] Sending magic packet to ${config.macAddress}`);
+
+    await sendWolPacket(config.macAddress);
+
+    writeInfoLog("[WakeOnLan] Magic packet sent successfully");
+  } catch (e) {
+    writeErrorLog(
+      `[WakeOnLan] Failed to send magic packet: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary

Add Wake-on-LAN (WoL) support to wake a sleeping Jellyfin server automatically when the app starts or resumes from background.

## 🏷️ Ticket / Issue

Closes #1538

## 🛠️ What's Changed

- Type: feat
- Scope: network
- Sends a WoL magic packet (UDP broadcast, port 9) before connecting to the server on app startup and foreground resume
- Per-server WoL configuration stored alongside existing local network config
- Settings UI under Network settings: toggle, MAC address input, and test button
- Only fires when on a configured home WiFi network (when SSID detection is available); on Android where SSID detection is unavailable, fires whenever enabled
- Failures are logged but never block app startup

## 📋 Details

Reuses the existing `react-native-udp` dependency (already used by `useJellyfinDiscovery`) for UDP broadcast. WoL config follows the same per-server storage pattern as `LocalNetworkConfig` in `secureCredentials.ts`.

No artificial delay is needed after sending the magic packet — the existing connection flow has no configured timeout, giving the server time to wake up naturally.

### ⚠️ Breaking Changes
None

### 🔐 Security & Privacy Impact
None. WoL packets are standard UDP broadcasts on the local network. No new permissions required.

### ⚡ Performance Impact
Negligible. One UDP packet sent on startup/resume when enabled. No-op when disabled.

### 🖼️ Screenshots

<img width="1080" height="2424" alt="screenshot_20260413_210858" src="https://github.com/user-attachments/assets/775a76a4-2748-4f49-8f43-d38ed3dc71ab" />

<img width="1080" height="2424" alt="screenshot_20260413_211420" src="https://github.com/user-attachments/assets/e713c140-b3f6-452b-82eb-9a7cf86b50b0" />



## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`bun run lint`, `bun run format`)
- [x] Type checks pass (`bun run typecheck`)
- [x] No secrets/credentials included
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions

- [x] Enabled WoL in Settings → Network → Wake on LAN, entered server MAC address
- [x] Tapped "Send Test Packet" — success toast shown
- [x] Verified magic packet received on server via `tcpdump` — correct format (6x 0xFF + 16x MAC, UDP port 9)
- [x] Put server to sleep, killed app, reopened — server woke up successfully
- [x] Put server to sleep, backgrounded app, brought to foreground — server woke up successfully
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## ⚙️ Deployment Notes
None. No new dependencies.

## 📝 AI Disclosure

This PR was developed with assistance from Claude Code (Anthropic). The implementation approach, code structure, and all code were reviewed and tested manually by the author.
