### PR TITLE
Android tv improvements

### DIFF
--- a/app/(auth)/(tabs)/(custom-links)/_layout.tsx
+++ b/app/(auth)/(tabs)/(custom-links)/_layout.tsx
@@ -1,11 +1,12 @@
 import { Stack } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { Platform } from "react-native";
+import { androidTVFadeScreenOptions } from "@/components/stacks/NestedTabPageStack";
 
 export default function CustomMenuLayout() {
   const { t } = useTranslation();
   return (
-    <Stack>
+    <Stack screenOptions={androidTVFadeScreenOptions}>
       <Stack.Screen
         name='index'
         options={{

--- a/app/(auth)/(tabs)/(favorites)/_layout.tsx
+++ b/app/(auth)/(tabs)/(favorites)/_layout.tsx
@@ -1,12 +1,15 @@
 import { Stack } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { Platform } from "react-native";
-import { nestedTabPageScreenOptions } from "@/components/stacks/NestedTabPageStack";
+import {
+  androidTVFadeScreenOptions,
+  nestedTabPageScreenOptions,
+} from "@/components/stacks/NestedTabPageStack";
 
 export default function SearchLayout() {
   const { t } = useTranslation();
   return (
-    <Stack>
+    <Stack screenOptions={androidTVFadeScreenOptions}>
       <Stack.Screen
         name='index'
         options={{

--- a/app/(auth)/(tabs)/(home)/_layout.tsx
+++ b/app/(auth)/(tabs)/(home)/_layout.tsx
@@ -3,7 +3,10 @@ import { Stack } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { Platform, View } from "react-native";
 import { Pressable } from "react-native-gesture-handler";
-import { nestedTabPageScreenOptions } from "@/components/stacks/NestedTabPageStack";
+import {
+  androidTVFadeScreenOptions,
+  nestedTabPageScreenOptions,
+} from "@/components/stacks/NestedTabPageStack";
 import useRouter from "@/hooks/useAppRouter";
 
 const Chromecast = Platform.isTV ? null : require("@/components/Chromecast");
@@ -18,7 +21,7 @@ export default function IndexLayout() {
   const { t } = useTranslation();
 
   return (
-    <Stack>
+    <Stack screenOptions={androidTVFadeScreenOptions}>
       <Stack.Screen
         name='index'
         options={{

--- a/app/(auth)/(tabs)/(libraries)/_layout.tsx
+++ b/app/(auth)/(tabs)/(libraries)/_layout.tsx
@@ -4,7 +4,10 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Platform, View } from "react-native";
 import { PlatformDropdown } from "@/components/PlatformDropdown";
-import { nestedTabPageScreenOptions } from "@/components/stacks/NestedTabPageStack";
+import {
+  androidTVFadeScreenOptions,
+  nestedTabPageScreenOptions,
+} from "@/components/stacks/NestedTabPageStack";
 import { useSettings } from "@/utils/atoms/settings";
 
 export default function IndexLayout() {
@@ -150,7 +153,7 @@ export default function IndexLayout() {
   if (!settings?.libraryOptions) return null;
 
   return (
-    <Stack>
+    <Stack screenOptions={androidTVFadeScreenOptions}>
       <Stack.Screen
         name='index'
         options={{

--- a/app/(auth)/(tabs)/(search)/_layout.tsx
+++ b/app/(auth)/(tabs)/(search)/_layout.tsx
@@ -2,6 +2,7 @@ import { Stack } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { Platform } from "react-native";
 import {
+  androidTVFadeScreenOptions,
   commonScreenOptions,
   nestedTabPageScreenOptions,
 } from "@/components/stacks/NestedTabPageStack";
@@ -9,7 +10,7 @@ import {
 export default function SearchLayout() {
   const { t } = useTranslation();
   return (
-    <Stack>
+    <Stack screenOptions={androidTVFadeScreenOptions}>
       <Stack.Screen
         name='index'
         options={{

--- a/app/(auth)/(tabs)/(settings)/_layout.tsx
+++ b/app/(auth)/(tabs)/(settings)/_layout.tsx
@@ -1,11 +1,12 @@
 import { Stack } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { Platform } from "react-native";
+import { androidTVFadeScreenOptions } from "@/components/stacks/NestedTabPageStack";
 
 export default function SettingsLayout() {
   const { t } = useTranslation();
   return (
-    <Stack>
+    <Stack screenOptions={androidTVFadeScreenOptions}>
       <Stack.Screen
         name='index'
         options={{

--- a/app/(auth)/(tabs)/(watchlists)/_layout.tsx
+++ b/app/(auth)/(tabs)/(watchlists)/_layout.tsx
@@ -3,7 +3,10 @@ import { Stack } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { Platform } from "react-native";
 import { Pressable } from "react-native-gesture-handler";
-import { nestedTabPageScreenOptions } from "@/components/stacks/NestedTabPageStack";
+import {
+  androidTVFadeScreenOptions,
+  nestedTabPageScreenOptions,
+} from "@/components/stacks/NestedTabPageStack";
 import useRouter from "@/hooks/useAppRouter";
 import { useStreamystatsEnabled } from "@/hooks/useWatchlists";
 
@@ -13,7 +16,7 @@ export default function WatchlistsLayout() {
   const streamystatsEnabled = useStreamystatsEnabled();
 
   return (
-    <Stack>
+    <Stack screenOptions={androidTVFadeScreenOptions}>
       <Stack.Screen
         name='index'
         options={{

--- a/app/(auth)/(tabs)/_layout.tsx
+++ b/app/(auth)/(tabs)/_layout.tsx
@@ -8,9 +8,17 @@ import type {
   TabNavigationState,
 } from "@react-navigation/native";
 import { withLayoutContext } from "expo-router";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Platform, View } from "react-native";
+import { Animated, Platform, TVFocusGuideView, View } from "react-native";
 import { SystemBars } from "react-native-edge-to-edge";
+import {
+  ANDROID_TV_SIDEBAR_EXPANDED_WIDTH,
+  ANDROID_TV_SIDEBAR_WIDTH,
+  AndroidTVSidebar,
+  type AndroidTVSidebarRoute,
+  HideAndroidTVNativeTabBar,
+} from "@/components/navigation/AndroidTVSidebar";
 import { Colors } from "@/constants/Colors";
 import { useTVBackHandler } from "@/hooks/useTVBackHandler";
 import { useSettings } from "@/utils/atoms/settings";
@@ -36,111 +44,215 @@ export const NativeTabs = withLayoutContext<
 export default function TabLayout() {
   const { settings } = useSettings();
   const { t } = useTranslation();
+  const useAndroidTVSidebar = Platform.OS === "android" && Platform.isTV;
+  const [androidTVSidebarExpanded, setAndroidTVSidebarExpanded] =
+    useState(false);
+  const androidTVSidebarWidth = useRef(
+    new Animated.Value(ANDROID_TV_SIDEBAR_WIDTH),
+  ).current;
+  const androidTVContentFocusRef = useRef<View>(null);
+  const androidTVSidebarRoutes: AndroidTVSidebarRoute[] = [
+    {
+      id: "(home)",
+      label: t("tabs.home"),
+      href: "/(auth)/(tabs)/(home)",
+      icon: require("@/assets/icons/house.fill.png"),
+      visible: true,
+    },
+    {
+      id: "(search)",
+      label: t("tabs.search"),
+      href: "/(auth)/(tabs)/(search)",
+      icon: require("@/assets/icons/magnifyingglass.png"),
+      visible: true,
+    },
+    {
+      id: "(favorites)",
+      label: t("tabs.favorites"),
+      href: "/(auth)/(tabs)/(favorites)",
+      icon: require("@/assets/icons/heart.fill.png"),
+      visible: true,
+    },
+    {
+      id: "(watchlists)",
+      label: t("watchlists.title"),
+      href: "/(auth)/(tabs)/(watchlists)",
+      icon: require("@/assets/icons/list.png"),
+      visible:
+        !!settings?.streamyStatsServerUrl && !settings?.hideWatchlistsTab,
+    },
+    {
+      id: "(libraries)",
+      label: t("tabs.library"),
+      href: "/(auth)/(tabs)/(libraries)",
+      icon: require("@/assets/icons/server.rack.png"),
+      visible: true,
+    },
+    {
+      id: "(custom-links)",
+      label: t("tabs.custom_links"),
+      href: "/(auth)/(tabs)/(custom-links)",
+      icon: require("@/assets/icons/list.png"),
+      visible: !!settings?.showCustomMenuLinks,
+    },
+    {
+      id: "(settings)",
+      label: t("tabs.settings"),
+      href: "/(auth)/(tabs)/(settings)",
+      icon: require("@/assets/icons/list.png"),
+      visible: true,
+    },
+  ];
 
   // Handle TV back button - prevent app exit when at root
   useTVBackHandler();
 
+  useEffect(() => {
+    if (!useAndroidTVSidebar) return;
+
+    Animated.timing(androidTVSidebarWidth, {
+      toValue: androidTVSidebarExpanded
+        ? ANDROID_TV_SIDEBAR_EXPANDED_WIDTH
+        : ANDROID_TV_SIDEBAR_WIDTH,
+      duration: 160,
+      useNativeDriver: false,
+    }).start();
+  }, [androidTVSidebarExpanded, androidTVSidebarWidth, useAndroidTVSidebar]);
+
+  const focusAndroidTVContent = useCallback(() => {
+    setTimeout(() => {
+      (androidTVContentFocusRef.current as any)?.requestTVFocus?.();
+    }, 220);
+  }, []);
+
   return (
-    <View style={{ flex: 1 }}>
+    <View
+      style={{
+        flex: 1,
+        flexDirection: useAndroidTVSidebar ? "row" : "column",
+      }}
+    >
       <SystemBars hidden={false} style='light' />
-      <NativeTabs
-        sidebarAdaptable={false}
-        tabBarStyle={{
-          backgroundColor: "#121212",
-        }}
-        tabBarActiveTintColor={Colors.primary}
-        activeIndicatorColor={"#392c3b"}
-        scrollEdgeAppearance='default'
+      {useAndroidTVSidebar && (
+        <Animated.View
+          style={{
+            width: androidTVSidebarWidth,
+            height: "100%",
+            zIndex: 100,
+          }}
+        >
+          <AndroidTVSidebar
+            routes={androidTVSidebarRoutes}
+            onExpandedChange={setAndroidTVSidebarExpanded}
+            onNavigate={focusAndroidTVContent}
+          />
+        </Animated.View>
+      )}
+      <TVFocusGuideView
+        ref={androidTVContentFocusRef as any}
+        autoFocus={useAndroidTVSidebar}
+        style={{ flex: 1 }}
       >
-        <NativeTabs.Screen redirect name='index' />
-        <NativeTabs.Screen
-          listeners={(_e) => ({
-            tabPress: (_e) => {
-              eventBus.emit("scrollToTop");
-            },
-          })}
-          name='(home)'
-          options={{
-            title: t("tabs.home"),
-            tabBarIcon:
-              Platform.OS === "android"
-                ? (_e) => require("@/assets/icons/house.fill.png")
-                : (_e) => ({ sfSymbol: "house.fill" }),
+        <NativeTabs
+          sidebarAdaptable={false}
+          tabBarStyle={{
+            backgroundColor: "#121212",
           }}
-        />
-        <NativeTabs.Screen
-          listeners={(_e) => ({
-            tabPress: (_e) => {
-              eventBus.emit("searchTabPressed");
-            },
-          })}
-          name='(search)'
-          options={{
-            role: "search",
-            title: t("tabs.search"),
-            tabBarIcon:
-              Platform.OS === "android"
-                ? (_e) => require("@/assets/icons/magnifyingglass.png")
-                : (_e) => ({ sfSymbol: "magnifyingglass" }),
-          }}
-        />
-        <NativeTabs.Screen
-          name='(favorites)'
-          options={{
-            title: t("tabs.favorites"),
-            tabBarIcon:
-              Platform.OS === "android"
-                ? (_e) => require("@/assets/icons/heart.fill.png")
-                : (_e) => ({ sfSymbol: "heart.fill" }),
-          }}
-        />
-        <NativeTabs.Screen
-          name='(watchlists)'
-          options={{
-            title: t("watchlists.title"),
-            tabBarItemHidden:
-              !settings?.streamyStatsServerUrl || settings?.hideWatchlistsTab,
-            tabBarIcon:
-              Platform.OS === "android"
-                ? (_e) => require("@/assets/icons/list.png")
-                : (_e) => ({ sfSymbol: "list.bullet.rectangle" }),
-          }}
-        />
-        <NativeTabs.Screen
-          name='(libraries)'
-          options={{
-            title: t("tabs.library"),
-            tabBarIcon:
-              Platform.OS === "android"
-                ? (_e) => require("@/assets/icons/server.rack.png")
-                : (_e) => ({ sfSymbol: "rectangle.stack.fill" }),
-          }}
-        />
-        <NativeTabs.Screen
-          name='(custom-links)'
-          options={{
-            title: t("tabs.custom_links"),
-            tabBarItemHidden: !settings?.showCustomMenuLinks,
-            tabBarIcon:
-              Platform.OS === "android"
-                ? (_e) => require("@/assets/icons/list.png")
-                : (_e) => ({ sfSymbol: "list.dash.fill" }),
-          }}
-        />
-        <NativeTabs.Screen
-          name='(settings)'
-          options={{
-            title: t("tabs.settings"),
-            tabBarItemHidden: !Platform.isTV,
-            tabBarIcon:
-              Platform.OS === "android"
-                ? (_e) => require("@/assets/icons/list.png")
-                : (_e) => ({ sfSymbol: "gearshape.fill" }),
-          }}
-        />
-      </NativeTabs>
-      <MiniPlayerBar />
-      <MusicPlaybackEngine />
+          tabBarActiveTintColor={Colors.primary}
+          activeIndicatorColor={"#392c3b"}
+          scrollEdgeAppearance='default'
+          tabBar={useAndroidTVSidebar ? HideAndroidTVNativeTabBar : undefined}
+        >
+          <NativeTabs.Screen redirect name='index' />
+          <NativeTabs.Screen
+            listeners={(_e) => ({
+              tabPress: (_e) => {
+                eventBus.emit("scrollToTop");
+              },
+            })}
+            name='(home)'
+            options={{
+              title: t("tabs.home"),
+              tabBarIcon:
+                Platform.OS === "android"
+                  ? (_e) => require("@/assets/icons/house.fill.png")
+                  : (_e) => ({ sfSymbol: "house.fill" }),
+            }}
+          />
+          <NativeTabs.Screen
+            listeners={(_e) => ({
+              tabPress: (_e) => {
+                eventBus.emit("searchTabPressed");
+              },
+            })}
+            name='(search)'
+            options={{
+              role: "search",
+              title: t("tabs.search"),
+              tabBarIcon:
+                Platform.OS === "android"
+                  ? (_e) => require("@/assets/icons/magnifyingglass.png")
+                  : (_e) => ({ sfSymbol: "magnifyingglass" }),
+            }}
+          />
+          <NativeTabs.Screen
+            name='(favorites)'
+            options={{
+              title: t("tabs.favorites"),
+              tabBarIcon:
+                Platform.OS === "android"
+                  ? (_e) => require("@/assets/icons/heart.fill.png")
+                  : (_e) => ({ sfSymbol: "heart.fill" }),
+            }}
+          />
+          <NativeTabs.Screen
+            name='(watchlists)'
+            options={{
+              title: t("watchlists.title"),
+              tabBarItemHidden:
+                !settings?.streamyStatsServerUrl || settings?.hideWatchlistsTab,
+              tabBarIcon:
+                Platform.OS === "android"
+                  ? (_e) => require("@/assets/icons/list.png")
+                  : (_e) => ({ sfSymbol: "list.bullet.rectangle" }),
+            }}
+          />
+          <NativeTabs.Screen
+            name='(libraries)'
+            options={{
+              title: t("tabs.library"),
+              tabBarIcon:
+                Platform.OS === "android"
+                  ? (_e) => require("@/assets/icons/server.rack.png")
+                  : (_e) => ({ sfSymbol: "rectangle.stack.fill" }),
+            }}
+          />
+          <NativeTabs.Screen
+            name='(custom-links)'
+            options={{
+              title: t("tabs.custom_links"),
+              tabBarItemHidden: !settings?.showCustomMenuLinks,
+              tabBarIcon:
+                Platform.OS === "android"
+                  ? (_e) => require("@/assets/icons/list.png")
+                  : (_e) => ({ sfSymbol: "list.dash.fill" }),
+            }}
+          />
+          <NativeTabs.Screen
+            name='(settings)'
+            options={{
+              title: t("tabs.settings"),
+              tabBarItemHidden: !Platform.isTV,
+              tabBarIcon:
+                Platform.OS === "android"
+                  ? (_e) => require("@/assets/icons/list.png")
+                  : (_e) => ({ sfSymbol: "gearshape.fill" }),
+            }}
+          />
+        </NativeTabs>
+        <MiniPlayerBar />
+        <MusicPlaybackEngine />
+      </TVFocusGuideView>
     </View>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,6 +10,7 @@ import * as BackgroundTask from "expo-background-task";
 import * as Device from "expo-device";
 import { Platform } from "react-native";
 import { GlobalModal } from "@/components/GlobalModal";
+import { androidTVFadeScreenOptions } from "@/components/stacks/NestedTabPageStack";
 import { enableTVMenuKeyInterception } from "@/hooks/useTVBackHandler";
 import i18n from "@/i18n";
 import { DownloadProvider } from "@/providers/DownloadProvider";
@@ -415,7 +416,10 @@ function Layout() {
                             <IntroSheetProvider>
                               <ThemeProvider value={DarkTheme}>
                                 <SystemBars style='light' hidden={false} />
-                                <Stack initialRouteName='(auth)/(tabs)'>
+                                <Stack
+                                  initialRouteName='(auth)/(tabs)'
+                                  screenOptions={androidTVFadeScreenOptions}
+                                >
                                   <Stack.Screen
                                     name='(auth)/(tabs)'
                                     options={{

--- a/components/ItemContent.tv.tsx
+++ b/components/ItemContent.tv.tsx
@@ -41,6 +41,7 @@ import {
   TVTechnicalDetails,
 } from "@/components/tv";
 import type { Track } from "@/components/video-player/controls/types";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import useRouter from "@/hooks/useAppRouter";
 import useDefaultPlaySettings from "@/hooks/useDefaultPlaySettings";
@@ -77,6 +78,7 @@ interface ItemContentTVProps {
 export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
   ({ item, itemWithSources }) => {
     const typography = useScaledTVTypography();
+    const tv = useTVDesignTokens();
     const [api] = useAtom(apiAtom);
     const [user] = useAtom(userAtom);
     const isOffline = useOfflineMode();
@@ -608,9 +610,9 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
         <ScrollView
           style={{ flex: 1 }}
           contentContainerStyle={{
-            paddingTop: insets.top + 140,
-            paddingBottom: insets.bottom + 60,
-            paddingHorizontal: insets.left + 80,
+            paddingTop: insets.top + tv.page.top,
+            paddingBottom: insets.bottom + tv.page.horizontalCompact,
+            paddingHorizontal: insets.left + tv.page.horizontal,
           }}
           showsVerticalScrollIndicator={false}
         >
@@ -628,9 +630,9 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                 <Image
                   source={{ uri: logoUrl }}
                   style={{
-                    height: 150,
+                    height: tv.size(150),
                     width: "80%",
-                    marginBottom: 24,
+                    marginBottom: tv.spacing.xl,
                   }}
                   contentFit='contain'
                   contentPosition='left'
@@ -641,7 +643,7 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                     fontSize: typography.display,
                     fontWeight: "bold",
                     color: "#FFFFFF",
-                    marginBottom: 20,
+                    marginBottom: tv.spacing.lg,
                   }}
                   numberOfLines={2}
                 >
@@ -651,7 +653,7 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
 
               {/* Episode info for TV shows */}
               {item.Type === "Episode" && (
-                <View style={{ marginBottom: 16 }}>
+                <View style={{ marginBottom: tv.spacing.md }}>
                   <Text
                     style={{
                       fontSize: typography.title,
@@ -665,7 +667,7 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                     style={{
                       fontSize: typography.body,
                       color: "white",
-                      marginTop: 6,
+                      marginTop: tv.size(6),
                     }}
                   >
                     S{item.ParentIndexNumber} E{item.IndexNumber} · {item.Name}
@@ -683,7 +685,7 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
 
               {/* Genres */}
               {item.Genres && item.Genres.length > 0 && (
-                <View style={{ marginBottom: 24 }}>
+                <View style={{ marginBottom: tv.spacing.xl }}>
                   <GenreTags genres={item.Genres} />
                 </View>
               )}
@@ -694,15 +696,15 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                   intensity={10}
                   tint='light'
                   style={{
-                    borderRadius: 8,
+                    borderRadius: tv.radius.sm,
                     overflow: "hidden",
                     maxWidth: SCREEN_WIDTH * 0.45,
-                    marginBottom: 32,
+                    marginBottom: tv.spacing["2xl"],
                   }}
                 >
                   <View
                     style={{
-                      padding: 16,
+                      padding: tv.spacing.md,
                       backgroundColor: "rgba(0,0,0,0.3)",
                     }}
                   >
@@ -710,7 +712,7 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                       style={{
                         fontSize: typography.body,
                         color: "#E5E7EB",
-                        lineHeight: 32,
+                        lineHeight: tv.size(32),
                       }}
                       numberOfLines={4}
                     >
@@ -724,8 +726,8 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
               <View
                 style={{
                   flexDirection: "row",
-                  gap: 16,
-                  marginBottom: 32,
+                  gap: tv.spacing.md,
+                  marginBottom: tv.spacing["2xl"],
                 }}
               >
                 <TVButton
@@ -735,9 +737,9 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                 >
                   <Ionicons
                     name='play'
-                    size={28}
+                    size={tv.size(28)}
                     color='#000000'
-                    style={{ marginRight: 10 }}
+                    style={{ marginRight: tv.spacing.xs }}
                   />
                   <Text
                     style={{
@@ -761,8 +763,8 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                 style={{
                   flexDirection: "row",
                   alignItems: "center",
-                  gap: 12,
-                  marginBottom: 24,
+                  gap: tv.spacing.sm,
+                  marginBottom: tv.spacing.xl,
                 }}
               >
                 {/* Quality selector */}
@@ -856,18 +858,18 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                   item.Type === "Episode"
                     ? SCREEN_WIDTH * 0.35
                     : SCREEN_WIDTH * 0.22,
-                marginLeft: 50,
+                marginLeft: tv.spacing["4xl"],
               }}
             >
               <View
                 style={{
                   aspectRatio: item.Type === "Episode" ? 16 / 9 : 2 / 3,
-                  borderRadius: 16,
+                  borderRadius: tv.radius.lg,
                   overflow: "hidden",
                   shadowColor: "#000",
-                  shadowOffset: { width: 0, height: 10 },
+                  shadowOffset: { width: 0, height: tv.spacing.xs },
                   shadowOpacity: 0.5,
-                  shadowRadius: 20,
+                  shadowRadius: tv.shadow.xl,
                 }}
               >
                 {item.Type === "Episode" ? (
@@ -896,16 +898,16 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
           </View>
 
           {/* Additional info section */}
-          <View style={{ marginTop: 40 }}>
+          <View style={{ marginTop: tv.spacing["3xl"] }}>
             {/* Season Episodes - Episode only */}
             {item.Type === "Episode" && seasonEpisodes.length > 1 && (
-              <View style={{ marginBottom: 40 }}>
+              <View style={{ marginBottom: tv.spacing["3xl"] }}>
                 <Text
                   style={{
                     fontSize: typography.heading,
                     fontWeight: "600",
                     color: "#FFFFFF",
-                    marginBottom: 24,
+                    marginBottom: tv.spacing.xl,
                   }}
                 >
                   {t("item_card.more_from_this_season")}

--- a/components/home/Favorites.tv.tsx
+++ b/components/home/Favorites.tv.tsx
@@ -11,12 +11,9 @@ import heart from "@/assets/icons/heart.fill.png";
 import { Text } from "@/components/common/Text";
 import { InfiniteScrollingCollectionList } from "@/components/home/InfiniteScrollingCollectionList.tv";
 import { Colors } from "@/constants/Colors";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
-
-const HORIZONTAL_PADDING = 60;
-const TOP_PADDING = 100;
-const SECTION_GAP = 10;
 
 type FavoriteTypes =
   | "Series"
@@ -29,6 +26,7 @@ type EmptyState = Record<FavoriteTypes, boolean>;
 
 export const Favorites = () => {
   const typography = useScaledTVTypography();
+  const tv = useTVDesignTokens();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const [api] = useAtom(apiAtom);
@@ -134,14 +132,14 @@ export const Favorites = () => {
           flex: 1,
           alignItems: "center",
           justifyContent: "center",
-          paddingHorizontal: HORIZONTAL_PADDING,
+          paddingHorizontal: tv.page.horizontalCompact,
         }}
       >
         <Image
           style={{
-            width: 64,
-            height: 64,
-            marginBottom: 16,
+            width: tv.size(64),
+            height: tv.size(64),
+            marginBottom: tv.spacing.md,
             tintColor: Colors.primary,
           }}
           contentFit='contain'
@@ -151,7 +149,7 @@ export const Favorites = () => {
           style={{
             fontSize: typography.heading,
             fontWeight: "bold",
-            marginBottom: 8,
+            marginBottom: tv.spacing.xs,
             color: "#FFFFFF",
           }}
         >
@@ -176,11 +174,11 @@ export const Favorites = () => {
       nestedScrollEnabled
       showsVerticalScrollIndicator={false}
       contentContainerStyle={{
-        paddingTop: insets.top + TOP_PADDING,
-        paddingBottom: insets.bottom + 60,
+        paddingTop: insets.top + tv.page.topCompact,
+        paddingBottom: insets.bottom + tv.page.horizontalCompact,
       }}
     >
-      <View style={{ gap: SECTION_GAP }}>
+      <View style={{ gap: tv.spacing.xs }}>
         <InfiniteScrollingCollectionList
           queryFn={fetchFavoriteSeries}
           queryKey={["home", "favorites", "series"]}

--- a/components/home/Home.tv.tsx
+++ b/components/home/Home.tv.tsx
@@ -32,6 +32,7 @@ import { StreamystatsPromotedWatchlists } from "@/components/home/StreamystatsPr
 import { StreamystatsRecommendations } from "@/components/home/StreamystatsRecommendations.tv";
 import { TVHeroCarousel } from "@/components/home/TVHeroCarousel";
 import { Loader } from "@/components/Loader";
+import { useScaledTVSizes } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import useRouter from "@/hooks/useAppRouter";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
@@ -43,8 +44,6 @@ import { getBackdropUrl } from "@/utils/jellyfin/image/getBackdropUrl";
 
 const HORIZONTAL_PADDING = 60;
 const TOP_PADDING = 100;
-// Generous gap between sections for Apple TV+ aesthetic
-const SECTION_GAP = 24;
 
 type InfiniteScrollingCollectionListSection = {
   type: "InfiniteScrollingCollectionList";
@@ -63,6 +62,7 @@ const BACKDROP_DEBOUNCE_MS = 300;
 
 export const Home = () => {
   const typography = useScaledTVTypography();
+  const sizes = useScaledTVSizes();
   const _router = useRouter();
   const { t } = useTranslation();
   const api = useAtomValue(apiAtom);
@@ -78,6 +78,11 @@ export const Home = () => {
   } = useNetworkStatus();
   const _invalidateCache = useInvalidatePlaybackProgressCache();
   const { showItemActions } = useTVItemActionModal();
+  const horizontalPadding = sizes.padding.horizontal;
+  const topPadding = Math.round(
+    (TOP_PADDING * horizontalPadding) / HORIZONTAL_PADDING,
+  );
+  const sectionGap = sizes.gaps.item;
 
   // Dynamic backdrop state with debounce
   const [focusedItem, setFocusedItem] = useState<BaseItemDto | null>(null);
@@ -568,7 +573,7 @@ export const Home = () => {
           flex: 1,
           alignItems: "center",
           justifyContent: "center",
-          paddingHorizontal: HORIZONTAL_PADDING,
+          paddingHorizontal: horizontalPadding,
         }}
       >
         <Text
@@ -592,7 +597,7 @@ export const Home = () => {
           {subtitle}
         </Text>
 
-        <View style={{ marginTop: 24 }}>
+        <View style={{ marginTop: sectionGap }}>
           <Button
             color='black'
             onPress={retryCheck}
@@ -721,8 +726,8 @@ export const Home = () => {
         nestedScrollEnabled
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{
-          paddingTop: showHero ? 0 : insets.top + TOP_PADDING,
-          paddingBottom: insets.bottom + 60,
+          paddingTop: showHero ? 0 : insets.top + topPadding,
+          paddingBottom: insets.bottom + sizes.padding.horizontal,
         }}
       >
         {/* Hero Carousel - Apple TV+ style featured content */}
@@ -736,8 +741,8 @@ export const Home = () => {
 
         <View
           style={{
-            gap: SECTION_GAP,
-            paddingTop: showHero ? SECTION_GAP : 0,
+            gap: sectionGap,
+            paddingTop: showHero ? sectionGap : 0,
           }}
         >
           {/* Skip first section (Continue Watching) when hero is shown since hero displays that content */}
@@ -757,7 +762,7 @@ export const Home = () => {
               settings.streamyStatsPromotedWatchlists;
             const streamystatsSections =
               index === streamystatsIndex && hasStreamystatsContent ? (
-                <View key='streamystats-sections' style={{ gap: SECTION_GAP }}>
+                <View key='streamystats-sections' style={{ gap: sectionGap }}>
                   {settings.streamyStatsMovieRecommendations && (
                     <StreamystatsRecommendations
                       title={t(
@@ -788,7 +793,7 @@ export const Home = () => {
               // First section only gets preferred focus if hero is not shown
               const isFirstSection = index === 0 && !showHero;
               return (
-                <View key={index} style={{ gap: SECTION_GAP }}>
+                <View key={index} style={{ gap: sectionGap }}>
                   <InfiniteScrollingCollectionList
                     title={section.title}
                     queryKey={section.queryKey}

--- a/components/home/InfiniteScrollingCollectionList.tv.tsx
+++ b/components/home/InfiniteScrollingCollectionList.tv.tsx
@@ -25,9 +25,6 @@ import useRouter from "@/hooks/useAppRouter";
 import { useTVItemActionModal } from "@/hooks/useTVItemActionModal";
 import { SortByOption, SortOrderOption } from "@/utils/atoms/filters";
 
-// Extra padding to accommodate scale animation (1.05x) and glow shadow
-const SCALE_PADDING = 20;
-
 interface Props extends ViewProps {
   title?: string | null;
   orientation?: "horizontal" | "vertical";
@@ -128,6 +125,7 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
   const posterSizes = useScaledTVPosterSizes();
   const sizes = useScaledTVSizes();
   const ITEM_GAP = sizes.gaps.item;
+  const listHorizontalPadding = sizes.padding.horizontal + sizes.padding.scale;
   const effectivePageSize = Math.max(1, pageSize);
   const router = useRouter();
   const { showItemActions } = useTVItemActionModal();
@@ -250,7 +248,7 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
           fontSize: typography.heading,
           fontWeight: "700",
           color: "#FFFFFF",
-          marginBottom: 20,
+          marginBottom: sizes.padding.scale,
           marginLeft: sizes.padding.horizontal,
           letterSpacing: 0.5,
         }}
@@ -275,8 +273,8 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
           style={{
             flexDirection: "row",
             gap: ITEM_GAP,
-            paddingHorizontal: SCALE_PADDING,
-            paddingVertical: SCALE_PADDING,
+            paddingHorizontal: sizes.padding.scale,
+            paddingVertical: sizes.padding.scale,
           }}
         >
           {[1, 2, 3, 4, 5].map((i) => (
@@ -328,14 +326,13 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
           windowSize={5}
           removeClippedSubviews={false}
           maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
-          style={{ overflow: "visible" }}
-          contentInset={{
-            left: sizes.padding.horizontal,
-            right: sizes.padding.horizontal,
+          style={{
+            overflow: "visible",
+            marginHorizontal: -sizes.padding.scale,
           }}
-          contentOffset={{ x: -sizes.padding.horizontal, y: 0 }}
           contentContainerStyle={{
-            paddingVertical: SCALE_PADDING,
+            paddingHorizontal: listHorizontalPadding,
+            paddingVertical: sizes.padding.scale,
           }}
           ListFooterComponent={
             <View

--- a/components/home/StreamystatsPromotedWatchlists.tv.tsx
+++ b/components/home/StreamystatsPromotedWatchlists.tv.tsx
@@ -13,7 +13,7 @@ import { Text } from "@/components/common/Text";
 import { getItemNavigation } from "@/components/common/TouchableItemRouter";
 import { TVPosterCard } from "@/components/tv/TVPosterCard";
 import { useScaledTVPosterSizes } from "@/constants/TVPosterSizes";
-import { useScaledTVSizes } from "@/constants/TVSizes";
+import { useScaledTVSizes, useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import useRouter from "@/hooks/useAppRouter";
 import { useTVItemActionModal } from "@/hooks/useTVItemActionModal";
@@ -21,8 +21,6 @@ import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { useSettings } from "@/utils/atoms/settings";
 import { createStreamystatsApi } from "@/utils/streamystats/api";
 import type { StreamystatsWatchlist } from "@/utils/streamystats/types";
-
-const SCALE_PADDING = 20;
 
 interface WatchlistSectionProps extends ViewProps {
   watchlist: StreamystatsWatchlist;
@@ -39,7 +37,9 @@ const WatchlistSection: React.FC<WatchlistSectionProps> = ({
   const typography = useScaledTVTypography();
   const posterSizes = useScaledTVPosterSizes();
   const sizes = useScaledTVSizes();
+  const tv = useTVDesignTokens();
   const ITEM_GAP = sizes.gaps.item;
+  const listHorizontalPadding = sizes.padding.horizontal + sizes.padding.scale;
   const api = useAtomValue(apiAtom);
   const user = useAtomValue(userAtom);
   const { settings } = useSettings();
@@ -144,7 +144,7 @@ const WatchlistSection: React.FC<WatchlistSectionProps> = ({
           fontSize: typography.heading,
           fontWeight: "700",
           color: "#FFFFFF",
-          marginBottom: 20,
+          marginBottom: tv.spacing.lg,
           marginLeft: sizes.padding.horizontal,
           letterSpacing: 0.5,
         }}
@@ -157,8 +157,8 @@ const WatchlistSection: React.FC<WatchlistSectionProps> = ({
           style={{
             flexDirection: "row",
             gap: ITEM_GAP,
-            paddingHorizontal: SCALE_PADDING,
-            paddingVertical: SCALE_PADDING,
+            paddingHorizontal: sizes.padding.scale,
+            paddingVertical: sizes.padding.scale,
           }}
         >
           {[1, 2, 3, 4, 5].map((i) => (
@@ -168,8 +168,8 @@ const WatchlistSection: React.FC<WatchlistSectionProps> = ({
                   backgroundColor: "#262626",
                   width: posterSizes.poster,
                   aspectRatio: 10 / 15,
-                  borderRadius: 12,
-                  marginBottom: 8,
+                  borderRadius: tv.radius.md,
+                  marginBottom: tv.spacing.xs,
                 }}
               />
             </View>
@@ -187,14 +187,13 @@ const WatchlistSection: React.FC<WatchlistSectionProps> = ({
           windowSize={5}
           removeClippedSubviews={false}
           getItemLayout={getItemLayout}
-          style={{ overflow: "visible" }}
-          contentInset={{
-            left: sizes.padding.horizontal,
-            right: sizes.padding.horizontal,
+          style={{
+            overflow: "visible",
+            marginHorizontal: -sizes.padding.scale,
           }}
-          contentOffset={{ x: -sizes.padding.horizontal, y: 0 }}
           contentContainerStyle={{
-            paddingVertical: SCALE_PADDING,
+            paddingHorizontal: listHorizontalPadding,
+            paddingVertical: sizes.padding.scale,
           }}
         />
       )}
@@ -212,6 +211,7 @@ export const StreamystatsPromotedWatchlists: React.FC<
 > = ({ enabled = true, onItemFocus, ...props }) => {
   const posterSizes = useScaledTVPosterSizes();
   const sizes = useScaledTVSizes();
+  const tv = useTVDesignTokens();
   const ITEM_GAP = sizes.gaps.item;
   const api = useAtomValue(apiAtom);
   const user = useAtomValue(userAtom);
@@ -286,20 +286,20 @@ export const StreamystatsPromotedWatchlists: React.FC<
       <View style={{ overflow: "visible" }} {...props}>
         <View
           style={{
-            height: 16,
-            width: 128,
+            height: tv.spacing.md,
+            width: tv.size(128),
             backgroundColor: "#262626",
-            borderRadius: 4,
-            marginLeft: SCALE_PADDING,
-            marginBottom: 16,
+            borderRadius: tv.spacing.xxs,
+            marginLeft: sizes.padding.scale,
+            marginBottom: tv.spacing.md,
           }}
         />
         <View
           style={{
             flexDirection: "row",
             gap: ITEM_GAP,
-            paddingHorizontal: SCALE_PADDING,
-            paddingVertical: SCALE_PADDING,
+            paddingHorizontal: sizes.padding.scale,
+            paddingVertical: sizes.padding.scale,
           }}
         >
           {[1, 2, 3, 4, 5].map((i) => (
@@ -309,8 +309,8 @@ export const StreamystatsPromotedWatchlists: React.FC<
                   backgroundColor: "#262626",
                   width: posterSizes.poster,
                   aspectRatio: 10 / 15,
-                  borderRadius: 12,
-                  marginBottom: 8,
+                  borderRadius: tv.radius.md,
+                  marginBottom: tv.spacing.xs,
                 }}
               />
             </View>

--- a/components/home/StreamystatsRecommendations.tv.tsx
+++ b/components/home/StreamystatsRecommendations.tv.tsx
@@ -12,7 +12,7 @@ import { FlatList, View, type ViewProps } from "react-native";
 import { Text } from "@/components/common/Text";
 import { getItemNavigation } from "@/components/common/TouchableItemRouter";
 import { TVPosterCard } from "@/components/tv/TVPosterCard";
-import { useScaledTVSizes } from "@/constants/TVSizes";
+import { useScaledTVSizes, useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import useRouter from "@/hooks/useAppRouter";
 import { useTVItemActionModal } from "@/hooks/useTVItemActionModal";
@@ -39,6 +39,8 @@ export const StreamystatsRecommendations: React.FC<Props> = ({
 }) => {
   const typography = useScaledTVTypography();
   const sizes = useScaledTVSizes();
+  const tv = useTVDesignTokens();
+  const listHorizontalPadding = sizes.padding.horizontal + sizes.padding.scale;
   const api = useAtomValue(apiAtom);
   const user = useAtomValue(userAtom);
   const { settings } = useSettings();
@@ -196,7 +198,7 @@ export const StreamystatsRecommendations: React.FC<Props> = ({
           fontSize: typography.heading,
           fontWeight: "700",
           color: "#FFFFFF",
-          marginBottom: 20,
+          marginBottom: tv.spacing.lg,
           marginLeft: sizes.padding.horizontal,
           letterSpacing: 0.5,
         }}
@@ -220,8 +222,8 @@ export const StreamystatsRecommendations: React.FC<Props> = ({
                   backgroundColor: "#262626",
                   width: sizes.posters.poster,
                   aspectRatio: 10 / 15,
-                  borderRadius: 12,
-                  marginBottom: 8,
+                  borderRadius: tv.radius.md,
+                  marginBottom: tv.spacing.xs,
                 }}
               />
             </View>
@@ -239,13 +241,12 @@ export const StreamystatsRecommendations: React.FC<Props> = ({
           windowSize={5}
           removeClippedSubviews={false}
           getItemLayout={getItemLayout}
-          style={{ overflow: "visible" }}
-          contentInset={{
-            left: sizes.padding.horizontal,
-            right: sizes.padding.horizontal,
+          style={{
+            overflow: "visible",
+            marginHorizontal: -sizes.padding.scale,
           }}
-          contentOffset={{ x: -sizes.padding.horizontal, y: 0 }}
           contentContainerStyle={{
+            paddingHorizontal: listHorizontalPadding,
             paddingVertical: sizes.padding.scale,
           }}
         />

--- a/components/home/TVHeroCarousel.tsx
+++ b/components/home/TVHeroCarousel.tsx
@@ -23,7 +23,11 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ProgressBar } from "@/components/common/ProgressBar";
 import { Text } from "@/components/common/Text";
 import { getItemNavigation } from "@/components/common/TouchableItemRouter";
-import { type ScaledTVSizes, useScaledTVSizes } from "@/constants/TVSizes";
+import {
+  type ScaledTVSizes,
+  useScaledTVSizes,
+  useTVViewportScale,
+} from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import useRouter from "@/hooks/useAppRouter";
 import {
@@ -55,8 +59,10 @@ interface HeroCardProps {
 const HeroCard: React.FC<HeroCardProps> = React.memo(
   ({ item, isFirst, sizes, onFocus, onPress, onLongPress }) => {
     const api = useAtomValue(apiAtom);
+    const viewportScale = useTVViewportScale();
     const [focused, setFocused] = useState(false);
     const scale = useRef(new Animated.Value(1)).current;
+    const cornerRadius = Math.round(24 * viewportScale);
 
     // Check if glass effect is available (tvOS 26+)
     const useGlass = Platform.OS === "ios" && isGlassEffectAvailable();
@@ -129,7 +135,7 @@ const HeroCard: React.FC<HeroCardProps> = React.memo(
           <GlassPosterView
             imageUrl={posterUrl}
             aspectRatio={16 / 9}
-            cornerRadius={24}
+            cornerRadius={cornerRadius}
             progress={progress}
             showWatchedIndicator={false}
             isFocused={focused}
@@ -154,7 +160,7 @@ const HeroCard: React.FC<HeroCardProps> = React.memo(
           style={{
             width: sizes.posters.episode,
             aspectRatio: 16 / 9,
-            borderRadius: 24,
+            borderRadius: cornerRadius,
             overflow: "hidden",
             transform: [{ scale }],
             borderWidth: 2,
@@ -162,7 +168,7 @@ const HeroCard: React.FC<HeroCardProps> = React.memo(
             shadowColor: "#FFFFFF",
             shadowOffset: { width: 0, height: 0 },
             shadowOpacity: focused ? 0.6 : 0,
-            shadowRadius: focused ? 20 : 0,
+            shadowRadius: focused ? Math.round(20 * viewportScale) : 0,
           }}
         >
           {posterUrl ? (
@@ -183,7 +189,7 @@ const HeroCard: React.FC<HeroCardProps> = React.memo(
             >
               <Ionicons
                 name='film-outline'
-                size={48}
+                size={Math.round(48 * viewportScale)}
                 color='rgba(255,255,255,0.3)'
               />
             </View>
@@ -205,6 +211,7 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
 }) => {
   const typography = useScaledTVTypography();
   const sizes = useScaledTVSizes();
+  const viewportScale = useTVViewportScale();
   const api = useAtomValue(apiAtom);
   const _insets = useSafeAreaInsets();
   const router = useRouter();
@@ -377,7 +384,18 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
 
   if (items.length === 0) return null;
 
+  const scaleValue = (value: number) => Math.round(value * viewportScale);
   const heroHeight = SCREEN_HEIGHT * sizes.padding.heroHeight;
+  const carouselBottom = scaleValue(40);
+  const carouselVerticalPadding = sizes.gaps.small + sizes.padding.scale;
+  const contentToCarouselGap = sizes.gaps.small;
+  const contentBottom =
+    carouselBottom +
+    sizes.posters.episode * (9 / 16) +
+    carouselVerticalPadding * 2 +
+    contentToCarouselGap;
+  const carouselHorizontalPadding =
+    sizes.padding.horizontal + sizes.padding.scale;
 
   return (
     <View style={{ height: heroHeight, width: "100%" }}>
@@ -471,8 +489,7 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
           position: "absolute",
           left: sizes.padding.horizontal,
           right: sizes.padding.horizontal,
-          bottom:
-            40 + sizes.posters.episode * (9 / 16) + sizes.gaps.small * 2 + 20,
+          bottom: contentBottom,
         }}
       >
         {/* Logo or Title */}
@@ -480,9 +497,9 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
           <Image
             source={{ uri: logoUrl }}
             style={{
-              height: 100,
+              height: scaleValue(100),
               width: SCREEN_WIDTH * 0.35,
-              marginBottom: 16,
+              marginBottom: scaleValue(16),
             }}
             contentFit='contain'
             contentPosition='left'
@@ -493,7 +510,7 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
               fontSize: typography.display,
               fontWeight: "bold",
               color: "#FFFFFF",
-              marginBottom: 12,
+              marginBottom: scaleValue(12),
             }}
             numberOfLines={1}
           >
@@ -507,7 +524,7 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
             style={{
               fontSize: typography.body,
               color: "rgba(255,255,255,0.9)",
-              marginBottom: 12,
+              marginBottom: scaleValue(12),
             }}
             numberOfLines={1}
           >
@@ -521,7 +538,7 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
             style={{
               fontSize: typography.body,
               color: "rgba(255,255,255,0.8)",
-              marginBottom: 16,
+              marginBottom: scaleValue(16),
               maxWidth: SCREEN_WIDTH * 0.5,
               lineHeight: typography.body * 1.4,
             }}
@@ -536,7 +553,7 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
           style={{
             flexDirection: "row",
             alignItems: "center",
-            gap: 16,
+            gap: scaleValue(16),
           }}
         >
           {year && (
@@ -562,9 +579,9 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
           {activeItem?.OfficialRating && (
             <View
               style={{
-                paddingHorizontal: 8,
-                paddingVertical: 2,
-                borderRadius: 4,
+                paddingHorizontal: scaleValue(8),
+                paddingVertical: Math.max(1, scaleValue(2)),
+                borderRadius: scaleValue(4),
                 borderWidth: 1,
                 borderColor: "rgba(255,255,255,0.5)",
               }}
@@ -584,15 +601,15 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
               style={{
                 flexDirection: "row",
                 alignItems: "center",
-                gap: 6,
+                gap: scaleValue(6),
               }}
             >
               <View
                 style={{
-                  width: 60,
-                  height: 4,
+                  width: scaleValue(60),
+                  height: Math.max(2, scaleValue(4)),
                   backgroundColor: "rgba(255,255,255,0.3)",
-                  borderRadius: 2,
+                  borderRadius: scaleValue(2),
                   overflow: "hidden",
                 }}
               >
@@ -601,7 +618,7 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
                     width: `${playedPercent}%`,
                     height: "100%",
                     backgroundColor: "#FFFFFF",
-                    borderRadius: 2,
+                    borderRadius: scaleValue(2),
                   }}
                 />
               </View>
@@ -624,7 +641,7 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
           position: "absolute",
           left: 0,
           right: 0,
-          bottom: 40,
+          bottom: carouselBottom,
         }}
       >
         <FlatList
@@ -632,13 +649,14 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
           data={heroItems}
           keyExtractor={keyExtractor}
           showsHorizontalScrollIndicator={false}
-          style={{ overflow: "visible" }}
-          contentInset={{
-            left: sizes.padding.horizontal,
-            right: sizes.padding.horizontal,
+          style={{
+            overflow: "visible",
+            marginHorizontal: -sizes.padding.scale,
           }}
-          contentOffset={{ x: -sizes.padding.horizontal, y: 0 }}
-          contentContainerStyle={{ paddingVertical: sizes.gaps.small }}
+          contentContainerStyle={{
+            paddingHorizontal: carouselHorizontalPadding,
+            paddingVertical: carouselVerticalPadding,
+          }}
           renderItem={renderHeroCard}
           removeClippedSubviews={false}
           initialNumToRender={8}

--- a/components/navigation/AndroidTVSidebar.tsx
+++ b/components/navigation/AndroidTVSidebar.tsx
@@ -1,0 +1,219 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useSegments } from "expo-router";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Animated, Image, Pressable, View } from "react-native";
+import { Text } from "@/components/common/Text";
+import { useTVFocusAnimation } from "@/components/tv/hooks/useTVFocusAnimation";
+import { Colors } from "@/constants/Colors";
+import { useScaledTVTypography } from "@/constants/TVTypography";
+import useRouter from "@/hooks/useAppRouter";
+
+export const ANDROID_TV_SIDEBAR_WIDTH = 60;
+export const ANDROID_TV_SIDEBAR_EXPANDED_WIDTH = 180;
+
+const ITEM_SIZE = 46;
+const ICON_SIZE = 20;
+const INACTIVE_ICON_COLOR = "rgba(209, 213, 219, 0.68)";
+const COLLAPSED_HORIZONTAL_PADDING = 7;
+const COLLAPSED_ICON_COLUMN_WIDTH =
+  ANDROID_TV_SIDEBAR_WIDTH - COLLAPSED_HORIZONTAL_PADDING * 2;
+
+type AndroidTVSidebarItemProps = {
+  focused: boolean;
+  icon: unknown;
+  label: string;
+  expanded: boolean;
+  onFocus: () => void;
+  onBlur: () => void;
+  onPress: () => void;
+};
+
+export type AndroidTVSidebarRoute = {
+  id: string;
+  label: string;
+  href: string;
+  icon: number;
+  visible: boolean;
+};
+
+function AndroidTVSidebarItem({
+  focused,
+  icon,
+  label,
+  expanded,
+  onFocus,
+  onBlur,
+  onPress,
+}: AndroidTVSidebarItemProps) {
+  const typography = useScaledTVTypography();
+  const {
+    focused: tvFocused,
+    handleFocus,
+    handleBlur,
+    animatedStyle,
+  } = useTVFocusAnimation({
+    scaleAmount: 1.04,
+    duration: 120,
+    onFocus,
+    onBlur,
+  });
+
+  const iconSource = useMemo(() => {
+    if (!icon || typeof icon !== "number") return null;
+    return Image.resolveAssetSource(icon);
+  }, [icon]);
+
+  return (
+    <Pressable
+      onPress={onPress}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      focusable
+    >
+      <Animated.View
+        style={[
+          animatedStyle,
+          {
+            height: ITEM_SIZE,
+            borderRadius: 10,
+            flexDirection: "row",
+            alignItems: "center",
+            backgroundColor: tvFocused
+              ? "rgba(238, 225, 246, 0.95)"
+              : focused
+                ? "rgba(147, 52, 233, 0.2)"
+                : "transparent",
+          },
+        ]}
+      >
+        <View
+          style={{
+            width: COLLAPSED_ICON_COLUMN_WIDTH,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          {iconSource ? (
+            <Image
+              source={iconSource}
+              resizeMode='contain'
+              style={{
+                width: ICON_SIZE,
+                height: ICON_SIZE,
+                tintColor: tvFocused
+                  ? "#000000"
+                  : focused
+                    ? Colors.primary
+                    : INACTIVE_ICON_COLOR,
+              }}
+            />
+          ) : (
+            <Ionicons
+              name='ellipse-outline'
+              size={ICON_SIZE}
+              color={
+                tvFocused
+                  ? "#000000"
+                  : focused
+                    ? Colors.primary
+                    : INACTIVE_ICON_COLOR
+              }
+            />
+          )}
+        </View>
+        {expanded && (
+          <Text
+            numberOfLines={1}
+            style={{
+              flex: 1,
+              marginLeft: 14,
+              marginRight: 16,
+              fontSize: typography.callout,
+              fontWeight: tvFocused || focused ? "700" : "500",
+              color: tvFocused ? "#000000" : "#FFFFFF",
+            }}
+          >
+            {label}
+          </Text>
+        )}
+      </Animated.View>
+    </Pressable>
+  );
+}
+
+export function AndroidTVSidebar({
+  routes,
+  onExpandedChange,
+  onNavigate,
+}: {
+  routes: AndroidTVSidebarRoute[];
+  onExpandedChange?: (expanded: boolean) => void;
+  onNavigate?: () => void;
+}) {
+  const router = useRouter();
+  const segments = useSegments() as string[];
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const visibleRoutes = routes.filter((route) => route.visible);
+
+  const handleItemFocus = useCallback(() => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    setExpanded(true);
+    onExpandedChange?.(true);
+  }, [onExpandedChange]);
+
+  const handleItemBlur = useCallback(() => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    closeTimer.current = setTimeout(() => {
+      setExpanded(false);
+      onExpandedChange?.(false);
+    }, 80);
+  }, [onExpandedChange]);
+
+  return (
+    <View
+      pointerEvents='box-none'
+      style={{
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        backgroundColor: "transparent",
+        paddingTop: 96,
+        paddingHorizontal: COLLAPSED_HORIZONTAL_PADDING,
+        zIndex: 100,
+      }}
+    >
+      <View style={{ gap: 12 }}>
+        {visibleRoutes.map((route) => {
+          const focused = segments.includes(route.id);
+
+          return (
+            <AndroidTVSidebarItem
+              key={route.id}
+              focused={focused}
+              icon={route.icon}
+              label={route.label}
+              expanded={expanded}
+              onFocus={handleItemFocus}
+              onBlur={handleItemBlur}
+              onPress={() => {
+                if (closeTimer.current) clearTimeout(closeTimer.current);
+                setExpanded(false);
+                onExpandedChange?.(false);
+                router.navigate(route.href as any);
+                onNavigate?.();
+              }}
+            />
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+export function HideAndroidTVNativeTabBar() {
+  return null;
+}

--- a/components/series/TVSeriesHeader.tsx
+++ b/components/series/TVSeriesHeader.tsx
@@ -8,6 +8,7 @@ import { Dimensions, View } from "react-native";
 import { Badge } from "@/components/Badge";
 import { Text } from "@/components/common/Text";
 import { GenreTags } from "@/components/GenreTags";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { getLogoImageUrlById } from "@/utils/jellyfin/image/getLogoImageUrlById";
@@ -20,6 +21,7 @@ interface TVSeriesHeaderProps {
 
 export const TVSeriesHeader: React.FC<TVSeriesHeaderProps> = ({ item }) => {
   const typography = useScaledTVTypography();
+  const tv = useTVDesignTokens();
   const api = useAtomValue(apiAtom);
 
   const logoUrl = useMemo(() => {
@@ -49,9 +51,9 @@ export const TVSeriesHeader: React.FC<TVSeriesHeaderProps> = ({ item }) => {
         <Image
           source={{ uri: logoUrl }}
           style={{
-            height: 100,
+            height: tv.size(100),
             width: "80%",
-            marginBottom: 24,
+            marginBottom: tv.spacing.xl,
           }}
           contentFit='contain'
           contentPosition='left'
@@ -62,7 +64,7 @@ export const TVSeriesHeader: React.FC<TVSeriesHeaderProps> = ({ item }) => {
             fontSize: typography.display,
             fontWeight: "bold",
             color: "#FFFFFF",
-            marginBottom: 16,
+            marginBottom: tv.spacing.md,
           }}
           numberOfLines={2}
         >
@@ -76,8 +78,8 @@ export const TVSeriesHeader: React.FC<TVSeriesHeaderProps> = ({ item }) => {
           flexDirection: "row",
           alignItems: "center",
           flexWrap: "wrap",
-          gap: 12,
-          marginBottom: 20,
+          gap: tv.spacing.sm,
+          marginBottom: tv.spacing.lg,
         }}
       >
         {yearString && (
@@ -92,14 +94,16 @@ export const TVSeriesHeader: React.FC<TVSeriesHeaderProps> = ({ item }) => {
           <Badge
             text={item.CommunityRating.toFixed(1)}
             variant='gray'
-            iconLeft={<Ionicons name='star' size={16} color='gold' />}
+            iconLeft={
+              <Ionicons name='star' size={tv.spacing.md} color='gold' />
+            }
           />
         )}
       </View>
 
       {/* Genres */}
       {item.Genres && item.Genres.length > 0 && (
-        <View style={{ marginBottom: 24 }}>
+        <View style={{ marginBottom: tv.spacing.xl }}>
           <GenreTags genres={item.Genres} />
         </View>
       )}
@@ -110,7 +114,7 @@ export const TVSeriesHeader: React.FC<TVSeriesHeaderProps> = ({ item }) => {
           intensity={10}
           tint='light'
           style={{
-            borderRadius: 8,
+            borderRadius: tv.radius.sm,
             overflow: "hidden",
             maxWidth: SCREEN_WIDTH * 0.45,
             alignSelf: "flex-start",
@@ -118,7 +122,7 @@ export const TVSeriesHeader: React.FC<TVSeriesHeaderProps> = ({ item }) => {
         >
           <View
             style={{
-              padding: 16,
+              padding: tv.spacing.md,
               backgroundColor: "rgba(0,0,0,0.3)",
             }}
           >
@@ -126,7 +130,7 @@ export const TVSeriesHeader: React.FC<TVSeriesHeaderProps> = ({ item }) => {
               style={{
                 fontSize: typography.body,
                 color: "#E5E7EB",
-                lineHeight: 32,
+                lineHeight: tv.size(32),
               }}
               numberOfLines={4}
             >

--- a/components/series/TVSeriesPage.tsx
+++ b/components/series/TVSeriesPage.tsx
@@ -30,6 +30,7 @@ import { seasonIndexAtom } from "@/components/series/SeasonPicker";
 import { TVEpisodeList } from "@/components/series/TVEpisodeList";
 import { TVSeriesHeader } from "@/components/series/TVSeriesHeader";
 import { TVFavoriteButton } from "@/components/tv/TVFavoriteButton";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import useRouter from "@/hooks/useAppRouter";
 import { useTVItemActionModal } from "@/hooks/useTVItemActionModal";
@@ -46,10 +47,7 @@ import {
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
 
-const HORIZONTAL_PADDING = 80;
-const TOP_PADDING = 140;
 const POSTER_WIDTH_PERCENT = 0.22;
-const SCALE_PADDING = 20;
 
 interface TVSeriesPageProps {
   item: BaseItemDto;
@@ -73,6 +71,7 @@ const TVFocusableButton: React.FC<{
   variant = "primary",
   refSetter,
 }) => {
+  const tv = useTVDesignTokens();
   const [focused, setFocused] = useState(false);
   const scale = useRef(new Animated.Value(1)).current;
 
@@ -109,7 +108,7 @@ const TVFocusableButton: React.FC<{
             shadowColor: isPrimary ? "#fff" : "#a855f7",
             shadowOffset: { width: 0, height: 0 },
             shadowOpacity: focused ? 0.6 : 0,
-            shadowRadius: focused ? 20 : 0,
+            shadowRadius: focused ? tv.shadow.xl : 0,
           },
         ]}
       >
@@ -122,13 +121,13 @@ const TVFocusableButton: React.FC<{
               : isPrimary
                 ? "rgba(255, 255, 255, 0.9)"
                 : "rgba(124, 58, 237, 0.8)",
-            borderRadius: 12,
-            paddingVertical: 18,
-            paddingHorizontal: 32,
+            borderRadius: tv.radius.md,
+            paddingVertical: tv.button.paddingVertical,
+            paddingHorizontal: tv.button.paddingHorizontal,
             flexDirection: "row",
             alignItems: "center",
             justifyContent: "center",
-            minWidth: 180,
+            minWidth: tv.button.minWidth,
           }}
         >
           {children}
@@ -145,6 +144,7 @@ const TVSeasonButton: React.FC<{
   disabled?: boolean;
 }> = ({ seasonName, onPress, disabled = false }) => {
   const typography = useScaledTVTypography();
+  const tv = useTVDesignTokens();
   const [focused, setFocused] = useState(false);
   const scale = useRef(new Animated.Value(1)).current;
 
@@ -176,19 +176,19 @@ const TVSeasonButton: React.FC<{
           shadowColor: "#fff",
           shadowOffset: { width: 0, height: 0 },
           shadowOpacity: focused ? 0.6 : 0,
-          shadowRadius: focused ? 20 : 0,
+          shadowRadius: focused ? tv.shadow.xl : 0,
         }}
       >
         <View
           style={{
             backgroundColor: focused ? "#fff" : "rgba(255,255,255,0.1)",
-            borderRadius: 12,
-            paddingVertical: 18,
-            paddingHorizontal: 32,
+            borderRadius: tv.radius.md,
+            paddingVertical: tv.button.paddingVertical,
+            paddingHorizontal: tv.button.paddingHorizontal,
             flexDirection: "row",
             alignItems: "center",
             justifyContent: "center",
-            gap: 10,
+            gap: tv.spacing.xs,
           }}
         >
           <Text
@@ -202,7 +202,7 @@ const TVSeasonButton: React.FC<{
           </Text>
           <Ionicons
             name='chevron-down'
-            size={28}
+            size={tv.size(28)}
             color={focused ? "#000" : "#FFFFFF"}
           />
         </View>
@@ -217,6 +217,7 @@ export const TVSeriesPage: React.FC<TVSeriesPageProps> = ({
   isLoading: _isLoading,
 }) => {
   const typography = useScaledTVTypography();
+  const tv = useTVDesignTokens();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const router = useRouter();
@@ -498,9 +499,9 @@ export const TVSeriesPage: React.FC<TVSeriesPageProps> = ({
         ref={mainScrollRef}
         style={{ flex: 1 }}
         contentContainerStyle={{
-          paddingTop: insets.top + TOP_PADDING,
-          paddingHorizontal: insets.left + HORIZONTAL_PADDING,
-          paddingBottom: insets.bottom + 60,
+          paddingTop: insets.top + tv.page.top,
+          paddingHorizontal: insets.left + tv.page.horizontal,
+          paddingBottom: insets.bottom + tv.page.horizontalCompact,
         }}
         showsVerticalScrollIndicator={false}
       >
@@ -519,8 +520,8 @@ export const TVSeriesPage: React.FC<TVSeriesPageProps> = ({
             <View
               style={{
                 flexDirection: "row",
-                gap: 16,
-                marginTop: 32,
+                gap: tv.spacing.md,
+                marginTop: tv.spacing["2xl"],
               }}
             >
               <TVFocusableButton
@@ -532,9 +533,9 @@ export const TVSeriesPage: React.FC<TVSeriesPageProps> = ({
               >
                 <Ionicons
                   name='play'
-                  size={28}
+                  size={tv.size(28)}
                   color='#000000'
-                  style={{ marginRight: 10 }}
+                  style={{ marginRight: tv.spacing.xs }}
                 />
                 <Text
                   style={{
@@ -563,18 +564,18 @@ export const TVSeriesPage: React.FC<TVSeriesPageProps> = ({
           <View
             style={{
               width: SCREEN_WIDTH * POSTER_WIDTH_PERCENT,
-              marginLeft: 50,
+              marginLeft: tv.spacing["4xl"],
             }}
           >
             <View
               style={{
                 aspectRatio: 2 / 3,
-                borderRadius: 16,
+                borderRadius: tv.radius.lg,
                 overflow: "hidden",
                 shadowColor: "#000",
-                shadowOffset: { width: 0, height: 10 },
+                shadowOffset: { width: 0, height: tv.spacing.xs },
                 shadowOpacity: 0.5,
-                shadowRadius: 20,
+                shadowRadius: tv.shadow.xl,
               }}
             >
               <ItemImage
@@ -587,14 +588,14 @@ export const TVSeriesPage: React.FC<TVSeriesPageProps> = ({
         </View>
 
         {/* Episodes section */}
-        <View style={{ marginTop: 40, overflow: "visible" }}>
+        <View style={{ marginTop: tv.spacing["3xl"], overflow: "visible" }}>
           <Text
             style={{
               fontSize: typography.heading,
               fontWeight: "600",
               color: "#FFFFFF",
-              marginBottom: 24,
-              marginLeft: SCALE_PADDING,
+              marginBottom: tv.spacing.xl,
+              marginLeft: tv.page.focusPadding,
             }}
           >
             {selectedSeasonName}
@@ -626,7 +627,7 @@ export const TVSeriesPage: React.FC<TVSeriesPageProps> = ({
             scrollViewRef={episodeListRef}
             firstEpisodeRefSetter={setFirstEpisodeRef}
             emptyText={t("item_card.no_episodes_for_this_season")}
-            horizontalPadding={HORIZONTAL_PADDING}
+            horizontalPadding={tv.page.horizontal}
           />
         </View>
       </ScrollView>

--- a/components/stacks/NestedTabPageStack.tsx
+++ b/components/stacks/NestedTabPageStack.tsx
@@ -10,7 +10,15 @@ type ICommonScreenOptions =
       navigation: any;
     }) => NativeStackNavigationOptions);
 
+export const androidTVFadeScreenOptions: NativeStackNavigationOptions =
+  Platform.OS === "android" && Platform.isTV
+    ? {
+        animation: "fade",
+      }
+    : {};
+
 export const commonScreenOptions: ICommonScreenOptions = {
+  ...androidTVFadeScreenOptions,
   title: "",
   headerShown: !Platform.isTV,
   headerTransparent: Platform.OS === "ios",

--- a/components/tv/TVActorCard.tsx
+++ b/components/tv/TVActorCard.tsx
@@ -3,6 +3,7 @@ import { Image } from "expo-image";
 import React from "react";
 import { Animated, Pressable, View } from "react-native";
 import { Text } from "@/components/common/Text";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import { useTVFocusAnimation } from "./hooks/useTVFocusAnimation";
 
@@ -20,6 +21,7 @@ export interface TVActorCardProps {
 export const TVActorCard = React.forwardRef<View, TVActorCardProps>(
   ({ person, apiBasePath, onPress, hasTVPreferredFocus }, ref) => {
     const typography = useScaledTVTypography();
+    const tv = useTVDesignTokens();
     const { focused, handleFocus, handleBlur, animatedStyle } =
       useTVFocusAnimation();
 
@@ -40,22 +42,22 @@ export const TVActorCard = React.forwardRef<View, TVActorCardProps>(
             animatedStyle,
             {
               alignItems: "center",
-              width: 160,
+              width: tv.size(160),
               shadowColor: "#fff",
               shadowOffset: { width: 0, height: 0 },
               shadowOpacity: focused ? 0.5 : 0,
-              shadowRadius: focused ? 16 : 0,
+              shadowRadius: focused ? tv.spacing.md : 0,
             },
           ]}
         >
           <View
             style={{
-              width: 140,
-              height: 140,
-              borderRadius: 70,
+              width: tv.size(140),
+              height: tv.size(140),
+              borderRadius: tv.size(70),
               overflow: "hidden",
               backgroundColor: "rgba(255,255,255,0.1)",
-              marginBottom: 14,
+              marginBottom: tv.size(14),
               borderWidth: 2,
               borderColor: focused ? "#FFFFFF" : "transparent",
             }}
@@ -76,7 +78,7 @@ export const TVActorCard = React.forwardRef<View, TVActorCardProps>(
               >
                 <Ionicons
                   name='person'
-                  size={56}
+                  size={tv.size(56)}
                   color='rgba(255,255,255,0.4)'
                 />
               </View>
@@ -89,7 +91,7 @@ export const TVActorCard = React.forwardRef<View, TVActorCardProps>(
               fontWeight: "600",
               color: focused ? "#fff" : "rgba(255,255,255,0.9)",
               textAlign: "center",
-              marginBottom: 4,
+              marginBottom: tv.spacing.xxs,
             }}
             numberOfLines={1}
           >

--- a/components/tv/TVBackdrop.tsx
+++ b/components/tv/TVBackdrop.tsx
@@ -1,20 +1,26 @@
 import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
 import { LinearGradient } from "expo-linear-gradient";
 import React from "react";
-import { View } from "react-native";
+import { Platform, View } from "react-native";
 import { ItemImage } from "@/components/common/ItemImage";
+import { ANDROID_TV_SIDEBAR_EXPANDED_WIDTH } from "@/components/navigation/AndroidTVSidebar";
 
 export interface TVBackdropProps {
   item: BaseItemDto;
 }
 
 export const TVBackdrop: React.FC<TVBackdropProps> = React.memo(({ item }) => {
+  const spillLeft =
+    Platform.OS === "android" && Platform.isTV
+      ? ANDROID_TV_SIDEBAR_EXPANDED_WIDTH
+      : 0;
+
   return (
     <View
       style={{
         position: "absolute",
         top: 0,
-        left: 0,
+        left: -spillLeft,
         right: 0,
         bottom: 0,
       }}

--- a/components/tv/TVButton.tsx
+++ b/components/tv/TVButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Animated, Pressable, View, type ViewStyle } from "react-native";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { useTVFocusAnimation } from "./hooks/useTVFocusAnimation";
 
 export interface TVButtonProps {
@@ -64,6 +65,7 @@ export const TVButton: React.FC<TVButtonProps> = ({
   nextFocusDown,
   nextFocusUp,
 }) => {
+  const tv = useTVDesignTokens();
   const { focused, handleFocus, handleBlur, animatedStyle } =
     useTVFocusAnimation({ scaleAmount });
 
@@ -88,7 +90,7 @@ export const TVButton: React.FC<TVButtonProps> = ({
             shadowColor: buttonStyles.shadowColor,
             shadowOffset: { width: 0, height: 0 },
             shadowOpacity: focused ? 0.4 : 0,
-            shadowRadius: focused ? 15 : 0,
+            shadowRadius: focused ? tv.shadow.lg : 0,
           },
           style,
         ]}
@@ -98,13 +100,15 @@ export const TVButton: React.FC<TVButtonProps> = ({
             backgroundColor: buttonStyles.backgroundColor,
             borderWidth: buttonStyles.borderWidth,
             borderColor: buttonStyles.borderColor,
-            borderRadius: 12,
-            paddingVertical: 18,
-            paddingHorizontal: square ? 18 : 32,
+            borderRadius: tv.radius.md,
+            paddingVertical: tv.button.paddingVertical,
+            paddingHorizontal: square
+              ? tv.button.squarePadding
+              : tv.button.paddingHorizontal,
             flexDirection: "row",
             alignItems: "center",
             justifyContent: "center",
-            minWidth: square ? undefined : 180,
+            minWidth: square ? undefined : tv.button.minWidth,
           }}
         >
           {children}

--- a/components/tv/TVCastSection.tsx
+++ b/components/tv/TVCastSection.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { ScrollView, TVFocusGuideView, View } from "react-native";
 import { Text } from "@/components/common/Text";
-import { useScaledTVSizes } from "@/constants/TVSizes";
+import { useScaledTVSizes, useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import { TVActorCard } from "./TVActorCard";
 
@@ -27,6 +27,7 @@ export const TVCastSection: React.FC<TVCastSectionProps> = React.memo(
   }) => {
     const typography = useScaledTVTypography();
     const sizes = useScaledTVSizes();
+    const tv = useTVDesignTokens();
     const { t } = useTranslation();
 
     if (cast.length === 0) {
@@ -34,13 +35,13 @@ export const TVCastSection: React.FC<TVCastSectionProps> = React.memo(
     }
 
     return (
-      <View style={{ marginBottom: 40 }}>
+      <View style={{ marginBottom: tv.spacing["3xl"] }}>
         <Text
           style={{
             fontSize: typography.heading,
             fontWeight: "600",
             color: "#FFFFFF",
-            marginBottom: 24,
+            marginBottom: tv.spacing.xl,
           }}
         >
           {t("item_card.cast")}
@@ -55,10 +56,10 @@ export const TVCastSection: React.FC<TVCastSectionProps> = React.memo(
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
-          style={{ marginHorizontal: -80, overflow: "visible" }}
+          style={{ marginHorizontal: -tv.page.horizontal, overflow: "visible" }}
           contentContainerStyle={{
-            paddingHorizontal: 80,
-            paddingVertical: 16,
+            paddingHorizontal: tv.page.horizontal,
+            paddingVertical: tv.spacing.md,
             gap: sizes.gaps.item,
           }}
         >

--- a/components/tv/TVFavoriteButton.tsx
+++ b/components/tv/TVFavoriteButton.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
 import React from "react";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { useFavorite } from "@/hooks/useFavorite";
 import { TVButton } from "./TVButton";
 
@@ -14,6 +15,7 @@ export const TVFavoriteButton: React.FC<TVFavoriteButtonProps> = ({
   disabled,
 }) => {
   const { isFavorite, toggleFavorite } = useFavorite(item);
+  const tv = useTVDesignTokens();
 
   return (
     <TVButton
@@ -24,7 +26,7 @@ export const TVFavoriteButton: React.FC<TVFavoriteButtonProps> = ({
     >
       <Ionicons
         name={isFavorite ? "heart" : "heart-outline"}
-        size={28}
+        size={tv.size(28)}
         color='#FFFFFF'
       />
     </TVButton>

--- a/components/tv/TVHorizontalList.tsx
+++ b/components/tv/TVHorizontalList.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { FlatList, ScrollView, View } from "react-native";
 import { Text } from "@/components/common/Text";
-import { useScaledTVSizes } from "@/constants/TVSizes";
+import { useScaledTVSizes, useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 
 interface TVHorizontalListProps<T> {
@@ -65,6 +65,7 @@ export function TVHorizontalList<T>({
 }: TVHorizontalListProps<T>) {
   const sizes = useScaledTVSizes();
   const typography = useScaledTVTypography();
+  const tv = useTVDesignTokens();
 
   // Use custom horizontal padding if provided, otherwise use default scale padding
   const effectiveHorizontalPadding = horizontalPadding ?? sizes.padding.scale;
@@ -94,7 +95,7 @@ export function TVHorizontalList<T>({
               fontSize: typography.heading,
               fontWeight: "700",
               color: "#FFFFFF",
-              marginBottom: 20,
+              marginBottom: tv.spacing.lg,
               marginLeft: sizes.padding.scale,
               letterSpacing: 0.5,
             }}
@@ -125,7 +126,7 @@ export function TVHorizontalList<T>({
               fontSize: typography.heading,
               fontWeight: "700",
               color: "#FFFFFF",
-              marginBottom: 20,
+              marginBottom: tv.spacing.lg,
               marginLeft: sizes.padding.scale,
               letterSpacing: 0.5,
             }}
@@ -167,7 +168,7 @@ export function TVHorizontalList<T>({
             fontSize: typography.heading,
             fontWeight: "700",
             color: "#FFFFFF",
-            marginBottom: 20,
+            marginBottom: tv.spacing.lg,
             marginLeft: sizes.padding.scale,
             letterSpacing: 0.5,
           }}

--- a/components/tv/TVMetadataBadges.tsx
+++ b/components/tv/TVMetadataBadges.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { View } from "react-native";
 import { Badge } from "@/components/Badge";
 import { Text } from "@/components/common/Text";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 
 export interface TVMetadataBadgesProps {
@@ -15,6 +16,7 @@ export interface TVMetadataBadgesProps {
 export const TVMetadataBadges: React.FC<TVMetadataBadgesProps> = React.memo(
   ({ year, duration, officialRating, communityRating }) => {
     const typography = useScaledTVTypography();
+    const tv = useTVDesignTokens();
 
     return (
       <View
@@ -22,8 +24,8 @@ export const TVMetadataBadges: React.FC<TVMetadataBadgesProps> = React.memo(
           flexDirection: "row",
           alignItems: "center",
           flexWrap: "wrap",
-          gap: 16,
-          marginBottom: 24,
+          gap: tv.spacing.md,
+          marginBottom: tv.spacing.xl,
         }}
       >
         {year != null && (
@@ -41,7 +43,9 @@ export const TVMetadataBadges: React.FC<TVMetadataBadgesProps> = React.memo(
           <Badge
             text={communityRating.toFixed(1)}
             variant='gray'
-            iconLeft={<Ionicons name='star' size={16} color='gold' />}
+            iconLeft={
+              <Ionicons name='star' size={tv.spacing.md} color='gold' />
+            }
           />
         )}
       </View>

--- a/components/tv/TVOptionButton.tsx
+++ b/components/tv/TVOptionButton.tsx
@@ -2,6 +2,7 @@ import { BlurView } from "expo-blur";
 import React from "react";
 import { Animated, Pressable, View } from "react-native";
 import { Text } from "@/components/common/Text";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import { useTVFocusAnimation } from "./hooks/useTVFocusAnimation";
 
@@ -16,6 +17,7 @@ export interface TVOptionButtonProps {
 export const TVOptionButton = React.forwardRef<View, TVOptionButtonProps>(
   ({ label, value, onPress, hasTVPreferredFocus, maxWidth }, ref) => {
     const typography = useScaledTVTypography();
+    const tv = useTVDesignTokens();
     const { focused, handleFocus, handleBlur, animatedStyle } =
       useTVFocusAnimation({ scaleAmount: 1.02, duration: 120 });
 
@@ -34,7 +36,7 @@ export const TVOptionButton = React.forwardRef<View, TVOptionButtonProps>(
               shadowColor: "#fff",
               shadowOffset: { width: 0, height: 0 },
               shadowOpacity: focused ? 0.4 : 0,
-              shadowRadius: focused ? 12 : 0,
+              shadowRadius: focused ? tv.shadow.md : 0,
             },
           ]}
         >
@@ -42,12 +44,12 @@ export const TVOptionButton = React.forwardRef<View, TVOptionButtonProps>(
             <View
               style={{
                 backgroundColor: "#fff",
-                borderRadius: 8,
-                paddingVertical: 10,
-                paddingHorizontal: 16,
+                borderRadius: tv.radius.sm,
+                paddingVertical: tv.spacing.xs,
+                paddingHorizontal: tv.spacing.md,
                 flexDirection: "row",
                 alignItems: "center",
-                gap: 8,
+                gap: tv.spacing.xs,
                 maxWidth,
               }}
             >
@@ -77,7 +79,7 @@ export const TVOptionButton = React.forwardRef<View, TVOptionButtonProps>(
               intensity={10}
               tint='light'
               style={{
-                borderRadius: 8,
+                borderRadius: tv.radius.sm,
                 overflow: "hidden",
                 maxWidth,
               }}
@@ -85,11 +87,11 @@ export const TVOptionButton = React.forwardRef<View, TVOptionButtonProps>(
               <View
                 style={{
                   backgroundColor: "rgba(0,0,0,0.3)",
-                  paddingVertical: 10,
-                  paddingHorizontal: 16,
+                  paddingVertical: tv.spacing.xs,
+                  paddingHorizontal: tv.spacing.md,
                   flexDirection: "row",
                   alignItems: "center",
-                  gap: 8,
+                  gap: tv.spacing.xs,
                 }}
               >
                 <Text

--- a/components/tv/TVPlayedButton.tsx
+++ b/components/tv/TVPlayedButton.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
 import React from "react";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { useMarkAsPlayed } from "@/hooks/useMarkAsPlayed";
 import { TVButton } from "./TVButton";
 
@@ -15,6 +16,7 @@ export const TVPlayedButton: React.FC<TVPlayedButtonProps> = ({
 }) => {
   const isPlayed = item.UserData?.Played ?? false;
   const toggle = useMarkAsPlayed([item]);
+  const tv = useTVDesignTokens();
 
   return (
     <TVButton
@@ -25,7 +27,7 @@ export const TVPlayedButton: React.FC<TVPlayedButtonProps> = ({
     >
       <Ionicons
         name={isPlayed ? "checkmark-circle" : "checkmark-circle-outline"}
-        size={28}
+        size={tv.size(28)}
         color='#FFFFFF'
       />
     </TVButton>

--- a/components/tv/TVPosterCard.tsx
+++ b/components/tv/TVPosterCard.tsx
@@ -14,6 +14,7 @@ import { ProgressBar } from "@/components/common/ProgressBar";
 import { Text } from "@/components/common/Text";
 import { WatchedIndicator } from "@/components/WatchedIndicator";
 import { useScaledTVPosterSizes } from "@/constants/TVPosterSizes";
+import { useTVViewportScale } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import {
   GlassPosterView,
@@ -108,6 +109,9 @@ export const TVPosterCard: React.FC<TVPosterCardProps> = ({
   const api = useAtomValue(apiAtom);
   const posterSizes = useScaledTVPosterSizes();
   const typography = useScaledTVTypography();
+  const viewportScale = useTVViewportScale();
+  const scaleValue = (value: number) => Math.round(value * viewportScale);
+  const posterRadius = scaleValue(24);
 
   const [focused, setFocused] = useState(false);
   const scale = useRef(new Animated.Value(1)).current;
@@ -344,23 +348,23 @@ export const TVPosterCard: React.FC<TVPosterCardProps> = ({
     <View
       style={{
         position: "absolute",
-        top: 12,
-        left: 12,
+        top: scaleValue(12),
+        left: scaleValue(12),
         backgroundColor: "#FFFFFF",
-        borderRadius: 8,
+        borderRadius: scaleValue(8),
         flexDirection: "row",
         alignItems: "center",
-        paddingHorizontal: 12,
-        paddingVertical: 8,
-        gap: 6,
+        paddingHorizontal: scaleValue(12),
+        paddingVertical: scaleValue(8),
+        gap: scaleValue(6),
         zIndex: 10,
       }}
     >
-      <Ionicons name='play' size={16} color='#000000' />
+      <Ionicons name='play' size={scaleValue(16)} color='#000000' />
       <Text
         style={{
           color: "#000000",
-          fontSize: 14,
+          fontSize: scaleValue(14),
           fontWeight: "700",
         }}
       >
@@ -382,7 +386,7 @@ export const TVPosterCard: React.FC<TVPosterCardProps> = ({
         justifyContent: "center",
       }}
     >
-      <Ionicons name='play-circle' size={56} color='white' />
+      <Ionicons name='play-circle' size={scaleValue(56)} color='white' />
     </View>
   ) : null;
 
@@ -395,7 +399,7 @@ export const TVPosterCard: React.FC<TVPosterCardProps> = ({
           style={{
             width,
             aspectRatio,
-            borderRadius: 24,
+            borderRadius: posterRadius,
             backgroundColor: "#1a1a1a",
             borderWidth: 2,
             borderColor: focused ? "#FFFFFF" : "transparent",
@@ -411,7 +415,7 @@ export const TVPosterCard: React.FC<TVPosterCardProps> = ({
           <GlassPosterView
             imageUrl={imageUrl}
             aspectRatio={aspectRatio}
-            cornerRadius={24}
+            cornerRadius={posterRadius}
             progress={progress}
             showWatchedIndicator={isWatched}
             isFocused={focused}
@@ -431,7 +435,7 @@ export const TVPosterCard: React.FC<TVPosterCardProps> = ({
           position: "relative",
           width,
           aspectRatio,
-          borderRadius: 24,
+          borderRadius: posterRadius,
           overflow: "hidden",
           backgroundColor: "#1a1a1a",
           borderWidth: 2,

--- a/components/tv/TVRefreshButton.tsx
+++ b/components/tv/TVRefreshButton.tsx
@@ -2,6 +2,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Animated, Easing } from "react-native";
+import { useTVDesignTokens } from "@/constants/TVSizes";
 import { TVButton } from "./TVButton";
 
 export interface TVRefreshButtonProps {
@@ -17,6 +18,7 @@ export const TVRefreshButton: React.FC<TVRefreshButtonProps> = ({
   const queryClient = externalQueryClient ?? defaultQueryClient;
   const [isRefreshing, setIsRefreshing] = useState(false);
   const spinValue = useRef(new Animated.Value(0)).current;
+  const tv = useTVDesignTokens();
 
   useEffect(() => {
     if (isRefreshing) {
@@ -63,7 +65,7 @@ export const TVRefreshButton: React.FC<TVRefreshButtonProps> = ({
       disabled={isRefreshing}
     >
       <Animated.View style={{ transform: [{ rotate: spin }] }}>
-        <Ionicons name='refresh' size={28} color='#FFFFFF' />
+        <Ionicons name='refresh' size={tv.size(28)} color='#FFFFFF' />
       </Animated.View>
     </TVButton>
   );

--- a/components/tv/TVSeriesSeasonCard.tsx
+++ b/components/tv/TVSeriesSeasonCard.tsx
@@ -3,7 +3,7 @@ import { Image } from "expo-image";
 import React, { useRef, useState } from "react";
 import { Animated, Easing, Platform, Pressable, View } from "react-native";
 import { Text } from "@/components/common/Text";
-import { useScaledTVSizes } from "@/constants/TVSizes";
+import { useScaledTVSizes, useTVDesignTokens } from "@/constants/TVSizes";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import {
   GlassPosterView,
@@ -30,6 +30,7 @@ export const TVSeriesSeasonCard: React.FC<TVSeriesSeasonCardProps> = ({
 }) => {
   const typography = useScaledTVTypography();
   const sizes = useScaledTVSizes();
+  const tv = useTVDesignTokens();
   const [focused, setFocused] = useState(false);
 
   // Check if glass effect is available (tvOS 26+)
@@ -51,7 +52,7 @@ export const TVSeriesSeasonCard: React.FC<TVSeriesSeasonCardProps> = ({
         <GlassPosterView
           imageUrl={imageUrl}
           aspectRatio={10 / 15}
-          cornerRadius={24}
+          cornerRadius={tv.radius.xl}
           progress={0}
           showWatchedIndicator={false}
           isFocused={focused}
@@ -66,7 +67,7 @@ export const TVSeriesSeasonCard: React.FC<TVSeriesSeasonCardProps> = ({
         style={{
           width: sizes.posters.poster,
           aspectRatio: 10 / 15,
-          borderRadius: 24,
+          borderRadius: tv.radius.xl,
           overflow: "hidden",
           backgroundColor: "rgba(255,255,255,0.1)",
           borderWidth: 2,
@@ -87,7 +88,11 @@ export const TVSeriesSeasonCard: React.FC<TVSeriesSeasonCardProps> = ({
               alignItems: "center",
             }}
           >
-            <Ionicons name='film' size={56} color='rgba(255,255,255,0.4)' />
+            <Ionicons
+              name='film'
+              size={tv.size(56)}
+              color='rgba(255,255,255,0.4)'
+            />
           </View>
         )}
       </View>
@@ -122,14 +127,14 @@ export const TVSeriesSeasonCard: React.FC<TVSeriesSeasonCardProps> = ({
             shadowColor: useGlass ? undefined : "#ffffff",
             shadowOffset: useGlass ? undefined : { width: 0, height: 0 },
             shadowOpacity: useGlass ? undefined : focused ? 0.3 : 0,
-            shadowRadius: useGlass ? undefined : focused ? 12 : 0,
+            shadowRadius: useGlass ? undefined : focused ? tv.shadow.md : 0,
           }}
         >
           {renderPoster()}
         </Animated.View>
       </Pressable>
 
-      <View style={{ marginTop: 12 }}>
+      <View style={{ marginTop: tv.spacing.sm }}>
         <Text
           style={{
             fontSize: typography.body,
@@ -145,7 +150,7 @@ export const TVSeriesSeasonCard: React.FC<TVSeriesSeasonCardProps> = ({
             style={{
               fontSize: typography.callout,
               color: "#9CA3AF",
-              marginTop: 4,
+              marginTop: tv.spacing.xxs,
             }}
             numberOfLines={1}
           >

--- a/constants/TVSizes.ts
+++ b/constants/TVSizes.ts
@@ -1,4 +1,78 @@
+import { useMemo } from "react";
+import { Platform, useWindowDimensions } from "react-native";
 import { TVTypographyScale, useSettings } from "@/utils/atoms/settings";
+
+const TV_BASELINE_WIDTH = 1920;
+const MIN_TV_VIEWPORT_SCALE = 0.5;
+
+/**
+ * Normalizes TV layout values across platforms.
+ *
+ * tvOS reports a 1920-wide logical viewport on common TV targets, while
+ * Android TV often reports density-independent widths such as 960 for a
+ * 1080p display. Scaling against a 1920 baseline keeps the UI from appearing
+ * oversized on Android TV while preserving the current tvOS sizing.
+ */
+export const useTVViewportScale = () => {
+  const { width } = useWindowDimensions();
+
+  return useMemo(() => {
+    if (!Platform.isTV || width <= 0) return 1;
+
+    return Math.min(
+      1,
+      Math.max(MIN_TV_VIEWPORT_SCALE, width / TV_BASELINE_WIDTH),
+    );
+  }, [width]);
+};
+
+export const useTVDesignTokens = () => {
+  const scale = useTVViewportScale();
+  const scaled = (value: number) => Math.round(value * scale);
+
+  return useMemo(
+    () => ({
+      scale,
+      size: scaled,
+      spacing: {
+        xxs: scaled(4),
+        xs: scaled(8),
+        sm: scaled(12),
+        md: scaled(16),
+        lg: scaled(20),
+        xl: scaled(24),
+        "2xl": scaled(32),
+        "3xl": scaled(40),
+        "4xl": scaled(48),
+      },
+      radius: {
+        sm: scaled(8),
+        md: scaled(12),
+        lg: scaled(16),
+        xl: scaled(24),
+      },
+      page: {
+        horizontal: scaled(80),
+        horizontalCompact: scaled(60),
+        top: scaled(140),
+        topCompact: scaled(100),
+        focusPadding: scaled(20),
+      },
+      shadow: {
+        md: scaled(12),
+        lg: scaled(15),
+        xl: scaled(20),
+      },
+      button: {
+        paddingVertical: scaled(18),
+        paddingHorizontal: scaled(32),
+        squarePadding: scaled(18),
+        minWidth: scaled(180),
+      },
+    }),
+    [scale],
+  );
+};
 
 /**
  * TV Layout Sizes
@@ -123,9 +197,11 @@ export type ScaledTVSizes = {
  */
 export const useScaledTVSizes = (): ScaledTVSizes => {
   const { settings } = useSettings();
-  const scale =
+  const viewportScale = useTVViewportScale();
+  const userScale =
     sizeScaleMultipliers[settings.tvTypographyScale] ??
     sizeScaleMultipliers[TVTypographyScale.Default];
+  const scale = userScale * viewportScale;
 
   return {
     posters: {
@@ -143,7 +219,7 @@ export const useScaledTVSizes = (): ScaledTVSizes => {
       horizontal: Math.round(TVPadding.horizontal * scale),
       scale: Math.round(TVPadding.scale * scale),
       vertical: Math.round(TVPadding.vertical * scale),
-      heroHeight: TVPadding.heroHeight * scale,
+      heroHeight: TVPadding.heroHeight * userScale,
     },
     animation: TVAnimation,
   };

--- a/constants/TVTypography.ts
+++ b/constants/TVTypography.ts
@@ -1,4 +1,5 @@
 import { TVTypographyScale, useSettings } from "@/utils/atoms/settings";
+import { useTVViewportScale } from "./TVSizes";
 
 /**
  * TV Typography Scale
@@ -39,9 +40,11 @@ const scaleMultipliers: Record<TVTypographyScale, number> = {
  */
 export const useScaledTVTypography = () => {
   const { settings } = useSettings();
-  const scale =
+  const viewportScale = useTVViewportScale();
+  const userScale =
     scaleMultipliers[settings.tvTypographyScale] ??
     scaleMultipliers[TVTypographyScale.Default];
+  const scale = userScale * viewportScale;
 
   return {
     display: Math.round(TVTypography.display * scale),


### PR DESCRIPTION
# 📦 **_DRAFT_** Pull Request 

## 🔖 Summary

Adds Android TV specific navigation and layout improvements for the TV interface.

This PR introduces a collapsible Android TV sidebar, hides the native tab bar on Android TV, applies smoother fade transitions across TV stacks, and improves layout scaling so the TV UI renders more consistently across Android TV and tvOS viewport sizes.

> **Note:** Marking this as a draft for now since it introduces a new TV design token system and Android TV sidebar. I’d like to confirm the direction looks okay before continuing and migrating more components to the token system.

## 🏷️ Ticket / Issue

## 🛠️ What’s Changed

- Type: feat
- Scope: tv
- Short summary: Adds Android TV sidebar navigation and responsive TV layout scaling to improve focus navigation, spacing, typography, and screen transitions on TV devices.

## 📋 Details
_Generated by Codex_
### Android TV sidebar navigation

- Adds a new `AndroidTVSidebar` component for Android TV.
- Displays the main app routes in a left sidebar
- Expands the sidebar when focused and collapses it after focus leaves.
- Hides the native tab bar on Android TV while keeping the existing native tabs for other platforms.

### TV stack transition improvements

- Adds shared `androidTVFadeScreenOptions`.
- Applies Android TV fade transitions to the root stack and nested tab stacks.


### Responsive TV layout scaling

- Adds viewport aware TV scaling via `useTVViewportScale`.
- Adds reusable TV design tokens via `useTVDesignTokens`.
- Updates TV typography scaling to account for Android TV viewport differences.
- Keeps tvOS sizing behaviour intact while preventing Android TV layouts from appearing oversized.
- Replaces hardcoded spacing, padding, radius, shadow, icon, and button sizes with scaled values across TV components.

### Updated TV screens and components

- Home screen spacing and section gaps now scale based on TV size settings.
- Favorites empty state and list padding now use scaled TV tokens.
- Item detail page now uses scaled padding, logo sizing, card radius, button spacing, shadows, metadata spacing, and season section spacing.
- Hero carousel now scales card radius, shadows, icons, content positioning, carousel padding, and metadata spacing.
- Horizontal lists and Streamystats sections now account for focus scale padding without relying on fixed content insets.
- TV buttons, metadata badges, option buttons, refresh/favorite/played buttons, backdrop, cast section, actor cards, poster cards, and series pages now use scaled TV layout values.

### ⚠️ Breaking Changes


### 🔐 Security & Privacy Impact


### ⚡ Performance Impact

Low expected impact.

The sidebar adds a small animated width transition on Android TV only. Layout scaling uses memoized viewport based values and replaces fixed dimensions with computed design tokens. No new network requests, persistence changes, or API changes are introduced.

### 🖼️ Screenshots / GIFs (if UI)

https://github.com/user-attachments/assets/0aeccf6d-e647-42c1-b06a-8f9a80303601


### 🤖 AI Disclaimer
Codex used


## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [x] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [x] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions

1. Run the app on an Android TV emulator or physical Android TV device.
2. Confirm the native bottom tab bar is hidden on Android TV.
3. Confirm the custom sidebar appears on the left.
4. Move focus onto the sidebar.
   - Sidebar should expand.
   - Focused item should animate.
   - Active route should be highlighted.
5. Navigate between Home, Search, Favorites, Libraries, Watchlists, Custom Links, and Settings.
6. Confirm focus returns to the page content after navigation.
7. Open item detail pages and confirm spacing, text, logo, buttons, metadata, and poster artwork are scaled correctly.
8. Scroll horizontal lists and confirm focused cards are not clipped.
9. Check the same screens on tvOS or non Android TV targets to confirm existing tab/navigation behaviour is unchanged.
10. Check logs for runtime warnings or focus/navigation errors.

## ⚙️ Deployment Notes
This changes TV UI behaviour only.

## 📝 Additional Notes
https://github.com/react-native-tvos/react-native-tvos/issues/57
More info on RN-tvos scaling issue