### PR TITLE
feat(tv): add progress bar scrubbing controls

### DIFF
--- a/components/tv/TVFocusableProgressBar.tsx
+++ b/components/tv/TVFocusableProgressBar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   Animated,
   Pressable,
@@ -7,7 +7,12 @@ import {
   type ViewStyle,
 } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
-import ReanimatedModule, { useAnimatedStyle } from "react-native-reanimated";
+import ReanimatedModule, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
 import { scaleSize } from "@/utils/scaleSize";
 import { useTVFocusAnimation } from "./hooks/useTVFocusAnimation";
 
@@ -32,11 +37,14 @@ export interface TVFocusableProgressBarProps {
   disabled?: boolean;
   /** Whether this component should receive initial focus */
   hasTVPreferredFocus?: boolean;
+  /** Whether the progress bar is in active scrub mode */
+  isScrubbing?: boolean;
   /** Optional style overrides */
   style?: ViewStyle;
 }
 
 const PROGRESS_BAR_HEIGHT = scaleSize(14);
+const PROGRESS_THUMB_SIZE = scaleSize(26);
 
 export const TVFocusableProgressBar: React.FC<TVFocusableProgressBarProps> =
   React.memo(
@@ -50,8 +58,11 @@ export const TVFocusableProgressBar: React.FC<TVFocusableProgressBarProps> =
       refSetter,
       disabled = false,
       hasTVPreferredFocus = false,
+      isScrubbing = false,
       style,
     }) => {
+      const thumbVisibility = useSharedValue(isScrubbing ? 1 : 0);
+
       const { focused, handleFocus, handleBlur, animatedStyle } =
         useTVFocusAnimation({
           scaleAmount: 1.02,
@@ -60,12 +71,25 @@ export const TVFocusableProgressBar: React.FC<TVFocusableProgressBarProps> =
           onBlur,
         });
 
+      useEffect(() => {
+        thumbVisibility.value = withTiming(isScrubbing ? 1 : 0, {
+          duration: isScrubbing ? 120 : 100,
+          easing: Easing.out(Easing.quad),
+        });
+      }, [isScrubbing, thumbVisibility]);
+
       const progressFillStyle = useAnimatedStyle(() => ({
         width: `${max.value > 0 ? (progress.value / max.value) * 100 : 0}%`,
       }));
 
       const cacheProgressStyle = useAnimatedStyle(() => ({
         width: `${max.value > 0 && cacheProgress ? (cacheProgress.value / max.value) * 100 : 0}%`,
+      }));
+
+      const progressThumbStyle = useAnimatedStyle(() => ({
+        left: `${max.value > 0 ? (progress.value / max.value) * 100 : 0}%`,
+        opacity: thumbVisibility.value,
+        transform: [{ scale: 0.65 + thumbVisibility.value * 0.35 }],
       }));
 
       return (
@@ -83,6 +107,7 @@ export const TVFocusableProgressBar: React.FC<TVFocusableProgressBarProps> =
               styles.animatedContainer,
               animatedStyle,
               focused && styles.animatedContainerFocused,
+              isScrubbing && styles.animatedContainerScrubbing,
             ]}
           >
             <View style={styles.progressTrackWrapper}>
