### PR TITLE
fix(tvOS): Patches for udp and screens menu button handling

### DIFF
--- a/bun-patches/react-native-screens@4.18.0.patch
+++ b/bun-patches/react-native-screens@4.18.0.patch
@@ -1,0 +1,87 @@
+diff --git a/ios/RNSScreenStack.mm b/ios/RNSScreenStack.mm
+index 47a671928338ae7fb4f85532d9fd1ed2d594f823..e4eecb7d5f9d3c3afc8a090fb953010e4e1b8a08 100644
+--- a/ios/RNSScreenStack.mm
++++ b/ios/RNSScreenStack.mm
+@@ -34,6 +34,11 @@
+ #import "integrations/RNSDismissibleModalProtocol.h"
+ #import "utils/UINavigationBar+RNSUtility.h"
+ 
++#if TARGET_OS_TV
++#import <React/RCTTVNavigationEventNotification.h>
++#import <React/RCTTVRemoteHandler.h>
++#endif // TARGET_OS_TV
++
+ #ifdef RNS_GAMMA_ENABLED
+ #import "RNSFrameCorrectionProvider.h"
+ #import "Swift-Bridging.h"
+@@ -43,6 +48,12 @@
+ namespace react = facebook::react;
+ #endif // RCT_NEW_ARCH_ENABLED
+ 
++#if TARGET_OS_TV
++@interface RNSNavigationController ()
++@property (nonatomic, strong) UITapGestureRecognizer *rnscreens_menuGestureRecognizer;
++@end
++#endif // TARGET_OS_TV
++
+ @interface RNSScreenStackView () <
+     UINavigationControllerDelegate,
+     UIAdaptivePresentationControllerDelegate,
+@@ -61,6 +72,57 @@
+ @end
+ 
+ @implementation RNSNavigationController
++
++#if TARGET_OS_TV
++- (void)viewDidLoad
++{
++  [super viewDidLoad];
++
++  self.rnscreens_menuGestureRecognizer =
++      [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(rnscreens_menuPressed:)];
++  self.rnscreens_menuGestureRecognizer.allowedPressTypes = @[ @(UIPressTypeMenu) ];
++
++  [[NSNotificationCenter defaultCenter] addObserver:self
++                                           selector:@selector(rnscreens_enableMenuGesture)
++                                               name:RCTTVEnableMenuKeyNotification
++                                             object:nil];
++  [[NSNotificationCenter defaultCenter] addObserver:self
++                                           selector:@selector(rnscreens_disableMenuGesture)
++                                               name:RCTTVDisableMenuKeyNotification
++                                             object:nil];
++
++  if ([RCTTVRemoteHandler useMenuKey]) {
++    [self rnscreens_enableMenuGesture];
++  }
++}
++
++- (void)dealloc
++{
++  [[NSNotificationCenter defaultCenter] removeObserver:self];
++}
++
++- (void)rnscreens_enableMenuGesture
++{
++  if (![self.view.gestureRecognizers containsObject:self.rnscreens_menuGestureRecognizer]) {
++    [self.view addGestureRecognizer:self.rnscreens_menuGestureRecognizer];
++  }
++}
++
++- (void)rnscreens_disableMenuGesture
++{
++  if ([self.view.gestureRecognizers containsObject:self.rnscreens_menuGestureRecognizer]) {
++    [self.view removeGestureRecognizer:self.rnscreens_menuGestureRecognizer];
++  }
++}
++
++- (void)rnscreens_menuPressed:(UIGestureRecognizer *)recognizer
++{
++  [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventMenu
++                                                               keyAction:recognizer.eventKeyAction
++                                                                     tag:nil
++                                                                  target:nil];
++}
++#endif // TARGET_OS_TV
+ 
+ #if !TARGET_OS_TV
+ - (UIViewController *)childViewControllerForStatusBarStyle

