### PR TITLE
fix: handle TV menu and back navigation

### DIFF
--- a/app/(auth)/(tabs)/_layout.tsx
+++ b/app/(auth)/(tabs)/_layout.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from "react-i18next";
 import { Platform, View } from "react-native";
 import { SystemBars } from "react-native-edge-to-edge";
 import { Colors } from "@/constants/Colors";
-import { useTVBackHandler } from "@/hooks/useTVBackHandler";
+import { useTVHomeBackHandler } from "@/hooks/useTVBackHandler";
 import { useSettings } from "@/utils/atoms/settings";
 import { eventBus } from "@/utils/eventBus";
 
@@ -38,7 +38,7 @@ export default function TabLayout() {
   const { t } = useTranslation();
 
   // Handle TV back button - prevent app exit when at root
-  useTVBackHandler();
+  useTVHomeBackHandler();
 
   return (
     <View style={{ flex: 1 }}>

--- a/components/login/TVUserSelectionScreen.tsx
+++ b/components/login/TVUserSelectionScreen.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from "react";
 import { BackHandler, Platform, ScrollView, View } from "react-native";
 import { Text } from "@/components/common/Text";
 import { useScaledTVTypography } from "@/constants/TVTypography";
+import { useTVEventHandler } from "@/hooks/useTVEventHandler";
 import type {
   SavedServer,
   SavedServerAccount,
@@ -17,18 +18,6 @@ interface TVUserSelectionScreenProps {
   onAddUser: () => void;
   onChangeServer: () => void;
   disabled?: boolean;
-}
-
-// TV event handler with fallback for non-TV platforms
-let useTVEventHandler: (callback: (evt: any) => void) => void;
-if (Platform.isTV) {
-  try {
-    useTVEventHandler = require("react-native").useTVEventHandler;
-  } catch {
-    useTVEventHandler = () => {};
-  }
-} else {
-  useTVEventHandler = () => {};
 }
 
 export const TVUserSelectionScreen: React.FC<TVUserSelectionScreenProps> = ({

--- a/components/video-player/controls/hooks/useRemoteControl.ts
+++ b/components/video-player/controls/hooks/useRemoteControl.ts
@@ -1,20 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Alert, BackHandler, Platform } from "react-native";
 import { type SharedValue, useSharedValue } from "react-native-reanimated";
-
-// TV event handler with fallback for non-TV platforms
-let useTVEventHandler: (callback: (evt: any) => void) => void;
-if (Platform.isTV) {
-  try {
-    useTVEventHandler = require("react-native").useTVEventHandler;
-  } catch {
-    // Fallback for non-TV platforms
-    useTVEventHandler = () => {};
-  }
-} else {
-  // No-op hook for non-TV platforms
-  useTVEventHandler = () => {};
-}
+import { useTVEventHandler } from "@/hooks/useTVEventHandler";
 
 interface UseRemoteControlProps {
   showControls: boolean;

--- a/components/video-player/controls/hooks/useRemoteControl.ts
+++ b/components/video-player/controls/hooks/useRemoteControl.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import { Alert, BackHandler, Platform } from "react-native";
+import { Alert } from "react-native";
 import { type SharedValue, useSharedValue } from "react-native-reanimated";
+import { useTVBackPress } from "@/hooks/useTVBackPress";
 import { useTVEventHandler } from "@/hooks/useTVEventHandler";
 
 interface UseRemoteControlProps {
@@ -57,7 +58,6 @@ interface UseRemoteControlProps {
  */
 export function useRemoteControl({
   showControls,
-  toggleControls,
   togglePlay,
   onBack,
   onHideControls,
@@ -93,61 +93,38 @@ export function useRemoteControl({
     videoTitleRef.current = videoTitle;
   }, [showControls, onHideControls, onBack, videoTitle]);
 
-  // Handle hardware back button (works on both Android TV and tvOS)
-  useEffect(() => {
-    if (!Platform.isTV) return;
-
-    const handleBackPress = () => {
-      if (showControlsRef.current && onHideControlsRef.current) {
-        // Controls are visible - just hide them
-        onHideControlsRef.current();
-        return true; // Prevent default back navigation
-      }
-      if (onBackRef.current) {
-        // Controls are hidden - show confirmation before exiting
-        Alert.alert(
-          "Stop Playback",
-          videoTitleRef.current
-            ? `Stop playing "${videoTitleRef.current}"?`
-            : "Are you sure you want to stop playback?",
-          [
-            { text: "Cancel", style: "cancel" },
-            { text: "Stop", style: "destructive", onPress: onBackRef.current },
-          ],
-        );
-        return true; // Prevent default back navigation
-      }
-      return false; // Let default back navigation happen
-    };
-
-    const subscription = BackHandler.addEventListener(
-      "hardwareBackPress",
-      handleBackPress,
-    );
-
-    return () => subscription.remove();
+  // BackHandler owns player exit: Android TV sends hardware back here, and
+  // react-native-tvos maps the Apple TV menu button to the same API.
+  useTVBackPress(() => {
+    if (showControlsRef.current && onHideControlsRef.current) {
+      // Controls are visible, so the first back press only hides them.
+      onHideControlsRef.current();
+      return true;
+    }
+    if (onBackRef.current) {
+      // Controls are hidden, so confirm before leaving playback.
+      Alert.alert(
+        "Stop Playback",
+        videoTitleRef.current
+          ? `Stop playing "${videoTitleRef.current}"?`
+          : "Are you sure you want to stop playback?",
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Stop", style: "destructive", onPress: onBackRef.current },
+        ],
+      );
+      return true;
+    }
+    return false;
   }, []);
 
   // TV remote control handling (no-op on non-TV platforms)
   useTVEventHandler((evt) => {
     if (!evt) return;
 
-    // Back/menu is handled by BackHandler above, but keep this for tvOS menu button
+    // Back/menu is handled by useTVBackPress above. Keep this handler focused
+    // on remote-control events like play/pause, D-pad, and long seek.
     if (evt.eventType === "menu") {
-      if (showControls && onHideControls) {
-        onHideControls();
-      } else if (onBack) {
-        Alert.alert(
-          "Stop Playback",
-          videoTitle
-            ? `Stop playing "${videoTitle}"?`
-            : "Are you sure you want to stop playback?",
-          [
-            { text: "Cancel", style: "cancel" },
-            { text: "Stop", style: "destructive", onPress: onBack },
-          ],
-        );
-      }
       return;
     }
 

--- a/hooks/useTVBackHandler.ts
+++ b/hooks/useTVBackHandler.ts
@@ -1,25 +1,12 @@
-import { useNavigation } from "@react-navigation/native";
-import { router, useSegments } from "expo-router";
-import { useEffect, useRef } from "react";
-import { BackHandler, Platform } from "react-native";
+import { useSegments } from "expo-router";
+import { useEffect } from "react";
+import { Platform } from "react-native";
+import {
+  disableTVMenuKeyInterception,
+  enableTVMenuKeyInterception,
+} from "./useTVBackPress";
 
-// TV event handler and control with fallback for non-TV platforms
-let useTVEventHandler: (callback: (evt: any) => void) => void;
-let TVEventControl: {
-  enableTVMenuKey: () => void;
-  disableTVMenuKey: () => void;
-} | null = null;
-
-if (Platform.isTV) {
-  try {
-    useTVEventHandler = require("react-native").useTVEventHandler;
-    TVEventControl = require("react-native").TVEventControl;
-  } catch {
-    useTVEventHandler = () => {};
-  }
-} else {
-  useTVEventHandler = () => {};
-}
+export { enableTVMenuKeyInterception } from "./useTVBackPress";
 
 /**
  * Check if we're at the root of a tab
@@ -55,106 +42,26 @@ function getCurrentTab(segments: string[]): string | undefined {
 }
 
 /**
- * Hook to handle TV back/menu button presses.
- *
- * Behavior:
- * - On home tab at root: allows app to exit (default tvOS behavior)
- * - On other tabs at root: navigates to home tab
- * - Deeper in navigation stack: goes back
+ * Keeps tvOS menu key interception disabled on the home tab root so the system
+ * can apply its native app-exit behavior. Other routes can opt into
+ * interception when they need JS-owned back handling.
  */
-export function useTVBackHandler() {
-  const navigation = useNavigation<any>();
+export function useTVHomeBackHandler() {
   const segments = useSegments();
-  const lastMenuKeyState = useRef<boolean | null>(null);
 
   // Get current state
   const currentTab = getCurrentTab(segments);
   const atTabRoot = isAtTabRoot(segments);
   const isOnHomeRoot = atTabRoot && currentTab === "(home)";
 
-  // Toggle menu key interception based on current location
-  useEffect(() => {
-    if (!Platform.isTV || !TVEventControl) return;
-
-    if (isOnHomeRoot) {
-      // On home tab root - disable interception to allow app exit
-      if (lastMenuKeyState.current !== false) {
-        TVEventControl.disableTVMenuKey();
-        lastMenuKeyState.current = false;
-      }
-    } else {
-      // On other screens - enable interception to handle navigation
-      if (lastMenuKeyState.current !== true) {
-        TVEventControl.enableTVMenuKey();
-        lastMenuKeyState.current = true;
-      }
-    }
-  }, [isOnHomeRoot]);
-
-  // Handle TV remote menu/back button events
-  useTVEventHandler((evt) => {
-    if (!evt) return;
-    if (evt.eventType === "menu" || evt.eventType === "back") {
-      // If on home root, let the default behavior happen (app exit)
-      if (isOnHomeRoot) {
-        return;
-      }
-
-      // If at tab root level (but not home), navigate to home
-      if (atTabRoot) {
-        router.navigate("/(auth)/(tabs)/(home)");
-        return;
-      }
-
-      // Not at tab root - go back in the stack
-      if (navigation.canGoBack()) {
-        navigation.goBack();
-        return;
-      }
-
-      // Fallback: navigate to home
-      router.navigate("/(auth)/(tabs)/(home)");
-    }
-  });
-
-  // Android TV BackHandler
   useEffect(() => {
     if (!Platform.isTV) return;
 
-    const handleBackPress = () => {
-      // If on home root, allow app to exit
-      if (isOnHomeRoot) {
-        return false; // Don't prevent default (allows exit)
-      }
+    if (isOnHomeRoot) {
+      disableTVMenuKeyInterception();
+      return;
+    }
 
-      if (atTabRoot) {
-        router.navigate("/(auth)/(tabs)/(home)");
-        return true;
-      }
-
-      if (navigation.canGoBack()) {
-        navigation.goBack();
-        return true;
-      }
-
-      router.navigate("/(auth)/(tabs)/(home)");
-      return true;
-    };
-
-    const subscription = BackHandler.addEventListener(
-      "hardwareBackPress",
-      handleBackPress,
-    );
-
-    return () => subscription.remove();
-  }, [navigation, isOnHomeRoot, atTabRoot]);
-}
-
-/**
- * Call this at app startup to enable TV menu key interception.
- */
-export function enableTVMenuKeyInterception() {
-  if (Platform.isTV && TVEventControl) {
-    TVEventControl.enableTVMenuKey();
-  }
+    enableTVMenuKeyInterception();
+  }, [isOnHomeRoot]);
 }

--- a/hooks/useTVBackPress.ts
+++ b/hooks/useTVBackPress.ts
@@ -1,0 +1,57 @@
+import { type DependencyList, useEffect } from "react";
+import { BackHandler, Platform } from "react-native";
+
+type TVBackPressHandler = () => boolean | null | undefined;
+
+let TVEventControl: {
+  enableTVMenuKey: () => void;
+  disableTVMenuKey: () => void;
+} | null = null;
+
+if (Platform.isTV) {
+  try {
+    TVEventControl = require("react-native").TVEventControl;
+  } catch {
+    TVEventControl = null;
+  }
+}
+
+export function enableTVMenuKeyInterception() {
+  if (Platform.isTV && TVEventControl) {
+    TVEventControl.enableTVMenuKey();
+  }
+}
+
+export function disableTVMenuKeyInterception() {
+  if (Platform.isTV && TVEventControl) {
+    TVEventControl.disableTVMenuKey();
+  }
+}
+
+/**
+ * Subscribe to TV back presses through React Native's BackHandler.
+ *
+ * On Android TV this handles the hardware back button. On tvOS,
+ * react-native-tvos maps the Apple TV menu button to the same API when menu key
+ * interception is enabled.
+ *
+ * @see https://reactnative.dev/docs/backhandler
+ */
+export function useTVBackPress(
+  handler: TVBackPressHandler,
+  deps: DependencyList,
+) {
+  useEffect(() => {
+    if (!Platform.isTV) return;
+
+    // BackHandler is the shared back/menu surface for TV platforms:
+    // Android TV sends hardware back here, and react-native-tvos sends menu
+    // here when menu key interception is enabled.
+    const subscription = BackHandler.addEventListener(
+      "hardwareBackPress",
+      handler,
+    );
+
+    return () => subscription.remove();
+  }, deps);
+}

--- a/hooks/useTVEventHandler.ts
+++ b/hooks/useTVEventHandler.ts
@@ -1,0 +1,17 @@
+import type { HWEvent } from "react-native";
+import { Platform } from "react-native";
+
+type UseTVEventHandler = (callback: (evt: HWEvent) => void) => void;
+
+let tvEventHandler: UseTVEventHandler = () => {};
+
+if (Platform.isTV) {
+  try {
+    tvEventHandler = require("react-native")
+      .useTVEventHandler as UseTVEventHandler;
+  } catch {
+    tvEventHandler = () => {};
+  }
+}
+
+export const useTVEventHandler = tvEventHandler;


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary
Fixes TV menu/back handling so player can use custom back button handling logic and root tab can exit to home screen.

## 🏷️ Ticket / Issue

## 🛠️ What’s Changed
- Type: fix
- Scope (optional): tvos, tv
- Short summary: simplify TV back/menu ownership so home root can exit natively and the player handles back/menu through a shared TV back hook.

## 📋 Details
_Generated by codex_

On the player screen pressing the back button was navigating back and not performing any of the custom logic like hiding controls or showing alert before exiting.

From some added logs:
```
  [player-back-handler] ...
  [tv-back-handler:event] {"eventType":"menu"}
  [tv-back-handler] {"segments":["(auth)","player","direct-player"]}
  [player-tv-event] {"eventType":"menu"}
  [player-back-handler] ...
```

Issue was overlapping ownership: the tab/home back handler was still mounted while the player route was active, and both layers could react to the same back event. That meant the tab handler could also navigate/back while the player was trying to run its custom logic.

- Renamed/simplified the tab-level handler to `useTVHomeBackHandler`.
   - `useTVHomeBackHandler` disables tvOS menu key interception on the home tab root so native tvOS app-exit behavior can run, and enables interception away from home root where JS-owned handling is needed.
   - Removed the custom route handling which is no longer needed and was preventing the player's custom back button handling
- Added `useTVBackPress`, a small wrapper around React Native `BackHandler` for TV platforms.
- Updated the player remote-control hook to use `useTVBackPress` for player exit behavior:
  - First back/menu press hides visible controls.
  - When controls are hidden, back/menu prompts before stopping playback.
- Kept `useTVEventHandler` focused on remote-control events like play/pause, D-pad, and long seek; it no longer owns menu/back behavior.


### ⚠️ Breaking Changes
None.

### 🔐 Security & Privacy Impact
None. No data, permissions, credentials, or network behavior changed.

### ⚡ Performance Impact
None.

### 🖼️ Screenshots / GIFs (if UI)
Not applicable. Behavior-only TV remote navigation fix.

## ✅ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [x] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [x] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions
1. Build/run the TV app.
2. On tvOS:
   - Open the home tab root and press the Apple TV Menu/Back button.
   - Verify the system/native app-exit behavior runs.
   - Start playback and press Menu/Back with controls visible.
   - Verify controls hide instead of navigating away.
   - Press Menu/Back again with controls hidden.
   - Verify the stop playback confirmation appears and stopping exits the player.
3. On Android TV:
   - Start playback and press hardware Back with controls visible.
   - Verify controls hide.
   - Press Back again with controls hidden.
   - Verify the stop playback confirmation appears and stopping exits the player.

## ⚙️ Deployment Notes


## 📝 Additional Notes

