### PR TITLE
fix(player/ios): Disable subtitles embedding for iOS simulator

### DIFF
--- a/modules/mpv-player/ios/MPVLayerRenderer.swift
+++ b/modules/mpv-player/ios/MPVLayerRenderer.swift
@@ -171,7 +171,11 @@ final class MPVLayerRenderer {
         // Enable composite OSD mode - renders subtitles directly onto video frames using GPU
         // This is better for PiP as subtitles are baked into the video
         // NOTE: Must be set BEFORE the #if targetEnvironment check or tvOS will freeze on player exit
+        #if targetEnvironment(simulator)
+        checkError(mpv_set_option_string(handle, "avfoundation-composite-osd", "no"))
+        #else
         checkError(mpv_set_option_string(handle, "avfoundation-composite-osd", "yes"))
+        #endif
 
         // Hardware decoding with VideoToolbox
         // On simulator, use software decoding since VideoToolbox is not available


### PR DESCRIPTION
<!--
  Pull Request Template for Streamyfin
  ====================================
  Use this template to help reviewers understand the purpose of your PR
  and to ensure all necessary checks are completed before merging.
-->

# 📦 Pull Request

## 🔖 Summary
<!--
A concise description of the changes introduced by this PR.
Example:
“Add real-time currency conversion widget to dashboard.”
-->
On the iOS simulator, there's no support for embedding the subtitles. PiP doesn't work with the subtitles on the simulator, but it should on a real device. This PR fixes a continuous `CoreImage` error spam and restores working subtitles when running the app on the iOS Simulator. It accomplishes this by conditionally disabling the `avfoundation-composite-osd` option only for the simulator environment.

## 🏷️ Ticket / Issue
<!--
Link to the related ticket, issue or user story.
You can also indicate if this PR supersedes a previous one.
Example:
- Closes #123
- Fixes STREAMYFIN-456
- Resolves #789
- Supersedes #120
- Related: #130
-->

## 🛠️ What’s Changed
<!-- Use a Conventional Commit in the PR title, e.g., `feat(auth): add MFA`. 
If this PR introduces a breaking change, include a `BREAKING CHANGE:` block in the description.
Spec: https://www.conventionalcommits.org/ -->

- Type: fix
- Scope (optional): mpv-player (ios)
- Short summary: Conditionally disable `avfoundation-composite-osd` on the Simulator to prevent `CoreImage` failures with software-decoded y420 frames.

## 📋 Details
<!--
Provide more context or background. Explain any non-obvious decisions.
Include screenshots or GIFs for UI changes if applicable.
-->
_Details made by Gemini_
The avfoundation-composite-osd option uses CoreImage to bake subtitles directly into video frames (required for Picture-in-Picture subtitle support).

On the iOS Simulator, hardware decoding is unavailable, so mpv falls back to software decoding, which outputs frames in the y420 (planar YUV) format. CoreImage does not support y420 pixel buffers, which caused subtitle rendering to fail and spammed the console with errors.

By wrapping this setting in #if targetEnvironment(simulator), we allow the Simulator to use standard CoreAnimation subtitle layers while preserving the high-quality PiP subtitle feature for real devices (which use hardware decoding and compatible pixel formats).

### ⚠️ Breaking Changes
<!-- List any breaking API/contract changes and migration guidance. If none, write “None”. -->

### 🔐 Security & Privacy Impact
<!-- Data touched, new permissions/scopes, PII, secrets, threat considerations. If none, write “None”. -->

### ⚡ Performance Impact
<!-- Hot paths, memory/CPU/latency implications, benchmarks if available. -->

### 🖼️ Screenshots / GIFs (if UI)
<!-- Before/After, dark mode, responsive states. -->

### 🤖 AI disclosure
AI was fully used to find the bug and fix it (thanks gemini-cli). It was then tested on the iOS simulator.

## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [x] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [x] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions
<!--
Describe how reviewers can test your changes.
Example:
1. `git fetch origin pull/<PR_ID>/head:branchname && git checkout branchname`
2. Install deps: `npm|pnpm|yarn|bun install`
3. Start service/app: `npm|pnpm|yarn|bun run [target]` (e.g., `npm run ios` or `bun run android:tv`)
4. Run tests: `npm|pnpm|yarn|bun test`
5. Verification steps:
   - [ ] Expected UI/endpoint behavior
   - [ ] Logs show no errors
   - [ ] Edge cases covered (list)
-->
1. Run the app on an iOS Simulator: bun run ios
2. Play any video file that has subtitles (internal or external).
3. Subtitles should now render correctly on the screen.
4. The console should no longer be spammed with `[CoreImage] blah blah format y420 is not supported` errors.

## ⚙️ Deployment Notes
<!--
Describe any deployment considerations such as config, environment vars, or native builds.
-->

## 📝 Additional Notes
<!--
Any other information or references related to this PR.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved subtitle rendering behavior inconsistencies on iOS simulators to align with device behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->