--- a/bun-patches/react-native-udp@4.1.7.patch
+++ b/bun-patches/react-native-udp@4.1.7.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/react-native-udp/.bun-tag-ea7df8754aa4db91 b/.bun-tag-ea7df8754aa4db91
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/react-native-udp.podspec b/react-native-udp.podspec
+index 7450cc7d0862aadfb47d796929c801a3dc423a57..fa3e42c0152ef2d87536b8c2e484f64d525e35ec 100644
+--- a/react-native-udp.podspec
++++ b/react-native-udp.podspec
+@@ -9,7 +9,8 @@ Pod::Spec.new do |s|
+   s.homepage       = package_json["homepage"]
+   s.license        = package_json["license"]
+   s.author         = { package_json["author"] => package_json["author"] }
+-  s.platform       = :ios, "7.0"
++  s.ios.deployment_target = "7.0"
++  s.tvos.deployment_target = "15.1"
+   s.source         = { :git => package_json["repository"]["url"], :tag => "v#{s.version}" }
+   s.source_files   = 'ios/**/*.{h,m}'
+   s.dependency 'React-Core'

--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "react-native-udp@4.1.7": "bun-patches/react-native-udp@4.1.7.patch",
+  },
   "overrides": {
     "expo-constants": "18.0.13",
   },

