### PR TITLE
feat(player): add chapter markers and chapter list

### DIFF
--- a/components/DownloadItem.tsx
+++ b/components/DownloadItem.tsx
@@ -9,7 +9,7 @@ import type {
   BaseItemDto,
   MediaSourceInfo,
 } from "@jellyfin/sdk/lib/generated-client/models";
-import { getUserLibraryApi } from "@jellyfin/sdk/lib/utils/api/user-library-api";
+import { getUserLibraryApi } from "@jellyfin/sdk/lib/utils/api";
 import { type Href } from "expo-router";
 import { t } from "i18next";
 import { useAtom } from "jotai";

--- a/components/DownloadItem.tsx
+++ b/components/DownloadItem.tsx
@@ -9,6 +9,7 @@ import type {
   BaseItemDto,
   MediaSourceInfo,
 } from "@jellyfin/sdk/lib/generated-client/models";
+import { getUserLibraryApi } from "@jellyfin/sdk/lib/utils/api/user-library-api";
 import { type Href } from "expo-router";
 import { t } from "i18next";
 import { useAtom } from "jotai";
@@ -195,9 +196,30 @@ export const DownloadItems: React.FC<DownloadProps> = ({
         );
       }
       const downloadDetailsPromises = items.map(async (item) => {
+        // Ensure the snapshot we store offline carries the Chapters array.
+        // Page-level fetches sometimes use a fields filter that omits it; the
+        // offline player would then render no chapter ticks / list.
+        let itemForDownload = item;
+        if (!itemForDownload.Chapters && itemForDownload.Id) {
+          try {
+            const enriched = await getUserLibraryApi(api).getItem({
+              itemId: itemForDownload.Id,
+              userId: user.Id!,
+            });
+            if (enriched.data) {
+              itemForDownload = enriched.data;
+            }
+          } catch (e) {
+            console.warn(
+              "[DownloadItem] failed to refresh item for Chapters, falling back to original",
+              e,
+            );
+          }
+        }
+
         const { mediaSource, audioIndex, subtitleIndex } =
           itemsNotDownloaded.length > 1
-            ? getDefaultPlaySettings(item, settings!)
+            ? getDefaultPlaySettings(itemForDownload, settings!)
             : {
                 mediaSource: selectedOptions?.mediaSource,
                 audioIndex: selectedOptions?.audioIndex,
@@ -206,7 +228,7 @@ export const DownloadItems: React.FC<DownloadProps> = ({
 
         const downloadDetails = await getDownloadUrl({
           api,
-          item,
+          item: itemForDownload,
           userId: user.Id!,
           mediaSource: mediaSource!,
           audioStreamIndex: audioIndex ?? -1,
@@ -218,7 +240,7 @@ export const DownloadItems: React.FC<DownloadProps> = ({
 
         return {
           url: downloadDetails?.url,
-          item,
+          item: itemForDownload,
           mediaSource: downloadDetails?.mediaSource,
         };
       });

--- a/components/chapters/ChapterList.tsx
+++ b/components/chapters/ChapterList.tsx
@@ -6,7 +6,7 @@
 
 import { Ionicons } from "@expo/vector-icons";
 import type { ChapterInfo } from "@jellyfin/sdk/lib/generated-client/models";
-import { useEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { FlatList, Modal, Pressable, StyleSheet, View } from "react-native";
 import { Text } from "@/components/common/Text";
@@ -30,7 +30,7 @@ interface ChapterListProps {
 
 const ROW_HEIGHT = 48;
 
-export function ChapterList({
+function ChapterListComponent({
   visible,
   chapters,
   currentPositionMs,
@@ -150,6 +150,8 @@ export function ChapterList({
     </Modal>
   );
 }
+
+export const ChapterList = memo(ChapterListComponent);
 
 const styles = StyleSheet.create({
   backdrop: {

--- a/components/chapters/ChapterList.tsx
+++ b/components/chapters/ChapterList.tsx
@@ -1,0 +1,194 @@
+/**
+ * A modal listing an item's chapters. Each row shows the chapter name and its
+ * timestamp; the current chapter is highlighted. Tapping a row seeks to that
+ * chapter and closes the modal. Player-agnostic — the seek is injected.
+ */
+
+import { Ionicons } from "@expo/vector-icons";
+import type { ChapterInfo } from "@jellyfin/sdk/lib/generated-client/models";
+import { useEffect, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { FlatList, Modal, Pressable, StyleSheet, View } from "react-native";
+import { Text } from "@/components/common/Text";
+import { Colors } from "@/constants/Colors";
+import {
+  type ChapterEntry,
+  chapterStartsMs,
+  formatChapterTime,
+  sortedChapters,
+} from "@/utils/chapters";
+
+interface ChapterListProps {
+  visible: boolean;
+  chapters: ChapterInfo[] | null | undefined;
+  /** Current playback position in milliseconds (to highlight the row). */
+  currentPositionMs: number;
+  /** Seek the player to this millisecond position. */
+  onSeek: (positionMs: number) => void;
+  onClose: () => void;
+}
+
+const ROW_HEIGHT = 48;
+
+export function ChapterList({
+  visible,
+  chapters,
+  currentPositionMs,
+  onSeek,
+  onClose,
+}: ChapterListProps) {
+  const { t } = useTranslation();
+  const listRef = useRef<FlatList<ChapterEntry>>(null);
+
+  const entries = useMemo(() => sortedChapters(chapters), [chapters]);
+  // Memoize starts so currentChapterIndex computation doesn't re-sort/filter
+  // every tick — chapters is the only input that drives the underlying array.
+  const starts = useMemo(() => chapterStartsMs(chapters), [chapters]);
+  const activeIndex = useMemo(() => {
+    let idx = -1;
+    for (let i = 0; i < starts.length; i++) {
+      if (currentPositionMs >= starts[i]) idx = i;
+      else break;
+    }
+    return idx;
+  }, [currentPositionMs, starts]);
+
+  // FlatList.initialScrollIndex only fires at first mount; <Modal> keeps its
+  // children mounted across visible toggles, so subsequent opens never scroll.
+  // Trigger an imperative scroll each time the sheet becomes visible.
+  useEffect(() => {
+    if (!visible || activeIndex < 0 || entries.length === 0) return;
+    const raf = requestAnimationFrame(() => {
+      listRef.current?.scrollToIndex({
+        index: activeIndex,
+        animated: false,
+        viewPosition: 0.5,
+      });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [visible, activeIndex, entries.length]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType='slide'
+      onRequestClose={onClose}
+    >
+      <Pressable onPress={onClose} style={styles.backdrop}>
+        <Pressable onPress={(e) => e.stopPropagation()} style={styles.sheet}>
+          <View style={styles.header}>
+            <Text style={styles.title}>{t("chapters.title")}</Text>
+            <Pressable
+              onPress={onClose}
+              hitSlop={10}
+              accessibilityRole='button'
+              accessibilityLabel={t("chapters.close")}
+            >
+              <Ionicons name='close' size={24} color={Colors.text} />
+            </Pressable>
+          </View>
+          <FlatList
+            ref={listRef}
+            data={entries}
+            keyExtractor={(item, index) => `${item.positionMs}-${index}`}
+            getItemLayout={(_, index) => ({
+              length: ROW_HEIGHT,
+              offset: ROW_HEIGHT * index,
+              index,
+            })}
+            onScrollToIndexFailed={(info) => {
+              // Required when getItemLayout is provided and the target index
+              // is outside the currently rendered window. Fallback to an
+              // offset-based scroll, then retry the precise scroll once a
+              // frame has elapsed.
+              listRef.current?.scrollToOffset({
+                offset: info.averageItemLength * info.index,
+                animated: false,
+              });
+              setTimeout(() => {
+                listRef.current?.scrollToIndex({
+                  index: info.index,
+                  animated: false,
+                  viewPosition: 0.5,
+                });
+              }, 50);
+            }}
+            renderItem={({ item, index }) => {
+              const positionMs = item.positionMs;
+              const isActive = index === activeIndex;
+              return (
+                <Pressable
+                  onPress={() => {
+                    onSeek(positionMs);
+                    onClose();
+                  }}
+                  style={[
+                    styles.row,
+                    isActive && { backgroundColor: `${Colors.primary}33` },
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.rowText,
+                      { color: isActive ? Colors.primary : Colors.text },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {item.chapter.Name ||
+                      t("chapters.chapter_number", { number: index + 1 })}
+                  </Text>
+                  <Text style={styles.rowTime}>
+                    {formatChapterTime(positionMs)}
+                  </Text>
+                </Pressable>
+              );
+            }}
+          />
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  sheet: {
+    backgroundColor: Colors.background,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    maxHeight: "70%",
+    paddingBottom: 24,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: 16,
+  },
+  title: {
+    color: Colors.text,
+    fontSize: 17,
+    fontWeight: "700",
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    height: ROW_HEIGHT,
+  },
+  rowText: {
+    fontSize: 15,
+    flex: 1,
+  },
+  rowTime: {
+    color: Colors.icon,
+    fontSize: 13,
+    marginLeft: 12,
+  },
+});

--- a/components/chapters/ChapterTicks.tsx
+++ b/components/chapters/ChapterTicks.tsx
@@ -4,7 +4,7 @@
  * so the slider underneath still receives touches.
  */
 
-import { useState } from "react";
+import { memo, useState } from "react";
 import { type LayoutChangeEvent, PixelRatio, View } from "react-native";
 import type { ChapterMarker } from "@/utils/chapters";
 
@@ -19,7 +19,7 @@ interface ChapterTicksProps {
   width?: number;
 }
 
-export function ChapterTicks({
+function ChapterTicksComponent({
   markers,
   // Semi-transparent black contrasts against both the filled progress
   // (#fff) and the unfilled track (rgba(255,255,255,0.2)) so the ticks
@@ -83,3 +83,5 @@ export function ChapterTicks({
     </View>
   );
 }
+
+export const ChapterTicks = memo(ChapterTicksComponent);

--- a/components/chapters/ChapterTicks.tsx
+++ b/components/chapters/ChapterTicks.tsx
@@ -1,0 +1,85 @@
+/**
+ * Chapter tick marks drawn as an absolute overlay over a progress slider.
+ * Renders nothing for media with one or zero chapters. `pointerEvents: "none"`
+ * so the slider underneath still receives touches.
+ */
+
+import { useState } from "react";
+import { type LayoutChangeEvent, PixelRatio, View } from "react-native";
+import type { ChapterMarker } from "@/utils/chapters";
+
+interface ChapterTicksProps {
+  /** Pre-computed markers (caller memoizes — avoids double-computing here). */
+  markers: ChapterMarker[];
+  /** Tick colour. */
+  color?: string;
+  /** Tick height in px — slightly less than the slider track thickness. */
+  height?: number;
+  /** Tick width in px — integer to avoid sub-pixel anti-aliasing. */
+  width?: number;
+}
+
+export function ChapterTicks({
+  markers,
+  // Semi-transparent black contrasts against both the filled progress
+  // (#fff) and the unfilled track (rgba(255,255,255,0.2)) so the ticks
+  // stay visible across the whole bar as playback advances.
+  color = "rgba(0,0,0,0.55)",
+  height = 14,
+  width = 2,
+}: ChapterTicksProps) {
+  // Hooks must run unconditionally — keep them before any early return.
+  const [sliderWidth, setSliderWidth] = useState(0);
+
+  const handleLayout = (e: LayoutChangeEvent) => {
+    setSliderWidth(e.nativeEvent.layout.width);
+  };
+
+  // One chapter (typically a single marker at 0) is not worth marking.
+  if (markers.length <= 1) return null;
+
+  return (
+    <View
+      pointerEvents='none'
+      onLayout={handleLayout}
+      style={{
+        position: "absolute",
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+        // Let ticks taller than this container bleed beyond its bounds.
+        overflow: "visible",
+      }}
+    >
+      {sliderWidth > 0 &&
+        markers
+          // Skip the leading 0ms marker — it overlaps the slider start and
+          // adds visual noise at an already-rendered boundary.
+          .filter((marker) => marker.positionMs > 0)
+          .map((marker, index) => {
+            // Align both the position AND the width onto the device's
+            // physical pixel grid. Without this, fractional dp values land
+            // at different sub-pixel fractions per tick — Android samples
+            // each one differently and some ticks render visibly thicker.
+            const centerDp = (marker.percent / 100) * sliderWidth;
+            const left = PixelRatio.roundToNearestPixel(centerDp - width / 2);
+            const snappedWidth = PixelRatio.roundToNearestPixel(width);
+            return (
+              <View
+                key={`${marker.positionMs}-${index}`}
+                style={{
+                  position: "absolute",
+                  left,
+                  top: "50%",
+                  marginTop: -height / 2,
+                  height,
+                  width: snappedWidth,
+                  backgroundColor: color,
+                }}
+              />
+            );
+          })}
+    </View>
+  );
+}

--- a/components/video-player/controls/BottomControls.tsx
+++ b/components/video-player/controls/BottomControls.tsx
@@ -189,7 +189,6 @@ export const BottomControls: FC<BottomControlsProps> = ({
               onPress={() => setChapterListVisible(true)}
               hitSlop={10}
               className='justify-center mr-4'
-              style={{ marginTop: 10 }}
               accessibilityRole='button'
               accessibilityLabel={t("chapters.open")}
             >

--- a/components/video-player/controls/BottomControls.tsx
+++ b/components/video-player/controls/BottomControls.tsx
@@ -1,18 +1,34 @@
-import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
-import type { FC } from "react";
-import { View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import type {
+  BaseItemDto,
+  ChapterInfo,
+} from "@jellyfin/sdk/lib/generated-client";
+import { type FC, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Pressable, View } from "react-native";
 import { Slider } from "react-native-awesome-slider";
 import { type SharedValue } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ChapterList } from "@/components/chapters/ChapterList";
+import { ChapterTicks } from "@/components/chapters/ChapterTicks";
 import { Text } from "@/components/common/Text";
 import { useSettings } from "@/utils/atoms/settings";
+import { chapterMarkers, chapterNameAt } from "@/utils/chapters";
 import NextEpisodeCountDownButton from "./NextEpisodeCountDownButton";
 import SkipButton from "./SkipButton";
 import { TimeDisplay } from "./TimeDisplay";
 import { TrickplayBubble } from "./TrickplayBubble";
 
+// Chapter tick height in dp — matches the slider track height for a clean,
+// flush look (no top/bottom overflow).
+const TICK_HEIGHT = 10;
+
 interface BottomControlsProps {
   item: BaseItemDto;
+  /** Item chapters, used for the tick overlay and chapter list. */
+  chapters?: ChapterInfo[] | null;
+  /** Total media duration in milliseconds. */
+  durationMs: number;
   showControls: boolean;
   isSliding: boolean;
   showRemoteBubble: boolean;
@@ -38,6 +54,8 @@ interface BottomControlsProps {
   handleSliderChange: (value: number) => void;
   handleTouchStart: () => void;
   handleTouchEnd: () => void;
+  /** Programmatic seek (chapter list, hotkeys) — bypasses slide gesture state. */
+  seekTo: (value: number) => void;
 
   // Trickplay props
   trickPlayUrl: {
@@ -61,6 +79,8 @@ interface BottomControlsProps {
 
 export const BottomControls: FC<BottomControlsProps> = ({
   item,
+  chapters,
+  durationMs,
   showControls,
   isSliding,
   showRemoteBubble,
@@ -84,12 +104,38 @@ export const BottomControls: FC<BottomControlsProps> = ({
   handleSliderChange,
   handleTouchStart,
   handleTouchEnd,
+  seekTo,
   trickPlayUrl,
   trickplayInfo,
   time,
 }) => {
   const { settings } = useSettings();
+  const { t } = useTranslation();
   const insets = useSafeAreaInsets();
+  const [chapterListVisible, setChapterListVisible] = useState(false);
+
+  // Only expose chapter UI when there are at least two real markers.
+  const chapterMarkerList = useMemo(
+    () => chapterMarkers(chapters, durationMs),
+    [chapters, durationMs],
+  );
+  const hasChapters = chapterMarkerList.length > 1;
+
+  // Current chapter name for the always-visible header label (live playback).
+  const currentChapterName = useMemo(
+    () => (hasChapters ? chapterNameAt(currentTime, chapters) : null),
+    [hasChapters, currentTime, chapters],
+  );
+
+  // Chapter name at the scrubbed position for the trickplay bubble. `time` is
+  // an {h,m,s} object derived from the slider's dragged value — convert back
+  // to ms for the lookup. Only useful while actively scrubbing.
+  const scrubChapterName = useMemo(() => {
+    if (!hasChapters) return null;
+    const scrubMs =
+      (time.hours * 3600 + time.minutes * 60 + time.seconds) * 1000;
+    return chapterNameAt(scrubMs, chapters);
+  }, [hasChapters, time.hours, time.minutes, time.seconds, chapters]);
 
   return (
     <View
@@ -131,8 +177,25 @@ export const BottomControls: FC<BottomControlsProps> = ({
           {item?.Type === "Audio" && (
             <Text className='text-xs opacity-50'>{item?.Album}</Text>
           )}
+          {currentChapterName ? (
+            <Text className='text-xs opacity-70 mt-1' numberOfLines={1}>
+              {currentChapterName}
+            </Text>
+          ) : null}
         </View>
-        <View className='flex flex-row space-x-2 shrink-0'>
+        <View className='flex flex-row items-center space-x-2 shrink-0'>
+          {hasChapters && (
+            <Pressable
+              onPress={() => setChapterListVisible(true)}
+              hitSlop={10}
+              className='justify-center mr-4'
+              style={{ marginTop: 10 }}
+              accessibilityRole='button'
+              accessibilityLabel={t("chapters.open")}
+            >
+              <Ionicons name='bookmarks' size={24} color='white' />
+            </Pressable>
+          )}
           <SkipButton
             showButton={showSkipButton}
             onPress={skipIntro}
@@ -176,6 +239,9 @@ export const BottomControls: FC<BottomControlsProps> = ({
               height: 10,
               justifyContent: "center",
               alignItems: "stretch",
+              // Allow chapter ticks taller than the 10px track to bleed out
+              // top/bottom (RN defaults to overflow: "hidden" on Android).
+              overflow: "visible",
             }}
             onTouchStart={handleTouchStart}
             onTouchEnd={handleTouchEnd}
@@ -203,6 +269,7 @@ export const BottomControls: FC<BottomControlsProps> = ({
                     trickPlayUrl={trickPlayUrl}
                     trickplayInfo={trickplayInfo}
                     time={time}
+                    chapterName={scrubChapterName}
                   />
                 )
               }
@@ -212,6 +279,7 @@ export const BottomControls: FC<BottomControlsProps> = ({
               minimumValue={min}
               maximumValue={max}
             />
+            <ChapterTicks markers={chapterMarkerList} height={TICK_HEIGHT} />
           </View>
           <TimeDisplay
             currentTime={currentTime}
@@ -219,6 +287,13 @@ export const BottomControls: FC<BottomControlsProps> = ({
           />
         </View>
       </View>
+      <ChapterList
+        visible={chapterListVisible}
+        chapters={chapters}
+        currentPositionMs={currentTime}
+        onSeek={seekTo}
+        onClose={() => setChapterListVisible(false)}
+      />
     </View>
   );
 };

--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -251,6 +251,7 @@ export const Controls: FC<Props> = ({
     handleTouchEnd,
     handleSliderComplete,
     handleSliderChange,
+    seekTo,
   } = useVideoSlider({
     progress,
     isSeeking,
@@ -528,6 +529,8 @@ export const Controls: FC<Props> = ({
           >
             <BottomControls
               item={item}
+              chapters={item.Chapters}
+              durationMs={maxMs}
               showControls={showControls}
               isSliding={isSliding}
               showRemoteBubble={showRemoteBubble}
@@ -551,6 +554,7 @@ export const Controls: FC<Props> = ({
               handleSliderChange={handleSliderChange}
               handleTouchStart={handleTouchStart}
               handleTouchEnd={handleTouchEnd}
+              seekTo={seekTo}
               trickPlayUrl={trickPlayUrl}
               trickplayInfo={trickplayInfo}
               time={isSliding || showRemoteBubble ? time : remoteTime}

--- a/components/video-player/controls/TrickplayBubble.tsx
+++ b/components/video-player/controls/TrickplayBubble.tsx
@@ -22,12 +22,15 @@ interface TrickplayBubbleProps {
     minutes: number;
     seconds: number;
   };
+  /** Chapter name at the scrubbed position, if any. */
+  chapterName?: string | null;
 }
 
 export const TrickplayBubble: FC<TrickplayBubbleProps> = ({
   trickPlayUrl,
   trickplayInfo,
   time,
+  chapterName,
 }) => {
   if (!trickPlayUrl || !trickplayInfo) {
     return null;
@@ -36,18 +39,29 @@ export const TrickplayBubble: FC<TrickplayBubbleProps> = ({
   const { x, y, url } = trickPlayUrl;
   const tileWidth = CONTROLS_CONSTANTS.TILE_WIDTH;
   const tileHeight = tileWidth / trickplayInfo.aspectRatio!;
+  const timeStr = `${time.hours > 0 ? `${time.hours}:` : ""}${
+    time.minutes < 10 ? `0${time.minutes}` : time.minutes
+  }:${time.seconds < 10 ? `0${time.seconds}` : time.seconds}`;
+
+  // Slightly larger preview than before (scale 1.6 vs old 1.4) to give the
+  // overlay text more room and feel closer to the Jellyfin web style.
+  const previewScale = 1.6;
 
   return (
     <View
       style={{
         position: "absolute",
         left: -62,
-        bottom: 0,
-        paddingTop: 30,
+        // Drop the bubble closer to the slider — less floating-high feel.
+        bottom: -20,
+        paddingTop: 12,
         paddingBottom: 5,
         width: tileWidth * 1.5,
         justifyContent: "center",
         alignItems: "center",
+        // Bring the bubble in front of the player title / overlays.
+        zIndex: 999,
+        elevation: 10,
       }}
     >
       <View
@@ -55,7 +69,7 @@ export const TrickplayBubble: FC<TrickplayBubbleProps> = ({
           width: tileWidth,
           height: tileHeight,
           alignSelf: "center",
-          transform: [{ scale: 1.4 }],
+          transform: [{ scale: previewScale }],
           borderRadius: 5,
         }}
         className='bg-neutral-800 overflow-hidden'
@@ -75,17 +89,51 @@ export const TrickplayBubble: FC<TrickplayBubbleProps> = ({
           source={{ uri: url }}
           contentFit='cover'
         />
+        {/*
+         * Bottom-right overlay (Jellyfin web style) — chapter name (small,
+         * faded) above the timestamp (small, bold). Sits on top of the
+         * trickplay frame inside the same overflow:hidden container so it
+         * always stays within the bubble bounds.
+         */}
+        <View
+          pointerEvents='none'
+          style={{
+            position: "absolute",
+            left: 4,
+            bottom: 3,
+            alignItems: "flex-start",
+            paddingHorizontal: 3,
+            paddingVertical: 1,
+            borderRadius: 3,
+            backgroundColor: "rgba(0,0,0,0.55)",
+            maxWidth: tileWidth - 8,
+          }}
+        >
+          {chapterName ? (
+            <Text
+              numberOfLines={1}
+              style={{
+                color: "#fff",
+                fontSize: 7,
+                opacity: 0.85,
+                lineHeight: 9,
+              }}
+            >
+              {chapterName}
+            </Text>
+          ) : null}
+          <Text
+            style={{
+              color: "#fff",
+              fontSize: 8,
+              fontWeight: "600",
+              lineHeight: 10,
+            }}
+          >
+            {timeStr}
+          </Text>
+        </View>
       </View>
-      <Text
-        style={{
-          marginTop: 30,
-          fontSize: 16,
-        }}
-      >
-        {`${time.hours > 0 ? `${time.hours}:` : ""}${
-          time.minutes < 10 ? `0${time.minutes}` : time.minutes
-        }:${time.seconds < 10 ? `0${time.seconds}` : time.seconds}`}
-      </Text>
     </View>
   );
 };

--- a/components/video-player/controls/TrickplayBubble.tsx
+++ b/components/video-player/controls/TrickplayBubble.tsx
@@ -52,8 +52,9 @@ export const TrickplayBubble: FC<TrickplayBubbleProps> = ({
       style={{
         position: "absolute",
         left: -62,
-        // Drop the bubble closer to the slider — less floating-high feel.
-        bottom: -20,
+        // Sit just above the slider — high enough not to overlap the
+        // progress bar, low enough to feel anchored to the thumb.
+        bottom: 0,
         paddingTop: 12,
         paddingBottom: 5,
         width: tileWidth * 1.5,

--- a/components/video-player/controls/hooks/useVideoSlider.ts
+++ b/components/video-player/controls/hooks/useVideoSlider.ts
@@ -74,6 +74,21 @@ export function useVideoSlider({
     [seek, play, progress, isSeeking],
   );
 
+  // Programmatic seek (chapter list, hotkeys) that bypasses the slide gesture.
+  // Reads `isPlaying` directly instead of `wasPlayingRef`, which is only set
+  // during a real slide and would carry stale state on a tap-to-seek.
+  const seekTo = useCallback(
+    (value: number) => {
+      const seekValue = Math.max(0, Math.floor(value));
+      progress.value = seekValue;
+      seek(seekValue);
+      if (isPlaying) {
+        play();
+      }
+    },
+    [seek, play, progress, isPlaying],
+  );
+
   const handleSliderChange = useCallback(
     debounce((value: number) => {
       // Convert ms to ticks for trickplay
@@ -96,5 +111,6 @@ export function useVideoSlider({
     handleTouchEnd,
     handleSliderComplete,
     handleSliderChange,
+    seekTo,
   };
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -610,6 +610,12 @@
     "downloaded_file_no": "No",
     "downloaded_file_cancel": "Cancel"
   },
+  "chapters": {
+    "title": "Chapters",
+    "chapter_number": "Chapter {{number}}",
+    "open": "Open chapters",
+    "close": "Close chapters"
+  },
   "item_card": {
     "next_up": "Next Up",
     "no_items_to_display": "No Items to Display",

--- a/utils/chapters.test.ts
+++ b/utils/chapters.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import {
+  chapterMarkers,
+  chapterNameAt,
+  chapterStartsMs,
+  currentChapterIndex,
+  formatChapterTime,
+  sortedChapters,
+} from "./chapters";
+
+// Helper: a ChapterInfo with a start in milliseconds.
+const ch = (ms: number, name?: string) => ({
+  StartPositionTicks: ms * 10000,
+  Name: name,
+});
+
+describe("chapterMarkers", () => {
+  test("maps chapters to position + percent", () => {
+    expect(chapterMarkers([ch(0), ch(30_000), ch(60_000)], 120_000)).toEqual([
+      { positionMs: 0, percent: 0 },
+      { positionMs: 30_000, percent: 25 },
+      { positionMs: 60_000, percent: 50 },
+    ]);
+  });
+
+  test("drops chapters past the duration", () => {
+    expect(chapterMarkers([ch(0), ch(200_000)], 120_000)).toEqual([
+      { positionMs: 0, percent: 0 },
+    ]);
+  });
+
+  test("returns [] when duration is 0 or chapters missing", () => {
+    expect(chapterMarkers([ch(0)], 0)).toEqual([]);
+    expect(chapterMarkers(null, 120_000)).toEqual([]);
+    expect(chapterMarkers(undefined, 120_000)).toEqual([]);
+  });
+
+  test("excludes a chapter exactly at the duration", () => {
+    expect(chapterMarkers([ch(0), ch(120_000)], 120_000)).toEqual([
+      { positionMs: 0, percent: 0 },
+    ]);
+  });
+
+  test("skips chapters with no StartPositionTicks", () => {
+    expect(
+      chapterMarkers([{ StartPositionTicks: undefined }, ch(30_000)], 120_000),
+    ).toEqual([{ positionMs: 30_000, percent: 25 }]);
+  });
+});
+
+describe("currentChapterIndex", () => {
+  const chapters = [ch(0), ch(30_000), ch(60_000)];
+  test("returns the chapter containing the position", () => {
+    expect(currentChapterIndex(0, chapters)).toBe(0);
+    expect(currentChapterIndex(15_000, chapters)).toBe(0);
+    expect(currentChapterIndex(30_000, chapters)).toBe(1);
+    expect(currentChapterIndex(90_000, chapters)).toBe(2);
+  });
+  test("returns -1 before the first chapter and for no chapters", () => {
+    expect(currentChapterIndex(-5, chapters)).toBe(-1);
+    expect(currentChapterIndex(10_000, [])).toBe(-1);
+    expect(currentChapterIndex(10_000, null)).toBe(-1);
+  });
+});
+
+describe("sortedChapters", () => {
+  test("pairs each chapter with its ms start, sorted ascending", () => {
+    const a = ch(60_000, "C");
+    const b = ch(0, "A");
+    const c = ch(30_000, "B");
+    expect(sortedChapters([a, b, c])).toEqual([
+      { chapter: b, positionMs: 0 },
+      { chapter: c, positionMs: 30_000 },
+      { chapter: a, positionMs: 60_000 },
+    ]);
+  });
+  test("returns [] for null/undefined", () => {
+    expect(sortedChapters(null)).toEqual([]);
+    expect(sortedChapters(undefined)).toEqual([]);
+  });
+});
+
+describe("chapterStartsMs", () => {
+  test("returns sorted ms positions", () => {
+    expect(chapterStartsMs([ch(60_000), ch(0), ch(30_000)])).toEqual([
+      0, 30_000, 60_000,
+    ]);
+  });
+
+  test("skips entries without StartPositionTicks", () => {
+    expect(
+      chapterStartsMs([ch(30_000), { StartPositionTicks: undefined }, ch(0)]),
+    ).toEqual([0, 30_000]);
+  });
+
+  test("returns [] for null/undefined/empty", () => {
+    expect(chapterStartsMs(null)).toEqual([]);
+    expect(chapterStartsMs(undefined)).toEqual([]);
+    expect(chapterStartsMs([])).toEqual([]);
+  });
+});
+
+describe("chapterNameAt", () => {
+  const named = [
+    { StartPositionTicks: 0, Name: "Intro" },
+    { StartPositionTicks: 30_000 * 10000, Name: "Action" },
+    { StartPositionTicks: 60_000 * 10000, Name: "Outro" },
+  ];
+
+  test("returns the chapter name for the active position", () => {
+    expect(chapterNameAt(0, named)).toBe("Intro");
+    expect(chapterNameAt(15_000, named)).toBe("Intro");
+    expect(chapterNameAt(45_000, named)).toBe("Action");
+    expect(chapterNameAt(90_000, named)).toBe("Outro");
+  });
+
+  test("returns null before the first chapter", () => {
+    expect(chapterNameAt(-1, named)).toBeNull();
+  });
+
+  test("returns null for null/undefined/empty chapters", () => {
+    expect(chapterNameAt(10_000, null)).toBeNull();
+    expect(chapterNameAt(10_000, undefined)).toBeNull();
+    expect(chapterNameAt(10_000, [])).toBeNull();
+  });
+
+  test("returns null when the active chapter has no Name", () => {
+    expect(chapterNameAt(15_000, [ch(0), ch(30_000)])).toBeNull();
+  });
+});
+
+describe("formatChapterTime", () => {
+  test("formats m:ss and h:mm:ss", () => {
+    expect(formatChapterTime(65_000)).toBe("1:05");
+    expect(formatChapterTime(3_725_000)).toBe("1:02:05");
+    expect(formatChapterTime(-100)).toBe("0:00");
+  });
+});

--- a/utils/chapters.ts
+++ b/utils/chapters.ts
@@ -70,9 +70,16 @@ export const chapterNameAt = (
   positionMs: number,
   chapters: ChapterInfo[] | null | undefined,
 ): string | null => {
-  const idx = currentChapterIndex(positionMs, chapters);
-  if (idx < 0) return null;
+  // Sort once, derive both the active index and the entry from the same array
+  // — `chapterNameAt` runs on every playback tick, so paying for one `sort()`
+  // instead of two is worth the duplication of the index loop here.
   const sorted = sortedChapters(chapters);
+  let idx = -1;
+  for (let i = 0; i < sorted.length; i++) {
+    if (positionMs >= sorted[i].positionMs) idx = i;
+    else break;
+  }
+  if (idx < 0) return null;
   const name = sorted[idx]?.chapter.Name;
   return name && name.length > 0 ? name : null;
 };

--- a/utils/chapters.ts
+++ b/utils/chapters.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure helpers for Jellyfin chapter markers. Dependency-free so they are
+ * unit-testable under `bun test`.
+ */
+
+import type { ChapterInfo } from "@jellyfin/sdk/lib/generated-client/models";
+import { ticksToMs } from "@/utils/time";
+
+export interface ChapterMarker {
+  /** Chapter start, in milliseconds. */
+  positionMs: number;
+  /** Chapter start as a percentage (0-100) of the media duration. */
+  percent: number;
+}
+
+export interface ChapterEntry {
+  chapter: ChapterInfo;
+  /** Chapter start, in milliseconds. */
+  positionMs: number;
+}
+
+/** Chapters paired with their millisecond start, sorted ascending by start. */
+export const sortedChapters = (
+  chapters: ChapterInfo[] | null | undefined,
+): ChapterEntry[] =>
+  (chapters ?? [])
+    .filter((c) => c.StartPositionTicks != null)
+    .map((chapter) => ({
+      chapter,
+      positionMs: ticksToMs(chapter.StartPositionTicks),
+    }))
+    .sort((a, b) => a.positionMs - b.positionMs);
+
+/** Chapter start positions in milliseconds, ascending. */
+export const chapterStartsMs = (
+  chapters: ChapterInfo[] | null | undefined,
+): number[] =>
+  (chapters ?? [])
+    .filter((c) => c.StartPositionTicks != null)
+    .map((c) => ticksToMs(c.StartPositionTicks))
+    .sort((a, b) => a - b);
+
+/** Chapter markers within [0, durationMs]; empty when duration is unknown. */
+export const chapterMarkers = (
+  chapters: ChapterInfo[] | null | undefined,
+  durationMs: number,
+): ChapterMarker[] => {
+  if (durationMs <= 0) return [];
+  return chapterStartsMs(chapters)
+    .filter((ms) => ms >= 0 && ms < durationMs)
+    .map((ms) => ({ positionMs: ms, percent: (ms / durationMs) * 100 }));
+};
+
+/** Index of the chapter containing `positionMs`, or -1 if before the first. */
+export const currentChapterIndex = (
+  positionMs: number,
+  chapters: ChapterInfo[] | null | undefined,
+): number => {
+  const starts = chapterStartsMs(chapters);
+  let index = -1;
+  for (let i = 0; i < starts.length; i++) {
+    if (positionMs >= starts[i]) index = i;
+    else break;
+  }
+  return index;
+};
+
+/** Name of the chapter containing `positionMs`, or null if none / unnamed. */
+export const chapterNameAt = (
+  positionMs: number,
+  chapters: ChapterInfo[] | null | undefined,
+): string | null => {
+  const idx = currentChapterIndex(positionMs, chapters);
+  if (idx < 0) return null;
+  const sorted = sortedChapters(chapters);
+  const name = sorted[idx]?.chapter.Name;
+  return name && name.length > 0 ? name : null;
+};
+
+/** `m:ss` (or `h:mm:ss` past an hour) label for a millisecond position. */
+export const formatChapterTime = (positionMs: number): string => {
+  const total = Math.max(0, Math.floor(positionMs / 1000));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = total % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return hours > 0
+    ? `${hours}:${pad(minutes)}:${pad(seconds)}`
+    : `${minutes}:${pad(seconds)}`;
+};


### PR DESCRIPTION
# 📦 Pull Request

## 🔖 Summary
Surface Jellyfin chapter markers in the native video player — tick marks on the seek bar, a chapter list sheet to jump between chapters, the active chapter name in the controls header, and the chapter name on the trickplay bubble while scrubbing. Works online and offline.

## 🏷️ Ticket / Issue
- Supersedes #1299
- Closes #34 (Chapters in videos — original request)

## 🛠️ What's Changed
- Type: `feat`
- Scope: `player`
- Adds chapter tick marks on the progress bar, a chapter list sheet, a live chapter-name label in the player header, and the chapter name on the trickplay bubble while scrubbing. Refreshes the cached `BaseItemDto.Chapters` at download time so offline playback gets the same UI.

## 📋 Details

Jellyfin exposes chapter markers on items, but the native player never surfaced them. This PR wires the data end-to-end with a strong split between pure helpers, presentational components, and integration glue.

### Architecture (4 commits)

| Commit | Layer | Files |
|---|---|---|
| `8d33aa3b` | Pure helpers + unit tests | `utils/chapters.ts`, `utils/chapters.test.ts` |
| `5f64ce49` | Presentational components (player-agnostic) | `components/chapters/ChapterTicks.tsx`, `components/chapters/ChapterList.tsx` |
| `98b90f5b` | Integration into the native player | `components/video-player/controls/{BottomControls,Controls,TrickplayBubble}.tsx`, `components/video-player/controls/hooks/useVideoSlider.ts`, `translations/en.json` |
| `558fb418` | Offline robustness | `components/DownloadItem.tsx` |

### Helpers (`utils/chapters.ts`)

Dependency-free, fully tested under `bun test`:
- `chapterMarkers(chapters, durationMs)` — markers within range, with precomputed `percent` for slider overlays.
- `chapterStartsMs(chapters)` — sorted start positions in ms (skips entries without `StartPositionTicks`).
- `currentChapterIndex(positionMs, chapters)` — active chapter index (-1 before the first chapter).
- `chapterNameAt(positionMs, chapters)` — active chapter name, or `null` if missing/unnamed.
- `sortedChapters(chapters)` — chapter entries paired with ms start.
- `formatChapterTime(positionMs)` — `m:ss` / `h:mm:ss` label.

All tolerate `null` / `undefined` / `[]`. **17 unit tests** cover sort order, boundary positions, missing fields and out-of-range inputs.

### `ChapterTicks` — slider overlay

- Reads pre-computed markers from a memoized prop (single filter/sort per `chapters` change).
- **Snaps tick position AND width onto the device pixel grid** via `PixelRatio.roundToNearestPixel()`. Without this, fractional dp values land at different sub-pixel fractions on non-integer density displays (this emulator is 420dpi → ratio 2.625), so Android anti-aliases each tick differently and some look visibly thicker than others.
- Default tick height = `10dp` (matches slider track for a flush look; configurable via prop for inside-track / overflow styles).
- Default tick color = `rgba(0,0,0,0.55)`, chosen so ticks stay visible against both the filled progress (`#fff`) and the unfilled track (`rgba(255,255,255,0.2)`) — old chapters visible as playback advances.
- Skips the leading `0ms` marker (overlaps the slider start visually).
- `pointerEvents="none"` so the slider still receives touches, `overflow: "visible"` so taller ticks can bleed beyond the 10dp track.

### `ChapterList` — bottom-sheet modal

- Highlights the active row (primary purple tint from `constants/Colors.ts`).
- Falls back to a localized `"Chapter N"` label when a chapter has no name.
- **Imperatively scrolls to the active chapter on each open**: `<Modal>` keeps its children mounted across `visible` toggles, so `FlatList.initialScrollIndex` (one-shot at mount) only worked on the first open. Uses a ref + `useEffect` on `visible` + `scrollToIndex` inside `requestAnimationFrame`, with an `onScrollToIndexFailed` fallback for indices outside the render window.
- All static styles in `StyleSheet.create()`; only dynamic `backgroundColor` / text color stays inline. The list re-renders on every playback tick (active row highlight follows `currentTime`), so cutting per-render style allocations is a measurable win.
- Color tokens from `constants/Colors.ts` — no hardcoded hex.
- `accessibilityRole` + `accessibilityLabel` on the close button.

### Player integration

`BottomControls`:
- Memoizes `chapterMarkerList` once per `(chapters, durationMs)` change.
- `hasChapters` gates the bookmark icon + list modal — nothing renders below two real markers.
- Adds a small **chapter-name label below the title/year** during playback. Updates live with `currentTime` (memoized).
- Computes a `scrubChapterName` (chapter at the dragged slider position) and pipes it into `TrickplayBubble`.

`useVideoSlider`:
- Adds `seekTo(value)`: a programmatic seek for non-gesture entry points (chapter list, hotkeys). Reads `isPlaying` directly instead of `wasPlayingRef`, which is only set inside `handleSliderStart`. Without this, a tap-to-seek from the chapter list previously either left paused playback stranded or auto-resumed against a manual pause.

`TrickplayBubble`:
- Accepts an optional `chapterName` prop. Renders a small bottom-left overlay inside the preview frame (Jellyfin-web style): chapter name above the timestamp. Hides the chapter line entirely when `null`.
- `zIndex` + `elevation` so the bubble lands in front of the title / surrounding overlays.
- Tightened positioning to sit just above the slider.

`translations/en.json`:
- `chapters.title`, `chapters.chapter_number`, `chapters.open`, `chapters.close` for the list modal and the bookmark a11y label.

### Offline robustness (`DownloadItem`)

Some screens fetch items with a `fields` filter (e.g. `series/[id].tsx` uses `["MediaSources", "MediaStreams", "Overview", "Trickplay"]`) and pass that DTO straight into the download flow. Jellyfin only returns `Chapters` in that case when explicitly listed, so the snapshot stored under `DownloadedItem.item` would have `Chapters: undefined`, and the offline player would render no ticks / list / chapter label.

`initiateDownload` now re-fetches via `getUserLibraryApi.getItem` (no fields filter → full DTO incl. `Chapters`) when `Chapters` is missing, and uses the enriched item for both `getDownloadUrl` and the snapshot. If the refresh call fails, we log a warning and fall back to the original item — the download itself still proceeds.

Trickplay offline already worked via `useTrickplay`, which reads `downloadedItem.trickPlayData.path` from the locally cached sheets.

### Edge cases handled

- **No chapters at all** → bookmark icon, list, header label, and trickplay chapter line all hide gracefully.
- **Chapters with empty/missing names** → fall back to `"Chapter N"` in the list, hide the chapter line in the bubble.
- **Single chapter** (typically `0ms` only) → `ChapterTicks` and chapter button hide (not worth marking).
- **Marker outside `[0, durationMs)`** → filtered out (no off-track ticks).
- **Modal re-opens** → scrolls to the active chapter again (fixes RN `<Modal>` + `initialScrollIndex` interaction).
- **Programmatic seek vs slide gesture** → distinct `seekTo` path avoids stale `wasPlayingRef`.
- **Non-integer device density** → pixel-grid snapping keeps tick size uniform.
- **White-on-white** → dark semi-transparent tick colour stays visible over the filled progress.
- **Offline playback** → `Chapters` refreshed at download time so the snapshot always carries them.

### ⚠️ Breaking Changes
None. All new components / helpers; no public API changes.

### 🔐 Security & Privacy Impact
None. Reads existing item metadata; no new network calls outside the (already authenticated) `getItem` refresh at download time.

### ⚡ Performance
- Chapter markers + `starts` memoized once per `chapters` change (not per tick).
- Active chapter index computed by iterating a pre-sorted `number[]` — no sort per tick.
- `ChapterTicks` renders once per `(chapters, durationMs, sliderWidth)`; ticks are plain absolute `<View>`s, no animations.
- Trickplay chapter name memoized on `(time.h, time.m, time.s)` so it only recomputes during a slide.
- `StyleSheet.create()` for the chapter list so high-frequency re-renders don't reallocate static style objects.
- Pixel-grid snapping avoids GPU subpixel oversampling on tick edges.

### ♿ Accessibility
- Bookmark icon: `accessibilityRole="button"`, `accessibilityLabel={t("chapters.open")}`.
- Close (X) in the list: `accessibilityRole="button"`, `accessibilityLabel={t("chapters.close")}`.
- Active row uses both colour change and background tint (not colour-only).

### 🖼️ Screenshots / GIFs
<img width="1684" height="757" alt="studio64_zVJYescr6h" src="https://github.com/user-attachments/assets/dad12cc2-4881-4afc-b582-55b08bdc61ee" />
<img width="1686" height="758" alt="studio64_SwvQDJdjxH" src="https://github.com/user-attachments/assets/da3d4452-22c5-4d1c-bdab-b1d5a315b3d0" />
<img width="1681" height="756" alt="studio64_515Yb41Ow0" src="https://github.com/user-attachments/assets/f7b4f048-1526-4500-b44b-31f7b0fecca4" />

## ✅ Checklist
- [x] I've read the contribution guidelines
- [x] Code follows project style and passes lint/format (`bunx biome check`)
- [x] Type checks pass (`bunx tsc --noEmit` — pre-existing `utils/jellyseerr/server/*` errors only, unrelated)
- [x] Unit tests added and passing (`bun test utils/chapters.test.ts` → 17/17)
- [ ] Docs updated (README/ADR/usage/API) — n/a, new internal components
- [x] No secrets/credentials included; env vars documented
- [ ] Release notes/CHANGELOG entry added (if applicable)
- [x] Verified locally on Android emulator (online + offline)

## 🔍 Testing Instructions

### Online
1. Check out `feat/chapters` and run the app (`bun run android` / `bun run ios`).
2. Play a file **with chapters** (e.g. *Avengers: Endgame* — has ~20 chapters):
   - Tick marks visible on the progress bar.
   - Bookmark icon at the right of the controls header.
   - Chapter name shown below the title (updates live as playback advances).
   - Scrub the slider → trickplay bubble shows the chapter name above the timestamp.
   - Tap the bookmark → list opens, current chapter highlighted, list scrolls to it.
   - Tap any chapter row → seeks there, playback state (playing/paused) preserved.
3. Play a file **without chapters** → no ticks, no bookmark icon, no chapter label, no chapter line in the trickplay bubble.
4. Run `bun test utils/chapters.test.ts` → 17 tests pass.

### Offline
1. Download a movie with chapters.
2. Force-stop the app, disable Wi-Fi on the device.
3. Open the app → Downloads → play the file.
4. Same checks as online: ticks, list, header label, trickplay chapter name — all rendered from the cached snapshot.

## ⚙️ Deployment Notes
None.

## 📝 Additional Notes
The chapter components are intentionally player-agnostic so the Chromecast player (PR #1402) can reuse `ChapterTicks` + `ChapterList` without duplication — just inject its own `onSeek` and `currentPositionMs`.