### PR TITLE
fix: tv overlay focus navigation

### DIFF
--- a/components/tv/TVNextEpisodeCountdown.tsx
+++ b/components/tv/TVNextEpisodeCountdown.tsx
@@ -40,7 +40,7 @@ export interface TVNextEpisodeCountdownProps {
   /** Whether this component should receive initial focus */
   hasTVPreferredFocus?: boolean;
   /** Destination used when moving down from this card */
-  downDestination?: RNView | null;
+  playButtonRef?: RNView | null;
 }
 
 // Position constants
@@ -57,7 +57,7 @@ export const TVNextEpisodeCountdown: FC<TVNextEpisodeCountdownProps> = ({
   controlsVisible = false,
   refSetter,
   hasTVPreferredFocus = true,
-  downDestination,
+  playButtonRef: downDestination,
 }) => {
   const typography = useScaledTVTypography();
   const { t } = useTranslation();

--- a/components/tv/TVNextEpisodeCountdown.tsx
+++ b/components/tv/TVNextEpisodeCountdown.tsx
@@ -7,7 +7,9 @@ import {
   Image,
   Pressable,
   Animated as RNAnimated,
+  type View as RNView,
   StyleSheet,
+  TVFocusGuideView,
   View,
 } from "react-native";
 import Animated, {
@@ -33,6 +35,12 @@ export interface TVNextEpisodeCountdownProps {
   onPlayNext?: () => void;
   /** Whether controls are visible - affects card position */
   controlsVisible?: boolean;
+  /** Callback ref setter for focus guide destination pattern */
+  refSetter?: (ref: RNView | null) => void;
+  /** Whether this component should receive initial focus */
+  hasTVPreferredFocus?: boolean;
+  /** Destination used when moving down from this card */
+  downDestination?: RNView | null;
 }
 
 // Position constants
@@ -47,6 +55,9 @@ export const TVNextEpisodeCountdown: FC<TVNextEpisodeCountdownProps> = ({
   onFinish,
   onPlayNext,
   controlsVisible = false,
+  refSetter,
+  hasTVPreferredFocus = true,
+  downDestination,
 }) => {
   const typography = useScaledTVTypography();
   const { t } = useTranslation();
@@ -135,10 +146,11 @@ export const TVNextEpisodeCountdown: FC<TVNextEpisodeCountdownProps> = ({
       pointerEvents='box-none'
     >
       <Pressable
+        ref={refSetter}
         onPress={onPlayNext}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        hasTVPreferredFocus={true}
+        hasTVPreferredFocus={hasTVPreferredFocus}
         focusable={true}
       >
         <RNAnimated.View style={[animatedStyle, focused && styles.focusedCard]}>
@@ -172,6 +184,12 @@ export const TVNextEpisodeCountdown: FC<TVNextEpisodeCountdownProps> = ({
           </BlurView>
         </RNAnimated.View>
       </Pressable>
+      {downDestination && (
+        <TVFocusGuideView
+          destinations={[downDestination]}
+          style={styles.returnFocusGuide}
+        />
+      )}
     </Animated.View>
   );
 };
@@ -234,5 +252,9 @@ const createStyles = (typography: ReturnType<typeof useScaledTVTypography>) =>
       height: "100%",
       backgroundColor: "#fff",
       borderRadius: 2,
+    },
+    returnFocusGuide: {
+      height: 1,
+      width: "100%",
     },
   });

--- a/components/tv/TVSkipSegmentCard.tsx
+++ b/components/tv/TVSkipSegmentCard.tsx
@@ -2,7 +2,13 @@ import { Ionicons } from "@expo/vector-icons";
 import type { FC } from "react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Pressable, Animated as RNAnimated, StyleSheet } from "react-native";
+import {
+  Pressable,
+  Animated as RNAnimated,
+  StyleSheet,
+  TVFocusGuideView,
+  type View,
+} from "react-native";
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -18,6 +24,12 @@ export interface TVSkipSegmentCardProps {
   type: "intro" | "credits";
   /** Whether controls are visible - affects card position */
   controlsVisible?: boolean;
+  /** Callback ref setter for focus guide destination pattern */
+  refSetter?: (ref: View | null) => void;
+  /** Whether this component should receive initial focus */
+  hasTVPreferredFocus?: boolean;
+  /** Destination used when moving down from this card */
+  downDestination?: View | null;
 }
 
 // Position constants - same as TVNextEpisodeCountdown (they're mutually exclusive)
@@ -29,6 +41,9 @@ export const TVSkipSegmentCard: FC<TVSkipSegmentCardProps> = ({
   onPress,
   type,
   controlsVisible = false,
+  refSetter,
+  hasTVPreferredFocus = true,
+  downDestination,
 }) => {
   const { t } = useTranslation();
   const { focused, handleFocus, handleBlur, animatedStyle } =
@@ -67,10 +82,11 @@ export const TVSkipSegmentCard: FC<TVSkipSegmentCardProps> = ({
       pointerEvents='box-none'
     >
       <Pressable
+        ref={refSetter}
         onPress={onPress}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        hasTVPreferredFocus={true}
+        hasTVPreferredFocus={hasTVPreferredFocus}
       >
         <RNAnimated.View
           style={[
@@ -90,6 +106,12 @@ export const TVSkipSegmentCard: FC<TVSkipSegmentCardProps> = ({
           <Text style={styles.label}>{labelText}</Text>
         </RNAnimated.View>
       </Pressable>
+      {downDestination && (
+        <TVFocusGuideView
+          destinations={[downDestination]}
+          style={styles.returnFocusGuide}
+        />
+      )}
     </Animated.View>
   );
 };
@@ -113,5 +135,9 @@ const styles = StyleSheet.create({
     fontSize: 20,
     color: "#fff",
     fontWeight: "600",
+  },
+  returnFocusGuide: {
+    height: 1,
+    width: "100%",
   },
 });

--- a/components/tv/TVSkipSegmentCard.tsx
+++ b/components/tv/TVSkipSegmentCard.tsx
@@ -29,7 +29,7 @@ export interface TVSkipSegmentCardProps {
   /** Whether this component should receive initial focus */
   hasTVPreferredFocus?: boolean;
   /** Destination used when moving down from this card */
-  downDestination?: View | null;
+  playButtonRef?: View | null;
 }
 
 // Position constants - same as TVNextEpisodeCountdown (they're mutually exclusive)
@@ -43,7 +43,7 @@ export const TVSkipSegmentCard: FC<TVSkipSegmentCardProps> = ({
   controlsVisible = false,
   refSetter,
   hasTVPreferredFocus = true,
-  downDestination,
+  playButtonRef: downDestination,
 }) => {
   const { t } = useTranslation();
   const { focused, handleFocus, handleBlur, animatedStyle } =

--- a/components/video-player/controls/Controls.tv.tsx
+++ b/components/video-player/controls/Controls.tv.tsx
@@ -1046,7 +1046,7 @@ export const Controls: FC<Props> = ({
         controlsVisible={showControls}
         refSetter={setSkipSegmentRef}
         hasTVPreferredFocus={!showControls}
-        downDestination={showControls ? playButtonRef : null}
+        playButtonRef={showControls ? playButtonRef : null}
       />
 
       {/* Skip credits card - show when there's content after credits, OR no next episode */}
@@ -1061,7 +1061,7 @@ export const Controls: FC<Props> = ({
         controlsVisible={showControls}
         refSetter={setSkipSegmentRef}
         hasTVPreferredFocus={!showControls}
-        downDestination={showControls ? playButtonRef : null}
+        playButtonRef={showControls ? playButtonRef : null}
       />
 
       {nextItem && (
@@ -1075,7 +1075,7 @@ export const Controls: FC<Props> = ({
           controlsVisible={showControls}
           refSetter={setNextEpisodeRef}
           hasTVPreferredFocus={!showControls}
-          downDestination={showControls ? playButtonRef : null}
+          playButtonRef={showControls ? playButtonRef : null}
         />
       )}
 

--- a/components/video-player/controls/Controls.tv.tsx
+++ b/components/video-player/controls/Controls.tv.tsx
@@ -268,6 +268,7 @@ export const Controls: FC<Props> = ({
   const [isProgressBarFocused, setIsProgressBarFocused] = useState(false);
   const [playButtonRef, setPlayButtonRef] = useState<View | null>(null);
   const [progressBarRef, setProgressBarRef] = useState<View | null>(null);
+  const [skipSegmentRef, setSkipSegmentRef] = useState<View | null>(null);
 
   // Minimal seek bar state (shows only progress bar when seeking while controls hidden)
   const [showMinimalSeekBar, setShowMinimalSeekBar] = useState(false);
@@ -1040,6 +1041,9 @@ export const Controls: FC<Props> = ({
         onPress={skipIntro}
         type='intro'
         controlsVisible={showControls}
+        refSetter={setSkipSegmentRef}
+        hasTVPreferredFocus={!showControls}
+        downDestination={showControls ? playButtonRef : null}
       />
 
       {/* Skip credits card - show when there's content after credits, OR no next episode */}
@@ -1052,6 +1056,9 @@ export const Controls: FC<Props> = ({
         onPress={skipCredit}
         type='credits'
         controlsVisible={showControls}
+        refSetter={setSkipSegmentRef}
+        hasTVPreferredFocus={!showControls}
+        downDestination={showControls ? playButtonRef : null}
       />
 
       {nextItem && (
@@ -1209,6 +1216,14 @@ export const Controls: FC<Props> = ({
               </Text>
             )}
           </View>
+
+          {/* Upward: control buttons → visible skip segment card */}
+          {skipSegmentRef && (
+            <TVFocusGuideView
+              destinations={[skipSegmentRef]}
+              style={styles.focusGuide}
+            />
+          )}
 
           <View style={styles.controlButtonsRow}>
             <TVControlButton

--- a/components/video-player/controls/Controls.tv.tsx
+++ b/components/video-player/controls/Controls.tv.tsx
@@ -269,6 +269,7 @@ export const Controls: FC<Props> = ({
   const [playButtonRef, setPlayButtonRef] = useState<View | null>(null);
   const [progressBarRef, setProgressBarRef] = useState<View | null>(null);
   const [skipSegmentRef, setSkipSegmentRef] = useState<View | null>(null);
+  const [nextEpisodeRef, setNextEpisodeRef] = useState<View | null>(null);
 
   // Minimal seek bar state (shows only progress bar when seeking while controls hidden)
   const [showMinimalSeekBar, setShowMinimalSeekBar] = useState(false);
@@ -1015,6 +1016,8 @@ export const Controls: FC<Props> = ({
     goToNextItem({ isAutoPlay: true });
   }, [goToNextItem]);
 
+  const topOverlayFocusTarget = skipSegmentRef ?? nextEpisodeRef;
+
   return (
     <View style={styles.controlsContainer} pointerEvents='box-none'>
       <Animated.View
@@ -1070,6 +1073,9 @@ export const Controls: FC<Props> = ({
           onFinish={handleAutoPlayFinish}
           onPlayNext={handleNextItemButton}
           controlsVisible={showControls}
+          refSetter={setNextEpisodeRef}
+          hasTVPreferredFocus={!showControls}
+          downDestination={showControls ? playButtonRef : null}
         />
       )}
 
@@ -1217,10 +1223,10 @@ export const Controls: FC<Props> = ({
             )}
           </View>
 
-          {/* Upward: control buttons → visible skip segment card */}
-          {skipSegmentRef && (
+          {/* Upward: control buttons → visible skip segment or next episode card */}
+          {topOverlayFocusTarget && (
             <TVFocusGuideView
-              destinations={[skipSegmentRef]}
+              destinations={[topOverlayFocusTarget]}
               style={styles.focusGuide}
             />
           )}


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary
Improve TV focus navigation for playback overlay actions, including skip intro/credits and next episode.

## 🏷️ Ticket / Issue
None.

## 🛠️ What’s Changed
- Type: fix
- Scope: tv
- Short summary: Adds TV focus guide destinations for right-aligned playback overlay cards so they can be reached from the control row.

## 📋 Details
_Details made by Codex_
The skip segment and next episode cards are positioned above the controls on the right side of the player. On tvOS, the geometric focus engine can fail to move focus from left-side controls, such as play/pause, to those overlay actions.

This adds explicit `TVFocusGuideView` navigation from the controls to the visible overlay card. When controls are visible, moving down from the overlay returns to play/pause. The code path is shared TV UI, so Android TV also receives the behavior, but this primarily addresses the tvOS focus issue.

### ⚠️ Breaking Changes
None.

### 🔐 Security & Privacy Impact
None.

### ⚡ Performance Impact
None expected. This only adds focus refs and focus guide views around existing TV controls.

### 🖼️ Screenshots / GIFs (if UI)
Not included. Change affects TV remote focus behavior.

## ✅ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [x] Docs not required for this focus-only UI fix
- [x] No secrets/credentials included; env vars documented
- [x] Release notes/CHANGELOG entry not required
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions
1. Run the TV app on Apple TV / tvOS.
2. Start playback for media with intro or credit segments.
3. Open the playback controls.
4. Focus the play/pause button or another control-row button.
5. Press up and verify focus moves to the visible skip intro/credits button.
6. Press down and verify focus returns to play/pause.
7. Near the end of an episode, verify the same up/down behavior with the next episode card.

Validation run:
- `npm run typecheck`
- `npx biome check components/tv/TVSkipSegmentCard.tsx components/tv/TVNextEpisodeCountdown.tsx components/video-player/controls/Controls.tv.tsx`

## ⚙️ Deployment Notes
No native rebuild required. This is a JS/TS focus-navigation change in the TV player controls.

## 📝 Additional Notes
The fix uses `TVFocusGuideView` because tvOS does not reliably support direct directional focus routing for this layout.