--- a/bun.lock
+++ b/bun.lock
@@ -116,6 +116,7 @@
     },
   },
   "patchedDependencies": {
+    "react-native-screens@4.18.0": "bun-patches/react-native-screens@4.18.0.patch",
     "react-native-udp@4.1.7": "bun-patches/react-native-udp@4.1.7.patch",
   },
   "overrides": {

--- a/components/companion/CompanionLoginScreen.tsx
+++ b/components/companion/CompanionLoginScreen.tsx
@@ -31,21 +31,24 @@ interface ParsedPairingCode {
 
 type ExpoCameraModule = typeof import("expo-camera");
 
+const ExpoCamera: ExpoCameraModule | null = Platform.isTV
+  ? null
+  : require("expo-camera");
+
 export const CompanionLoginScreen: React.FC = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const [api] = useAtom(apiAtom);
   const [user] = useAtom(userAtom);
 
-  const [screenState, setScreenState] = useState<ScreenState>("scanning");
+  const [screenState, setScreenState] = useState<ScreenState>(
+    Platform.isTV ? "form" : "scanning",
+  );
   const [pairingCode, setPairingCode] = useState<string>("");
   const [serverUrl, setServerUrl] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [cameraModule, setCameraModule] = useState<ExpoCameraModule | null>(
-    null,
-  );
 
   // Pre-fill server URL and username from current session
   useEffect(() => {
@@ -58,30 +61,20 @@ export const CompanionLoginScreen: React.FC = () => {
     }
   }, [api?.basePath, user?.Name]);
 
-  // Load camera module only on devices that include it in the native build.
-  useEffect(() => {
-    if (Platform.isTV) {
-      setScreenState("form");
-      return;
-    }
-
-    import("expo-camera").then(setCameraModule);
-  }, []);
-
   // Request camera permission
   useEffect(() => {
-    if (!cameraModule) return;
+    if (!ExpoCamera) return;
 
-    cameraModule.Camera.getCameraPermissionsAsync().then((response) => {
+    ExpoCamera.Camera.getCameraPermissionsAsync().then((response) => {
       if (!response.granted) {
-        cameraModule.Camera.requestCameraPermissionsAsync().then((result) => {
+        ExpoCamera.Camera.requestCameraPermissionsAsync().then((result) => {
           if (!result.granted) {
             setScreenState("no-permission");
           }
         });
       }
     });
-  }, [cameraModule]);
+  }, []);
 
   const validateAndParseQR = useCallback(
     (data: string): ParsedPairingCode | null => {
@@ -481,7 +474,7 @@ export const CompanionLoginScreen: React.FC = () => {
     );
   }
 
-  const CameraView = cameraModule?.CameraView;
+  const CameraView = ExpoCamera?.CameraView;
 
   if (!CameraView) {
     return (

--- a/components/companion/CompanionLoginScreen.tsx
+++ b/components/companion/CompanionLoginScreen.tsx
@@ -1,4 +1,3 @@
-import { Camera, CameraView } from "expo-camera";
 import { useAtom } from "jotai";
 import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -30,6 +29,8 @@ interface ParsedPairingCode {
   code: string;
 }
 
+type ExpoCameraModule = typeof import("expo-camera");
+
 export const CompanionLoginScreen: React.FC = () => {
   const { t } = useTranslation();
   const router = useRouter();
@@ -42,6 +43,9 @@ export const CompanionLoginScreen: React.FC = () => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [cameraModule, setCameraModule] = useState<ExpoCameraModule | null>(
+    null,
+  );
 
   // Pre-fill server URL and username from current session
   useEffect(() => {
@@ -54,18 +58,30 @@ export const CompanionLoginScreen: React.FC = () => {
     }
   }, [api?.basePath, user?.Name]);
 
+  // Load camera module only on devices that include it in the native build.
+  useEffect(() => {
+    if (Platform.isTV) {
+      setScreenState("form");
+      return;
+    }
+
+    import("expo-camera").then(setCameraModule);
+  }, []);
+
   // Request camera permission
   useEffect(() => {
-    Camera.getCameraPermissionsAsync().then((response) => {
+    if (!cameraModule) return;
+
+    cameraModule.Camera.getCameraPermissionsAsync().then((response) => {
       if (!response.granted) {
-        Camera.requestCameraPermissionsAsync().then((result) => {
+        cameraModule.Camera.requestCameraPermissionsAsync().then((result) => {
           if (!result.granted) {
             setScreenState("no-permission");
           }
         });
       }
     });
-  }, []);
+  }, [cameraModule]);
 
   const validateAndParseQR = useCallback(
     (data: string): ParsedPairingCode | null => {
@@ -462,6 +478,22 @@ export const CompanionLoginScreen: React.FC = () => {
           </View>
         </ScrollView>
       </KeyboardAvoidingView>
+    );
+  }
+
+  const CameraView = cameraModule?.CameraView;
+
+  if (!CameraView) {
+    return (
+      <View className='flex-1 bg-black items-center justify-center p-8'>
+        <Button
+          onPress={handleEnterCodeManually}
+          color='purple'
+          textClassName='flex-1 text-center'
+        >
+          {t("companion_login.enter_code_manually")}
+        </Button>
+      </View>
     );
   }
 

--- a/components/login/TVAddServerForm.tsx
+++ b/components/login/TVAddServerForm.tsx
@@ -1,18 +1,10 @@
-import { Ionicons } from "@expo/vector-icons";
 import { t } from "i18next";
-import React, { useEffect, useRef, useState } from "react";
-import {
-  Animated,
-  BackHandler,
-  Easing,
-  Platform,
-  Pressable,
-  ScrollView,
-  View,
-} from "react-native";
+import React, { useCallback, useState } from "react";
+import { ScrollView, View } from "react-native";
 import { Button } from "@/components/Button";
 import { Text } from "@/components/common/Text";
 import { useScaledTVTypography } from "@/constants/TVTypography";
+import { useTVBackPress } from "@/hooks/useTVBackPress";
 import { TVInput } from "./TVInput";
 
 interface TVAddServerFormProps {
@@ -22,68 +14,6 @@ interface TVAddServerFormProps {
   loading?: boolean;
   disabled?: boolean;
 }
-
-const TVBackButton: React.FC<{
-  onPress: () => void;
-  label: string;
-  disabled?: boolean;
-}> = ({ onPress, label, disabled = false }) => {
-  const [isFocused, setIsFocused] = useState(false);
-  const scale = useRef(new Animated.Value(1)).current;
-
-  const animateFocus = (focused: boolean) => {
-    Animated.timing(scale, {
-      toValue: focused ? 1.05 : 1,
-      duration: 150,
-      easing: Easing.out(Easing.quad),
-      useNativeDriver: true,
-    }).start();
-  };
-
-  return (
-    <Pressable
-      onPress={onPress}
-      onFocus={() => {
-        setIsFocused(true);
-        animateFocus(true);
-      }}
-      onBlur={() => {
-        setIsFocused(false);
-        animateFocus(false);
-      }}
-      style={{ alignSelf: "flex-start", marginBottom: 24 }}
-      disabled={disabled}
-      focusable={!disabled}
-    >
-      <Animated.View
-        style={{
-          transform: [{ scale }],
-          flexDirection: "row",
-          alignItems: "center",
-          paddingVertical: 8,
-          paddingHorizontal: 12,
-          borderRadius: 8,
-          backgroundColor: isFocused ? "#fff" : "rgba(255, 255, 255, 0.15)",
-        }}
-      >
-        <Ionicons
-          name='chevron-back'
-          size={28}
-          color={isFocused ? "#000" : "#fff"}
-        />
-        <Text
-          style={{
-            color: isFocused ? "#000" : "#fff",
-            fontSize: 20,
-            marginLeft: 4,
-          }}
-        >
-          {label}
-        </Text>
-      </Animated.View>
-    </Pressable>
-  );
-};
 
 export const TVAddServerForm: React.FC<TVAddServerFormProps> = ({
   onConnect,
@@ -103,23 +33,13 @@ export const TVAddServerForm: React.FC<TVAddServerFormProps> = ({
 
   const isDisabled = disabled || loading;
 
-  // Handle Android TV back button, needed as an "override"
-  useEffect(() => {
-    if (!Platform.isTV) return;
+  const handleBack = useCallback(() => {
+    if (isDisabled) return false;
+    onBack();
+    return true;
+  }, [isDisabled, onBack]);
 
-    const handleBackPress = () => {
-      if (disabled) return false;
-      onBack();
-      return true;
-    };
-
-    const subscription = BackHandler.addEventListener(
-      "hardwareBackPress",
-      handleBackPress,
-    );
-
-    return () => subscription.remove();
-  }, [onBack, disabled]);
+  useTVBackPress(() => handleBack(), [handleBack]);
 
   return (
     <ScrollView
@@ -139,12 +59,19 @@ export const TVAddServerForm: React.FC<TVAddServerFormProps> = ({
           paddingHorizontal: 60,
         }}
       >
-        {/* Back Button */}
-        <TVBackButton
-          onPress={onBack}
-          label={t("common.back")}
-          disabled={isDisabled}
-        />
+        {/* Title */}
+        <Text
+          style={{
+            fontSize: typography.heading,
+            fontWeight: "bold",
+            color: "#FFFFFF",
+            textAlign: "left",
+            marginBottom: 24,
+            paddingHorizontal: 8,
+          }}
+        >
+          {t("server.enter_url_to_jellyfin_server")}
+        </Text>
 
         {/* Server URL Input */}
         <View style={{ marginBottom: 24, paddingHorizontal: 8 }}>
@@ -173,21 +100,9 @@ export const TVAddServerForm: React.FC<TVAddServerFormProps> = ({
           </Button>
         </View>
 
-        {/* Hint text */}
-        <Text
-          style={{
-            fontSize: typography.callout,
-            color: "#6B7280",
-            textAlign: "left",
-            paddingHorizontal: 8,
-          }}
-        >
-          {t("server.enter_url_to_jellyfin_server")}
-        </Text>
-
         {/* Pair with Phone */}
         {onStartPairing && (
-          <View style={{ marginTop: 32 }}>
+          <View>
             <Button
               onPress={onStartPairing}
               className='bg-neutral-800 border border-neutral-700'

--- a/components/login/TVAddUserForm.tsx
+++ b/components/login/TVAddUserForm.tsx
@@ -1,18 +1,10 @@
-import { Ionicons } from "@expo/vector-icons";
 import { t } from "i18next";
-import React, { useEffect, useRef, useState } from "react";
-import {
-  Animated,
-  BackHandler,
-  Easing,
-  Platform,
-  Pressable,
-  ScrollView,
-  View,
-} from "react-native";
+import React, { useCallback, useState } from "react";
+import { ScrollView, View } from "react-native";
 import { Button } from "@/components/Button";
 import { Text } from "@/components/common/Text";
 import { useScaledTVTypography } from "@/constants/TVTypography";
+import { useTVBackPress } from "@/hooks/useTVBackPress";
 import { TVInput } from "./TVInput";
 import { TVSaveAccountToggle } from "./TVSaveAccountToggle";
 
@@ -29,68 +21,6 @@ interface TVAddUserFormProps {
   loading?: boolean;
   disabled?: boolean;
 }
-
-const TVBackButton: React.FC<{
-  onPress: () => void;
-  label: string;
-  disabled?: boolean;
-}> = ({ onPress, label, disabled = false }) => {
-  const [isFocused, setIsFocused] = useState(false);
-  const scale = useRef(new Animated.Value(1)).current;
-
-  const animateFocus = (focused: boolean) => {
-    Animated.timing(scale, {
-      toValue: focused ? 1.05 : 1,
-      duration: 150,
-      easing: Easing.out(Easing.quad),
-      useNativeDriver: true,
-    }).start();
-  };
-
-  return (
-    <Pressable
-      onPress={onPress}
-      onFocus={() => {
-        setIsFocused(true);
-        animateFocus(true);
-      }}
-      onBlur={() => {
-        setIsFocused(false);
-        animateFocus(false);
-      }}
-      style={{ alignSelf: "flex-start", marginBottom: 40 }}
-      disabled={disabled}
-      focusable={!disabled}
-    >
-      <Animated.View
-        style={{
-          transform: [{ scale }],
-          flexDirection: "row",
-          alignItems: "center",
-          paddingVertical: 8,
-          paddingHorizontal: 12,
-          borderRadius: 8,
-          backgroundColor: isFocused ? "#fff" : "rgba(255, 255, 255, 0.15)",
-        }}
-      >
-        <Ionicons
-          name='chevron-back'
-          size={28}
-          color={isFocused ? "#000" : "#fff"}
-        />
-        <Text
-          style={{
-            color: isFocused ? "#000" : "#fff",
-            fontSize: 20,
-            marginLeft: 4,
-          }}
-        >
-          {label}
-        </Text>
-      </Animated.View>
-    </Pressable>
-  );
-};
 
 export const TVAddUserForm: React.FC<TVAddUserFormProps> = ({
   serverName,
@@ -116,23 +46,13 @@ export const TVAddUserForm: React.FC<TVAddUserFormProps> = ({
 
   const isDisabled = disabled || loading;
 
-  // Handle Android TV back button, needed as an "override"
-  useEffect(() => {
-    if (!Platform.isTV) return;
+  const handleBack = useCallback(() => {
+    if (isDisabled) return false;
+    onBack();
+    return true;
+  }, [isDisabled, onBack]);
 
-    const handleBackPress = () => {
-      if (disabled) return false;
-      onBack();
-      return true;
-    };
-
-    const subscription = BackHandler.addEventListener(
-      "hardwareBackPress",
-      handleBackPress,
-    );
-
-    return () => subscription.remove();
-  }, [onBack, disabled]);
+  useTVBackPress(() => handleBack(), [handleBack]);
 
   return (
     <ScrollView
@@ -152,13 +72,6 @@ export const TVAddUserForm: React.FC<TVAddUserFormProps> = ({
           paddingHorizontal: 60,
         }}
       >
-        {/* Back Button */}
-        <TVBackButton
-          onPress={onBack}
-          label={t("common.back")}
-          disabled={isDisabled}
-        />
-
         {/* Title */}
         <Text
           style={{

--- a/components/login/TVLogin.tsx
+++ b/components/login/TVLogin.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, View } from "react-native";
 import { useMMKVString } from "react-native-mmkv";
 import { Text } from "@/components/common/Text";
+import { useTVMenuKeyInterception } from "@/hooks/useTVBackPress";
 import { apiAtom, useJellyfin } from "@/providers/JellyfinProvider";
 import { selectedTVServerAtom } from "@/utils/atoms/selectedTVServer";
 import { storage } from "@/utils/mmkv";
@@ -77,6 +78,8 @@ export const TVLogin: React.FC = () => {
   // Current screen state
   const [currentScreen, setCurrentScreen] =
     useState<TVLoginScreen>("server-selection");
+  // No interception on server-selection so that it can go back to home screen on tvOS
+  useTVMenuKeyInterception(currentScreen !== "server-selection");
 
   // Current selected server for user selection screen
   const [currentServer, setCurrentServer] = useState<SavedServer | null>(null);

--- a/components/login/TVQRCodeDisplay.tsx
+++ b/components/login/TVQRCodeDisplay.tsx
@@ -1,17 +1,10 @@
-import { Ionicons } from "@expo/vector-icons";
 import { t } from "i18next";
-import React, { useEffect, useRef } from "react";
-import {
-  Animated,
-  BackHandler,
-  Easing,
-  Platform,
-  Pressable,
-  View,
-} from "react-native";
+import React, { useCallback } from "react";
+import { View } from "react-native";
 import QRCode from "react-native-qrcode-svg";
 import { Text } from "@/components/common/Text";
 import { useScaledTVTypography } from "@/constants/TVTypography";
+import { useTVBackPress } from "@/hooks/useTVBackPress";
 import { scaleSize } from "@/utils/scaleSize";
 
 interface TVQRCodeDisplayProps {
@@ -24,7 +17,6 @@ export const TVQRCodeDisplay: React.FC<TVQRCodeDisplayProps> = ({
   onBack,
 }) => {
   const typography = useScaledTVTypography();
-  const handledRef = useRef(false);
 
   const qrSize = scaleSize(280);
   const cardPadding = scaleSize(16);
@@ -36,29 +28,13 @@ export const TVQRCodeDisplay: React.FC<TVQRCodeDisplayProps> = ({
     code,
   });
 
-  // Handle Android TV back button
-  useEffect(() => {
-    if (!Platform.isTV || !onBack) return;
-
-    const handleBackPress = () => {
-      if (handledRef.current) return true;
-
-      handledRef.current = true;
-      setTimeout(() => {
-        handledRef.current = false;
-      }, 100);
-
-      onBack();
-      return true;
-    };
-
-    const subscription = BackHandler.addEventListener(
-      "hardwareBackPress",
-      handleBackPress,
-    );
-
-    return () => subscription.remove();
+  const handleBack = useCallback(() => {
+    if (!onBack) return false;
+    onBack();
+    return true;
   }, [onBack]);
+
+  useTVBackPress(() => handleBack(), [handleBack]);
 
   return (
     <View
@@ -75,9 +51,6 @@ export const TVQRCodeDisplay: React.FC<TVQRCodeDisplayProps> = ({
           paddingHorizontal: outerPadding,
         }}
       >
-        {/* Back Button */}
-        {onBack && <TVBackButton onPress={onBack} />}
-
         {/* QR Code */}
         <View
           style={{
@@ -138,64 +111,5 @@ export const TVQRCodeDisplay: React.FC<TVQRCodeDisplayProps> = ({
         </View>
       </View>
     </View>
-  );
-};
-
-const TVBackButton: React.FC<{
-  onPress: () => void;
-}> = ({ onPress }) => {
-  const [isFocused, setIsFocused] = React.useState(false);
-  const scale = useRef(new Animated.Value(1)).current;
-
-  const animateFocus = (focused: boolean) => {
-    Animated.timing(scale, {
-      toValue: focused ? 1.05 : 1,
-      duration: 150,
-      easing: Easing.out(Easing.quad),
-      useNativeDriver: true,
-    }).start();
-  };
-
-  return (
-    <Pressable
-      onPress={onPress}
-      onFocus={() => {
-        setIsFocused(true);
-        animateFocus(true);
-      }}
-      onBlur={() => {
-        setIsFocused(false);
-        animateFocus(false);
-      }}
-      style={{ alignSelf: "flex-start", marginBottom: 24 }}
-      focusable
-    >
-      <Animated.View
-        style={{
-          transform: [{ scale }],
-          flexDirection: "row",
-          alignItems: "center",
-          paddingVertical: 8,
-          paddingHorizontal: 12,
-          borderRadius: 8,
-          backgroundColor: isFocused ? "#fff" : "rgba(255, 255, 255, 0.15)",
-        }}
-      >
-        <Ionicons
-          name='chevron-back'
-          size={28}
-          color={isFocused ? "#000" : "#fff"}
-        />
-        <Text
-          style={{
-            color: isFocused ? "#000" : "#fff",
-            fontSize: 20,
-            marginLeft: 4,
-          }}
-        >
-          {t("common.back")}
-        </Text>
-      </Animated.View>
-    </Pressable>
   );
 };

--- a/components/login/TVUserSelectionScreen.tsx
+++ b/components/login/TVUserSelectionScreen.tsx
@@ -1,9 +1,9 @@
 import { t } from "i18next";
-import React, { useEffect } from "react";
-import { BackHandler, Platform, ScrollView, View } from "react-native";
+import React, { useCallback } from "react";
+import { ScrollView, View } from "react-native";
 import { Text } from "@/components/common/Text";
 import { useScaledTVTypography } from "@/constants/TVTypography";
-import { useTVEventHandler } from "@/hooks/useTVEventHandler";
+import { useTVBackPress } from "@/hooks/useTVBackPress";
 import type {
   SavedServer,
   SavedServerAccount,
@@ -32,31 +32,13 @@ export const TVUserSelectionScreen: React.FC<TVUserSelectionScreenProps> = ({
   const accounts = server.accounts || [];
   const hasAccounts = accounts.length > 0;
 
-  // Handle TV remote back/menu button
-  useTVEventHandler((evt) => {
-    if (!evt || disabled) return;
-    if (evt.eventType === "menu" || evt.eventType === "back") {
-      onChangeServer();
-    }
-  });
+  const handleBackPress = useCallback(() => {
+    if (disabled) return false;
+    onChangeServer();
+    return true;
+  }, [disabled, onChangeServer]);
 
-  // Handle Android TV back button
-  useEffect(() => {
-    if (!Platform.isTV) return;
-
-    const handleBackPress = () => {
-      if (disabled) return false;
-      onChangeServer();
-      return true;
-    };
-
-    const subscription = BackHandler.addEventListener(
-      "hardwareBackPress",
-      handleBackPress,
-    );
-
-    return () => subscription.remove();
-  }, [onChangeServer, disabled]);
+  useTVBackPress(handleBackPress, [handleBackPress]);
 
   return (
     <ScrollView

--- a/hooks/useTVBackPress.ts
+++ b/hooks/useTVBackPress.ts
@@ -28,6 +28,19 @@ export function disableTVMenuKeyInterception() {
   }
 }
 
+export function useTVMenuKeyInterception(enabled = true) {
+  useEffect(() => {
+    if (!Platform.isTV) return;
+
+    if (enabled) {
+      enableTVMenuKeyInterception();
+      return;
+    }
+
+    disableTVMenuKeyInterception();
+  }, [enabled]);
+}
+
 /**
  * Subscribe to TV back presses through React Native's BackHandler.
  *
@@ -52,6 +65,8 @@ export function useTVBackPress(
       handler,
     );
 
-    return () => subscription.remove();
+    return () => {
+      subscription.remove();
+    };
   }, deps);
 }

--- a/package.json
+++ b/package.json
@@ -162,6 +162,9 @@
   "trustedDependencies": [
     "unrs-resolver"
   ],
+  "patchedDependencies": {
+    "react-native-udp@4.1.7": "bun-patches/react-native-udp@4.1.7.patch"
+  },
   "resolutions": {
     "expo-constants": "18.0.13"
   }

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "unrs-resolver"
   ],
   "patchedDependencies": {
+    "react-native-screens@4.18.0": "bun-patches/react-native-screens@4.18.0.patch",
     "react-native-udp@4.1.7": "bun-patches/react-native-udp@4.1.7.patch"
   },
   "resolutions": {


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary

Fixes tvOS login/navigation issues by carrying targeted Bun patches for native dependencies and consolidating TV login back/menu handling. Also prevents the companion login screen from eagerly loading `expo-camera` on TV builds.

## 🏷️ Ticket / Issue

## 🛠️ What’s Changed

- Type: fix, refactor
- Scope: tvOS, login, native patches
- Short summary: Adds tvOS-specific patches for `react-native-udp` and `react-native-screens`, lazy-loads the companion camera module, and centralizes TV login back/menu handling.

## 📋 Details
_Generated by Codex_
- Adds a `react-native-udp@4.1.7` Bun patch so the podspec declares separate iOS and tvOS deployment targets.
- Adds a `react-native-screens@4.18.0` Bun patch so native-stack screens on tvOS can forward Menu button presses through React Native TV navigation events. (relevant thread https://github.com/streamyfin/streamyfin/pull/1559)
- Registers both patches in `package.json` and `bun.lock`.
- Updates `CompanionLoginScreen` to dynamically import `expo-camera` only on non-TV devices. On TV, it falls back to manual pairing code entry rather than trying to load a native camera module that may not exist in the TV build.
   -  The route still exists in the shared home stack, so tvOS may compile/include it even if normal TV UI does not navigate there. That makes the lazy expo-camera import useful: it prevents the TV build from eagerly loading a native camera module that may not exist.
- Refactors TV login screens to use shared `useTVBackPress` / menu-key interception helpers.
- Removes duplicated visible TV back buttons from login sub-screens where remote/Menu handling now owns the back action.

I checked newer upstream versions before keeping the `react-native-screens` patch:

- `react-native-screens@4.24.0` and `4.25.1` do not include equivalent tvOS Menu key forwarding in `RNSScreenStack.mm`.
- `react-native-screens@4.25.1` also requires `react-native >=0.82.0`, while this project is currently on `react-native-tvos@0.81.5-2`.
- Latest `react-native-tvos@0.85.3-0` still keeps the Menu recognizer attached to React root/modal views; it does not cover `react-native-screens`' native navigation controller path.

### ⚠️ Breaking Changes
None.

### 🔐 Security & Privacy Impact
No new permissions, secrets, or stored data. The existing camera permission remains for mobile companion QR scanning, but the camera module is no longer eagerly loaded on TV.

### ⚡ Performance Impact
Negligible. The companion camera module is now lazy-loaded, which avoids unnecessary native module loading on TV builds.

### 🖼️ Screenshots / GIFs (if UI)
<img width="1000" src="https://github.com/user-attachments/assets/9dce5e6b-d352-448d-91c8-60c9c91a1268" />
<img width="1000" src="https://github.com/user-attachments/assets/7c66a1d9-ffd8-4bda-972e-40afae059cfd" />



## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [x] Docs updated (README/ADR/usage/API)
- [x] No secrets/credentials included; env vars documented
- [x] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions

1. Check out this PR branch.
2. Install dependencies with `bun install` and confirm the Bun patches apply cleanly.
3. Build/run the TV target with `bun run ios:tv`.
4. On tvOS login:
   - Open the server add/user add/QR pairing/user selection screens.
   - Press the remote Menu/back button and confirm it navigates to the expected previous login step.
   - Confirm Menu/back from the initial server-selection screen can leave the TV login flow.
5. On mobile companion login:
   - Open companion login from Settings.
   - Confirm QR scanning still loads the camera.
   - Confirm manual code entry still works.

## ⚙️ Deployment Notes

Native builds need dependencies installed after this change so Bun applies:

- `bun-patches/react-native-udp@4.1.7.patch`
- `bun-patches/react-native-screens@4.18.0.patch`

Because this changes iOS/tvOS native dependency sources, rebuild the native app after installing dependencies.

## 📝 Additional Notes

The `react-native-screens` patch is intentionally scoped to tvOS and mirrors React Native TV's existing Menu key notification/event flow for the native-stack controller path.