@@ -90,6 +115,7 @@ export const TVFocusableProgressBar: React.FC<TVFocusableProgressBarProps> =
                 style={[
                   styles.progressTrack,
                   focused && styles.progressTrackFocused,
+                  isScrubbing && styles.progressTrackScrubbing,
                 ]}
               >
                 {cacheProgress && (
@@ -101,6 +127,10 @@ export const TVFocusableProgressBar: React.FC<TVFocusableProgressBarProps> =
                   style={[styles.progressFill, progressFillStyle]}
                 />
               </View>
+              <ReanimatedView
+                pointerEvents='none'
+                style={[styles.progressThumb, progressThumbStyle]}
+              />
               {/* Chapter markers - positioned outside track to extend above */}
               {chapterPositions.length > 0 && (
                 <View
@@ -141,6 +171,11 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.5,
     shadowRadius: scaleSize(12),
   },
+  animatedContainerScrubbing: {
+    shadowOpacity: 0.8,
+    shadowRadius: 18,
+    transform: [{ scale: 1.03 }],
+  },
   progressTrackWrapper: {
     position: "relative",
     height: PROGRESS_BAR_HEIGHT,
@@ -154,6 +189,9 @@ const styles = StyleSheet.create({
   progressTrackFocused: {
     // Brighter track when focused
     backgroundColor: "rgba(255,255,255,0.35)",
+  },
+  progressTrackScrubbing: {
+    backgroundColor: "rgba(255,255,255,0.45)",
   },
   cacheProgress: {
     position: "absolute",
@@ -170,6 +208,23 @@ const styles = StyleSheet.create({
     height: "100%",
     backgroundColor: "#fff",
     borderRadius: scaleSize(8),
+  },
+  progressThumb: {
+    position: "absolute",
+    top: -(PROGRESS_THUMB_SIZE - PROGRESS_BAR_HEIGHT) / 2,
+    width: PROGRESS_THUMB_SIZE,
+    height: PROGRESS_THUMB_SIZE,
+    marginLeft: -PROGRESS_THUMB_SIZE / 2,
+    borderRadius: PROGRESS_THUMB_SIZE / 2,
+    backgroundColor: "#fff",
+    borderWidth: 3,
+    borderColor: "rgba(255,255,255,0.75)",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.35,
+    shadowRadius: 6,
+    elevation: 8,
+    zIndex: 3,
   },
   chapterMarkersContainer: {
     position: "absolute",

--- a/components/video-player/controls/Controls.tv.tsx
+++ b/components/video-player/controls/Controls.tv.tsx
@@ -22,6 +22,7 @@ import {
 } from "react-native";
 import Animated, {
   Easing,
+  runOnJS,
   type SharedValue,
   useAnimatedReaction,
   useAnimatedStyle,
@@ -108,6 +109,7 @@ const TV_TRICKPLAY_INTERNAL_OFFSET = 62 * TV_TRICKPLAY_SCALE;
 const TV_TRICKPLAY_CENTERING_OFFSET = 98 * TV_TRICKPLAY_SCALE;
 const TV_TRICKPLAY_RIGHT_PADDING = 150;
 const TV_TRICKPLAY_FADE_DURATION = 200;
+const TV_TOUCH_SCRUB_SENSITIVITY = 0.2;
 
 interface TVTrickplayBubbleProps {
   trickPlayUrl: {
@@ -481,9 +483,9 @@ export const Controls: FC<Props> = ({
   // For live TV, determine if we're at the live edge (within 5 seconds of max)
   const LIVE_EDGE_THRESHOLD = 5000; // 5 seconds in ms
 
-  const getFinishTime = () => {
+  const getFinishTime = (remainingMs = remainingTime) => {
     const now = new Date();
-    const finishTime = new Date(now.getTime() + remainingTime);
+    const finishTime = new Date(now.getTime() + remainingMs);
     return finishTime.toLocaleTimeString([], {
       hour: "2-digit",
       minute: "2-digit",
@@ -496,6 +498,9 @@ export const Controls: FC<Props> = ({
     setShowControls(!showControls);
   }, [showControls, setShowControls, isSkipOrCountdownVisible]);
 
+  const [isProgressBarScrubbing, setIsProgressBarScrubbing] = useState(false);
+  const [scrubPreviewPosition, setScrubPreviewPosition] = useState(0);
+  const isProgressBarScrubbingValue = useSharedValue(false);
   const [showSeekBubble, setShowSeekBubble] = useState(false);
   const [seekBubbleTime, setSeekBubbleTime] = useState({
     hours: 0,
@@ -507,6 +512,9 @@ export const Controls: FC<Props> = ({
   );
   const continuousSeekRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const seekAccelerationRef = useRef(1);
+  const wasPlayingBeforeScrubRef = useRef(false);
+  const progressBeforeScrubRef = useRef(0);
+  const isCancelingProgressScrubRef = useRef(false);
   const controlsInteractionRef = useRef<() => void>(() => {});
   const goToNextItemRef = useRef<(opts?: { isAutoPlay?: boolean }) => void>(
     () => {},
@@ -634,9 +642,23 @@ export const Controls: FC<Props> = ({
 
   const SEEK_THRESHOLD_MS = 5000;
 
+  useEffect(() => {
+    isProgressBarScrubbingValue.value = isProgressBarScrubbing;
+  }, [isProgressBarScrubbing, isProgressBarScrubbingValue]);
+
+  const displayCurrentTime = isProgressBarScrubbing
+    ? scrubPreviewPosition
+    : currentTime;
+  const displayRemainingTime = isProgressBarScrubbing
+    ? Math.max(0, max.value - scrubPreviewPosition)
+    : remainingTime;
+
   useAnimatedReaction(
     () => progress.value,
     (current, _previous) => {
+      if (isProgressBarScrubbingValue.value) {
+        return;
+      }
       const progressUnit = CONTROLS_CONSTANTS.PROGRESS_UNIT_MS;
       const progressDiff = Math.abs(current - effectiveProgress.value);
       if (progressDiff >= progressUnit) {
@@ -652,6 +674,123 @@ export const Controls: FC<Props> = ({
     },
     [],
   );
+
+  const showPersistentSeekBubble = useCallback(
+    (positionMs: number) => {
+      calculateTrickplayUrl(msToTicks(positionMs));
+      updateSeekBubbleTime(positionMs);
+      setScrubPreviewPosition(positionMs);
+      setShowSeekBubble(true);
+
+      if (seekBubbleTimeoutRef.current) {
+        clearTimeout(seekBubbleTimeoutRef.current);
+        seekBubbleTimeoutRef.current = null;
+      }
+
+      controlsInteractionRef.current();
+    },
+    [calculateTrickplayUrl, updateSeekBubbleTime],
+  );
+
+  const hideSeekBubbleAfterDelay = useCallback(() => {
+    if (seekBubbleTimeoutRef.current) {
+      clearTimeout(seekBubbleTimeoutRef.current);
+    }
+    seekBubbleTimeoutRef.current = setTimeout(() => {
+      setShowSeekBubble(false);
+    }, 2000);
+  }, []);
+
+  const handleProgressBarPress = useCallback(() => {
+    if (isCancelingProgressScrubRef.current) return;
+    if (!isProgressBarFocused) return;
+
+    if (isProgressBarScrubbing) {
+      const newPosition = Math.max(
+        min.value,
+        Math.min(max.value, effectiveProgress.value),
+      );
+      progress.value = newPosition;
+      seek(newPosition);
+      setIsProgressBarScrubbing(false);
+      hideSeekBubbleAfterDelay();
+      if (wasPlayingBeforeScrubRef.current) {
+        _play();
+      }
+      wasPlayingBeforeScrubRef.current = false;
+      controlsInteractionRef.current();
+      return;
+    }
+
+    wasPlayingBeforeScrubRef.current = isPlaying;
+    progressBeforeScrubRef.current = progress.value;
+    if (isPlaying) {
+      _pause();
+    }
+    effectiveProgress.value = progressBeforeScrubRef.current;
+    setIsProgressBarScrubbing(true);
+    showPersistentSeekBubble(progressBeforeScrubRef.current);
+  }, [
+    isProgressBarFocused,
+    isProgressBarScrubbing,
+    min,
+    max,
+    effectiveProgress,
+    progress,
+    seek,
+    isPlaying,
+    _play,
+    _pause,
+    hideSeekBubbleAfterDelay,
+    showPersistentSeekBubble,
+  ]);
+
+  const finishProgressScrubCancel = useCallback(
+    (resumePlayback: boolean, positionMs: number) => {
+      setScrubPreviewPosition(positionMs);
+      setIsProgressBarScrubbing(false);
+      hideSeekBubbleAfterDelay();
+
+      if (resumePlayback) {
+        _play();
+      }
+
+      wasPlayingBeforeScrubRef.current = false;
+      isCancelingProgressScrubRef.current = false;
+      controlsInteractionRef.current();
+    },
+    [_play, hideSeekBubbleAfterDelay],
+  );
+
+  const cancelProgressScrub = useCallback(() => {
+    if (!isProgressBarScrubbing || isCancelingProgressScrubRef.current) return;
+
+    isCancelingProgressScrubRef.current = true;
+
+    const resumePlayback = wasPlayingBeforeScrubRef.current;
+    const currentPosition = Math.max(
+      min.value,
+      Math.min(max.value, progress.value),
+    );
+
+    effectiveProgress.value = withTiming(
+      currentPosition,
+      {
+        duration: 140,
+        easing: Easing.out(Easing.quad),
+      },
+      () => {
+        runOnJS(finishProgressScrubCancel)(resumePlayback, currentPosition);
+      },
+    );
+  }, [
+    isProgressBarScrubbing,
+    effectiveProgress,
+    progress,
+    min,
+    max,
+    finishProgressScrubCancel,
+  ]);
 
   const handleSeekForwardButton = useCallback(() => {
     // For live TV, check if we're already at the live edge
@@ -707,6 +846,26 @@ export const Controls: FC<Props> = ({
 
   // Progress bar D-pad seeking (10s increments for finer control)
   const handleProgressSeekRight = useCallback(() => {
+    if (isCancelingProgressScrubRef.current) return;
+
+    if (isProgressBarScrubbing) {
+      if (
+        isLiveTV &&
+        max.value - effectiveProgress.value < LIVE_EDGE_THRESHOLD
+      ) {
+        controlsInteractionRef.current();
+        return;
+      }
+
+      const newPosition = Math.min(
+        max.value,
+        effectiveProgress.value + 10 * 1000,
+      );
+      effectiveProgress.value = newPosition;
+      showPersistentSeekBubble(newPosition);
+      return;
+    }
+
     // For live TV, check if we're already at the live edge
     if (isLiveTV && max.value - progress.value < LIVE_EDGE_THRESHOLD) {
       // Already at live edge, don't seek further
@@ -733,13 +892,28 @@ export const Controls: FC<Props> = ({
   }, [
     progress,
     max,
+    effectiveProgress,
     seek,
     calculateTrickplayUrl,
     updateSeekBubbleTime,
     isLiveTV,
+    isProgressBarScrubbing,
+    showPersistentSeekBubble,
   ]);
 
   const handleProgressSeekLeft = useCallback(() => {
+    if (isCancelingProgressScrubRef.current) return;
+
+    if (isProgressBarScrubbing) {
+      const newPosition = Math.max(
+        min.value,
+        effectiveProgress.value - 10 * 1000,
+      );
+      effectiveProgress.value = newPosition;
+      showPersistentSeekBubble(newPosition);
+      return;
+    }
+
     const newPosition = Math.max(min.value, progress.value - 10 * 1000);
     progress.value = newPosition;
     seek(newPosition);
@@ -756,7 +930,50 @@ export const Controls: FC<Props> = ({
     }, 2000);
 
     controlsInteractionRef.current();
-  }, [progress, min, seek, calculateTrickplayUrl, updateSeekBubbleTime]);
+  }, [
+    progress,
+    min,
+    effectiveProgress,
+    seek,
+    calculateTrickplayUrl,
+    updateSeekBubbleTime,
+    isProgressBarScrubbing,
+    showPersistentSeekBubble,
+  ]);
+
+  const handleProgressScrubPan = useCallback(
+    (deltaX: number) => {
+      if (
+        !isProgressBarScrubbing ||
+        isCancelingProgressScrubRef.current ||
+        max.value <= 0
+      ) {
+        return;
+      }
+
+      const newPosition = Math.max(
+        min.value,
+        Math.min(
+          max.value,
+          effectiveProgress.value +
+            (deltaX / progressBarWidth) *
+              max.value *
+              TV_TOUCH_SCRUB_SENSITIVITY,
+        ),
+      );
+
+      effectiveProgress.value = newPosition;
+      showPersistentSeekBubble(newPosition);
+    },
+    [
+      isProgressBarScrubbing,
+      max,
+      min,
+      effectiveProgress,
+      progressBarWidth,
+      showPersistentSeekBubble,
+    ],
+  );
 
   // Minimal seek mode handlers (only show progress bar, not full controls)
   const handleMinimalSeekRight = useCallback(() => {
@@ -949,9 +1166,10 @@ export const Controls: FC<Props> = ({
   }, [setShowControls, isSkipOrCountdownVisible]);
 
   const hideControls = useCallback(() => {
+    cancelProgressScrub();
     setShowControls(false);
     setFocusPlayButton(false);
-  }, [setShowControls]);
+  }, [cancelProgressScrub, setShowControls]);
 
   // When controls hide (and no skip/countdown overlay is visible), move focus
   // to the invisible overlay so hidden buttons can't receive select events.
@@ -967,8 +1185,24 @@ export const Controls: FC<Props> = ({
   }, [showControls, isSkipOrCountdownVisible]);
 
   const handleBack = useCallback(() => {
+    if (isProgressBarScrubbing) {
+      cancelProgressScrub();
+      return;
+    }
+
+    if (showControls) {
+      hideControls();
+      return;
+    }
+
     router.back();
-  }, [router]);
+  }, [
+    cancelProgressScrub,
+    hideControls,
+    isProgressBarScrubbing,
+    router,
+    showControls,
+  ]);
 
   const handleWillExit = useCallback(() => {
     exitingRef.current = true;
@@ -985,6 +1219,9 @@ export const Controls: FC<Props> = ({
     toggleControls,
     togglePlay,
     isProgressBarFocused,
+    isProgressBarScrubbing,
+    onProgressBarPress: handleProgressBarPress,
+    onProgressScrubPan: handleProgressScrubPan,
     onSeekLeft: handleProgressSeekLeft,
     onSeekRight: handleProgressSeekRight,
     onMinimalSeekLeft: handleMinimalSeekLeft,
@@ -1007,7 +1244,7 @@ export const Controls: FC<Props> = ({
     episodeView: false,
     onHideControls: hideControls,
     timeout: TV_AUTO_HIDE_TIMEOUT,
-    disabled: false,
+    disabled: isProgressBarScrubbing,
   });
 
   controlsInteractionRef.current = handleControlsInteraction;
@@ -1244,17 +1481,17 @@ export const Controls: FC<Props> = ({
 
           <View style={styles.timeContainer}>
             <Text style={[styles.timeText, { fontSize: typography.body }]}>
-              {formatTimeString(currentTime, "ms")}
+              {formatTimeString(displayCurrentTime, "ms")}
             </Text>
             {!isLiveTV && (
               <View style={styles.timeRight}>
                 <Text style={[styles.timeText, { fontSize: typography.body }]}>
-                  -{formatTimeString(remainingTime, "ms")}
+                  -{formatTimeString(displayRemainingTime, "ms")}
                 </Text>
                 <Text
                   style={[styles.endsAtText, { fontSize: typography.callout }]}
                 >
-                  {t("player.ends_at")} {getFinishTime()}
+                  {t("player.ends_at")} {getFinishTime(displayRemainingTime)}
                 </Text>
               </View>
             )}
@@ -1422,8 +1659,13 @@ export const Controls: FC<Props> = ({
             />
           )}
 
-          {/* Progress bar with focus trapping for left/right */}
-          <TVFocusGuideView trapFocusLeft trapFocusRight>
+          {/* Progress bar with focus trapping for scrubbing/navigation */}
+          <TVFocusGuideView
+            trapFocusLeft
+            trapFocusRight
+            trapFocusUp={isProgressBarScrubbing}
+            trapFocusDown={isProgressBarScrubbing}
+          >
             <TVFocusableProgressBar
               progress={effectiveProgress}
               max={max}
@@ -1433,22 +1675,23 @@ export const Controls: FC<Props> = ({
               onBlur={() => setIsProgressBarFocused(false)}
               refSetter={setProgressBarRef}
               hasTVPreferredFocus={false}
+              isScrubbing={isProgressBarScrubbing}
             />
           </TVFocusGuideView>
 
           <View style={styles.timeContainer}>
             <Text style={[styles.timeText, { fontSize: typography.body }]}>
-              {formatTimeString(currentTime, "ms")}
+              {formatTimeString(displayCurrentTime, "ms")}
             </Text>
             {!isLiveTV && (
               <View style={styles.timeRight}>
                 <Text style={[styles.timeText, { fontSize: typography.body }]}>
-                  -{formatTimeString(remainingTime, "ms")}
+                  -{formatTimeString(displayRemainingTime, "ms")}
                 </Text>
                 <Text
                   style={[styles.endsAtText, { fontSize: typography.callout }]}
                 >
-                  {t("player.ends_at")} {getFinishTime()}
+                  {t("player.ends_at")} {getFinishTime(displayRemainingTime)}
                 </Text>
               </View>
             )}

--- a/components/video-player/controls/hooks/useRemoteControl.ts
+++ b/components/video-player/controls/hooks/useRemoteControl.ts
@@ -1,8 +1,23 @@
 import { useEffect, useRef, useState } from "react";
-import { Alert } from "react-native";
+import { Alert, Platform } from "react-native";
 import { type SharedValue, useSharedValue } from "react-native-reanimated";
 import { useTVBackPress } from "@/hooks/useTVBackPress";
 import { useTVEventHandler } from "@/hooks/useTVEventHandler";
+
+let TVEventControl: {
+  enableTVMenuKey: () => void;
+  disableTVMenuKey: () => void;
+  enableTVPanGesture?: () => void;
+  disableTVPanGesture?: () => void;
+} | null = null;
+
+if (Platform.isTV) {
+  try {
+    TVEventControl = require("react-native").TVEventControl;
+  } catch {
+    TVEventControl = null;
+  }
+}
 
 interface UseRemoteControlProps {
   showControls: boolean;
@@ -17,6 +32,12 @@ interface UseRemoteControlProps {
   videoTitle?: string;
   /** Whether the progress bar currently has focus */
   isProgressBarFocused?: boolean;
+  /** Whether the progress bar is actively preview-scrubbing */
+  isProgressBarScrubbing?: boolean;
+  /** Callback when select/enter is pressed on the focused progress bar */
+  onProgressBarPress?: () => void;
+  /** Callback for touch-surface pan movement while scrubbing */
+  onProgressScrubPan?: (deltaX: number) => void;
   /** Callback for seeking left when progress bar is focused */
   onSeekLeft?: () => void;
   /** Callback for seeking right when progress bar is focused */
@@ -67,6 +88,9 @@ export function useRemoteControl({
   onHideControls,
   videoTitle,
   isProgressBarFocused,
+  isProgressBarScrubbing,
+  onProgressBarPress,
+  onProgressScrubPan,
   onSeekLeft,
   onSeekRight,
   onMinimalSeekLeft,
@@ -93,6 +117,14 @@ export function useRemoteControl({
   const videoTitleRef = useRef(videoTitle);
   const onWillExitRef = useRef(onWillExit);
   const onCancelExitRef = useRef(onCancelExit);
+  const isProgressBarScrubbingRef = useRef(isProgressBarScrubbing);
+  const lastPanXRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!Platform.isTV || !TVEventControl) return;
+
+    TVEventControl.enableTVMenuKey();
+  }, []);
 
   useEffect(() => {
     showControlsRef.current = showControls;
@@ -101,6 +133,7 @@ export function useRemoteControl({
     videoTitleRef.current = videoTitle;
     onWillExitRef.current = onWillExit;
     onCancelExitRef.current = onCancelExit;
+    isProgressBarScrubbingRef.current = isProgressBarScrubbing;
   }, [
     showControls,
     onHideControls,
@@ -108,11 +141,41 @@ export function useRemoteControl({
     videoTitle,
     onWillExit,
     onCancelExit,
+    isProgressBarScrubbing,
   ]);
+
+  useEffect(() => {
+    if (
+      !Platform.isTV ||
+      Platform.OS !== "ios" ||
+      !TVEventControl?.enableTVPanGesture ||
+      !TVEventControl?.disableTVPanGesture
+    ) {
+      return;
+    }
+
+    if (isProgressBarScrubbing) {
+      TVEventControl.enableTVPanGesture();
+      return () => {
+        TVEventControl?.disableTVPanGesture?.();
+        lastPanXRef.current = null;
+      };
+    }
+
+    TVEventControl.disableTVPanGesture();
+    lastPanXRef.current = null;
+  }, [isProgressBarScrubbing]);
 
   // BackHandler owns player exit: Android TV sends hardware back here, and
   // react-native-tvos maps the Apple TV menu button to the same API.
   useTVBackPress(() => {
+    if (isProgressBarScrubbingRef.current && onBackRef.current) {
+      // Active progress scrubbing owns the first back press so both TV
+      // platforms cancel scrubbing through the shared back/menu handler.
+      onBackRef.current();
+      return true;
+    }
+
     if (showControlsRef.current && onHideControlsRef.current) {
       // Controls are visible, so the first back press only hides them.
       onHideControlsRef.current();
@@ -148,7 +211,7 @@ export function useRemoteControl({
 
     // Back/menu is handled by useTVBackPress above. Keep this handler focused
     // on remote-control events like play/pause, D-pad, and long seek.
-    if (evt.eventType === "menu") {
+    if (evt.eventType === "menu" || evt.eventType === "back") {
       return;
     }
 
@@ -157,6 +220,62 @@ export function useRemoteControl({
       togglePlay?.();
       onInteraction?.();
       return;
+    }
+
+    if (isProgressBarScrubbing) {
+      if (evt.eventType === "pan") {
+        const body = evt.body;
+        if (!body) return;
+
+        if (body.state === "Began") {
+          lastPanXRef.current = body.x;
+          return;
+        }
+
+        if (body.state === "Changed" && onProgressScrubPan) {
+          const previousX = lastPanXRef.current ?? body.x;
+          const deltaX = body.x - previousX;
+          lastPanXRef.current = body.x;
+
+          if (Math.abs(deltaX) >= 1) {
+            onProgressScrubPan(deltaX);
+          }
+          return;
+        }
+
+        if (body.state === "Ended") {
+          lastPanXRef.current = null;
+          return;
+        }
+
+        return;
+      }
+
+      if (
+        (evt.eventType === "select" || evt.eventType === "enter") &&
+        onProgressBarPress
+      ) {
+        onProgressBarPress();
+        return;
+      }
+      if (
+        (evt.eventType === "longLeft" || evt.eventType === "left") &&
+        onSeekLeft
+      ) {
+        if (evt.eventType === "left" || evt.eventKeyAction === 0) {
+          onSeekLeft();
+        }
+        return;
+      }
+      if (
+        (evt.eventType === "longRight" || evt.eventType === "right") &&
+        onSeekRight
+      ) {
+        if (evt.eventType === "right" || evt.eventKeyAction === 0) {
+          onSeekRight();
+        }
+        return;
+      }
     }
 
     // Handle long press D-pad for continuous seeking (works in both modes)
@@ -185,11 +304,6 @@ export function useRemoteControl({
 
     // Handle D-pad when controls are hidden
     if (!showControls) {
-      // Ignore select/enter events - let the native Pressable handle them
-      // This prevents controls from showing when pressing buttons like skip intro
-      if (evt.eventType === "select" || evt.eventType === "enter") {
-        return;
-      }
       // Minimal seek mode for left/right
       if (evt.eventType === "left" && onMinimalSeekLeft) {
         onMinimalSeekLeft();
@@ -199,21 +313,40 @@ export function useRemoteControl({
         onMinimalSeekRight();
         return;
       }
-      // Up/down shows controls with play button focused
+      // Select toggles playback without opening controls.
       if (
-        (evt.eventType === "up" || evt.eventType === "down") &&
+        (evt.eventType === "select" || evt.eventType === "enter") &&
+        togglePlay
+      ) {
+        togglePlay();
+        onInteraction?.();
+        return;
+      }
+      // Vertical navigation shows controls with play button focused.
+      if (
+        (evt.eventType === "up" ||
+          evt.eventType === "down" ||
+          evt.eventType === "swipeUp" ||
+          evt.eventType === "swipeDown") &&
         onVerticalDpad
       ) {
         onVerticalDpad();
         return;
       }
       // Ignore all other events (focus/blur, swipes, etc.)
-      // User can press up/down to show controls
+      // User can move vertically to show controls.
       return;
     }
 
     // Controls are showing - handle seeking when progress bar is focused
     if (isProgressBarFocused) {
+      if (
+        (evt.eventType === "select" || evt.eventType === "enter") &&
+        onProgressBarPress
+      ) {
+        onProgressBarPress();
+        return;
+      }
       if (evt.eventType === "left" && onSeekLeft) {
         onSeekLeft();
         return;


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary
Adds TV progress bar scrubbing controls to the video player so apple tv remote users can enter a focused scrub mode, preview seek position, and commit or cancel the seek.

## 🏷️ Ticket / Issue
Related: TV interface player controls

## 🛠️ What’s Changed
- Type: feat
- Scope (optional): tv
- Short summary: add focused TV progress-bar scrubbing with D-pad, long-press, and tvOS pan gesture support.

## 📋 Details
This adds active scrub mode for the TV progress bar, including preview progress state, seek confirmation/cancel handling, and a visible thumb while scrubbing.

The remote-control hook now routes select/enter, left/right, long-left/long-right, back/menu, and tvOS pan gestures through the progress-bar scrubbing flow.

### ⚠️ Breaking Changes
None.

### 🔐 Security & Privacy Impact
None.

### ⚡ Performance Impact
Minimal. The new behavior uses local shared values, refs, and existing TV event handling; no network or storage paths are changed.

### 🖼️ Screenshots / GIFs (if UI)

https://github.com/user-attachments/assets/95183e19-2546-468f-8410-ba0c6064a62a



## ✅ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Code follows project style and passes lint/format (`npm|pnpm|yarn|bun` scripts)
- [x] Type checks pass (tsc/biome/etc.)
- [x] Docs updated (README/ADR/usage/API) or not required
- [x] No secrets/credentials included; env vars documented
- [x] Release notes/CHANGELOG entry added (if applicable) or not required
- [x] Verified locally that changes behave as expected

## 🔍 Testing Instructions
1. Check out this PR branch.
2. Install dependencies with `bun install`.
3. Start a TV build with `bun run ios:tv` or `bun run android:tv`.
4. Play an item and focus the progress bar.
5. Verification steps:
   - [ ] Press select/enter on the focused progress bar to enter scrub mode.
   - [ ] Use left/right and long-left/long-right to adjust the preview position.
   - [ ] Press select/enter again to commit the seek.
   - [ ] Press back/menu while scrubbing to cancel scrub mode without exiting playback.
   - [ ] On tvOS, use the touch surface while scrubbing and confirm the preview position changes.

Local validation run after rebase:
- `bun run typecheck` currently fails on existing `expo-router/js-top-tabs` and `expo-router/react-navigation` module resolution errors outside this PR diff.
- `bun run check` currently fails on an existing unused `chapterPositions` parameter in `BottomControls.tsx` and formatting in an untracked local file.
- `git diff --check streamyfin/feat/tv-interface..HEAD` passes.

## ⚙️ Deployment Notes
Requires a TV-capable native build to exercise remote and pan gesture behavior.

## 📝 Additional Notes

