### PR TITLE
chore: upgrade Biome to 2.4.16, clean up lint, and fix TV password modal

### DIFF
--- a/app/(auth)/(tabs)/(custom-links)/index.tsx
+++ b/app/(auth)/(tabs)/(custom-links)/index.tsx
@@ -16,7 +16,7 @@ export interface MenuLink {
   icon: string;
 }
 
-export default function menuLinks() {
+export default function CustomLinksPage() {
   const [api] = useAtom(apiAtom);
   const insets = useSafeAreaInsets();
   const [menuLinks, setMenuLinks] = useState<MenuLink[]>([]);

--- a/app/(auth)/(tabs)/(favorites)/index.tsx
+++ b/app/(auth)/(tabs)/(favorites)/index.tsx
@@ -5,7 +5,7 @@ import { Favorites } from "@/components/home/Favorites";
 import { Favorites as TVFavorites } from "@/components/home/Favorites.tv";
 import { useInvalidatePlaybackProgressCache } from "@/hooks/useRevalidatePlaybackProgressCache";
 
-export default function favorites() {
+export default function FavoritesPage() {
   const invalidateCache = useInvalidatePlaybackProgressCache();
 
   const [loading, setLoading] = useState(false);

--- a/app/(auth)/(tabs)/(home)/downloads/index.tsx
+++ b/app/(auth)/(tabs)/(home)/downloads/index.tsx
@@ -20,7 +20,7 @@ import { OfflineModeProvider } from "@/providers/OfflineModeProvider";
 import { queueAtom } from "@/utils/atoms/queue";
 import { writeToLog } from "@/utils/log";
 
-export default function page() {
+export default function DownloadsPage() {
   const navigation = useNavigation();
   const { t } = useTranslation();
   const [_queue, _setQueue] = useAtom(queueAtom);

--- a/app/(auth)/(tabs)/(home)/sessions/index.tsx
+++ b/app/(auth)/(tabs)/(home)/sessions/index.tsx
@@ -23,7 +23,7 @@ import { formatBitrate } from "@/utils/bitrate";
 import { getPrimaryImageUrl } from "@/utils/jellyfin/image/getPrimaryImageUrl";
 import { formatTimeString } from "@/utils/time";
 
-export default function page() {
+export default function SessionsPage() {
   const { sessions, isLoading } = useSessions({} as useSessionsProps);
   const { t } = useTranslation();
 
@@ -72,7 +72,7 @@ const SessionCard = ({ session }: SessionCardProps) => {
   };
 
   const getProgressPercentage = () => {
-    if (!session.NowPlayingItem || !session.NowPlayingItem.RunTimeTicks) {
+    if (!session.NowPlayingItem?.RunTimeTicks) {
       return 0;
     }
 

--- a/app/(auth)/(tabs)/(home)/settings/appearance/hide-libraries/page.tsx
+++ b/app/(auth)/(tabs)/(home)/settings/appearance/hide-libraries/page.tsx
@@ -12,7 +12,7 @@ import DisabledSetting from "@/components/settings/DisabledSetting";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { useSettings } from "@/utils/atoms/settings";
 
-export default function page() {
+export default function AppearanceHideLibrariesPage() {
   const { settings, updateSettings, pluginSettings } = useSettings();
   const user = useAtomValue(userAtom);
   const api = useAtomValue(apiAtom);

--- a/app/(auth)/(tabs)/(home)/settings/hide-libraries/page.tsx
+++ b/app/(auth)/(tabs)/(home)/settings/hide-libraries/page.tsx
@@ -11,7 +11,7 @@ import DisabledSetting from "@/components/settings/DisabledSetting";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { useSettings } from "@/utils/atoms/settings";
 
-export default function page() {
+export default function HideLibrariesPage() {
   const { settings, updateSettings, pluginSettings } = useSettings();
   const user = useAtomValue(userAtom);
   const api = useAtomValue(apiAtom);

--- a/app/(auth)/(tabs)/(home)/settings/plugins/jellyseerr/page.tsx
+++ b/app/(auth)/(tabs)/(home)/settings/plugins/jellyseerr/page.tsx
@@ -4,7 +4,7 @@ import DisabledSetting from "@/components/settings/DisabledSetting";
 import { JellyseerrSettings } from "@/components/settings/Jellyseerr";
 import { useSettings } from "@/utils/atoms/settings";
 
-export default function page() {
+export default function JellyseerrPluginPage() {
   const { pluginSettings } = useSettings();
   const insets = useSafeAreaInsets();
 

--- a/app/(auth)/(tabs)/(home)/settings/plugins/kefinTweaks/page.tsx
+++ b/app/(auth)/(tabs)/(home)/settings/plugins/kefinTweaks/page.tsx
@@ -4,7 +4,7 @@ import DisabledSetting from "@/components/settings/DisabledSetting";
 import { KefinTweaksSettings } from "@/components/settings/KefinTweaks";
 import { useSettings } from "@/utils/atoms/settings";
 
-export default function page() {
+export default function KefinTweaksPage() {
   const { pluginSettings } = useSettings();
   const insets = useSafeAreaInsets();
 

--- a/app/(auth)/(tabs)/(home)/settings/plugins/marlin-search/page.tsx
+++ b/app/(auth)/(tabs)/(home)/settings/plugins/marlin-search/page.tsx
@@ -18,7 +18,7 @@ import DisabledSetting from "@/components/settings/DisabledSetting";
 import { useNetworkAwareQueryClient } from "@/hooks/useNetworkAwareQueryClient";
 import { useSettings } from "@/utils/atoms/settings";
 
-export default function page() {
+export default function MarlinSearchPage() {
   const navigation = useNavigation();
 
   const { t } = useTranslation();

--- a/app/(auth)/(tabs)/(home)/settings/plugins/streamystats/page.tsx
+++ b/app/(auth)/(tabs)/(home)/settings/plugins/streamystats/page.tsx
@@ -17,7 +17,7 @@ import { ListItem } from "@/components/list/ListItem";
 import { useNetworkAwareQueryClient } from "@/hooks/useNetworkAwareQueryClient";
 import { useSettings } from "@/utils/atoms/settings";
 
-export default function page() {
+export default function StreamystatsPage() {
   const { t } = useTranslation();
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();

--- a/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/jellyseerr/company/[companyId].tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/jellyseerr/company/[companyId].tsx
@@ -13,7 +13,7 @@ import {
 } from "@/utils/jellyseerr/server/models/Search";
 import { COMPANY_LOGO_IMAGE_FILTER } from "@/utils/jellyseerr/src/components/Discover/NetworkSlider";
 
-export default function page() {
+export default function JellyseerrCompanyPage() {
   const local = useLocalSearchParams();
   const { jellyseerrApi, isJellyseerrMovieOrTvResult } = useJellyseerr();
 

--- a/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/jellyseerr/genre/[genreId].tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/jellyseerr/genre/[genreId].tsx
@@ -9,7 +9,7 @@ import JellyseerrPoster from "@/components/posters/JellyseerrPoster";
 import { Endpoints, useJellyseerr } from "@/hooks/useJellyseerr";
 import { DiscoverSliderType } from "@/utils/jellyseerr/server/constants/discover";
 
-export default function page() {
+export default function JellyseerrGenrePage() {
   const local = useLocalSearchParams();
   const { jellyseerrApi, isJellyseerrMovieOrTvResult } = useJellyseerr();
 

--- a/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/jellyseerr/person/[personId].tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/jellyseerr/person/[personId].tsx
@@ -11,7 +11,7 @@ import JellyseerrPoster from "@/components/posters/JellyseerrPoster";
 import { useJellyseerr } from "@/hooks/useJellyseerr";
 import type { PersonCreditCast } from "@/utils/jellyseerr/server/models/Person";
 
-export default function page() {
+export default function JellyseerrPersonPage() {
   const local = useLocalSearchParams();
   const { t } = useTranslation();
 

--- a/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/livetv/channels.tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/livetv/channels.tsx
@@ -8,7 +8,7 @@ import { ItemImage } from "@/components/common/ItemImage";
 import { Text } from "@/components/common/Text";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 
-export default function page() {
+export default function LiveTvChannelsPage() {
   const [api] = useAtom(apiAtom);
   const [user] = useAtom(userAtom);
   const _insets = useSafeAreaInsets();

--- a/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/livetv/guide.tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/livetv/guide.tsx
@@ -17,7 +17,7 @@ const ITEMS_PER_PAGE = 20;
 
 const MemoizedLiveTVGuideRow = React.memo(LiveTVGuideRow);
 
-export default function page() {
+export default function LiveTvGuidePage() {
   const [api] = useAtom(apiAtom);
   const [user] = useAtom(userAtom);
   const insets = useSafeAreaInsets();

--- a/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/livetv/recordings.tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/livetv/recordings.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 import { Text } from "@/components/common/Text";
 
-export default function page() {
+export default function LiveTvRecordingsPage() {
   const { t } = useTranslation();
   return (
     <View className='flex items-center justify-center h-full -mt-12'>

--- a/app/(auth)/(tabs)/(search)/index.tsx
+++ b/app/(auth)/(tabs)/(search)/index.tsx
@@ -66,7 +66,7 @@ const exampleSearches = [
   "The Mandalorian",
 ];
 
-export default function search() {
+export default function SearchPage() {
   const params = useLocalSearchParams();
   const insets = useSafeAreaInsets();
   const router = useRouter();
@@ -221,7 +221,7 @@ export default function search() {
 
         const ids = response1.data.ids;
 
-        if (!ids || !ids.length) {
+        if (!ids?.length) {
           return [];
         }
 

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -63,7 +63,7 @@ import { writeToLog } from "@/utils/log";
 import { msToTicks, ticksToSeconds } from "@/utils/time";
 import { generateDeviceProfile } from "../../../utils/profiles/native";
 
-export default function page() {
+export default function DirectPlayerPage() {
   const videoRef = useRef<MpvPlayerViewRef>(null);
   const user = useAtomValue(userAtom);
   const api = useAtomValue(apiAtom);
@@ -317,7 +317,7 @@ export default function page() {
         }
 
         let result: Stream | null = null;
-        if (offline && downloadedItem && downloadedItem.mediaSource) {
+        if (offline && downloadedItem?.mediaSource) {
           const url = downloadedItem.videoFilePath;
           if (item) {
             result = {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "files": {
     "includes": [
       "**/*",

--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.28.6",
-        "@biomejs/biome": "2.3.11",
+        "@biomejs/biome": "2.4.16",
         "@react-native-community/cli": "20.1.3",
         "@react-native-tvos/config-tv": "0.1.6",
         "@types/jest": "29.5.14",
@@ -309,23 +309,23 @@
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.11", "@biomejs/cli-darwin-x64": "2.3.11", "@biomejs/cli-linux-arm64": "2.3.11", "@biomejs/cli-linux-arm64-musl": "2.3.11", "@biomejs/cli-linux-x64": "2.3.11", "@biomejs/cli-linux-x64-musl": "2.3.11", "@biomejs/cli-win32-arm64": "2.3.11", "@biomejs/cli-win32-x64": "2.3.11" }, "bin": { "biome": "bin/biome" } }, "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@bottom-tabs/react-navigation": ["@bottom-tabs/react-navigation@1.2.0", "", { "dependencies": { "color": "^5.0.0" }, "peerDependencies": { "@react-navigation/native": ">=7", "react": "*", "react-native": "*", "react-native-bottom-tabs": "*" } }, "sha512-gEnLP7q9Iai0KlVxHDIdlrDgkvJ5vwPzL2+2ucz5BdPWd++Cf5GO1jPq92R4/85PrioviCZnlAD91Wx8WxPOjA=="],
 

--- a/components/PlayButton.tsx
+++ b/components/PlayButton.tsx
@@ -414,7 +414,7 @@ export const PlayButton: React.FC<Props> = ({
   ]);
 
   const derivedTargetWidth = useDerivedValue(() => {
-    if (!item || !item.RunTimeTicks) return 0;
+    if (!item?.RunTimeTicks) return 0;
     const userData = item.UserData;
     if (userData?.PlaybackPositionTicks) {
       return userData.PlaybackPositionTicks > 0

--- a/components/PlayButton.tv.tsx
+++ b/components/PlayButton.tv.tsx
@@ -78,7 +78,7 @@ export const PlayButton: React.FC<Props> = ({
   };
 
   const derivedTargetWidth = useDerivedValue(() => {
-    if (!item || !item.RunTimeTicks) return 0;
+    if (!item?.RunTimeTicks) return 0;
     const userData = item.UserData;
     if (userData?.PlaybackPositionTicks) {
       return userData.PlaybackPositionTicks > 0

--- a/components/downloads/DownloadCard.tsx
+++ b/components/downloads/DownloadCard.tsx
@@ -116,7 +116,7 @@ export const DownloadCard = ({ process, ...props }: DownloadCardProps) => {
   }, [process?.progress]);
 
   // Return null after all hooks have been called
-  if (!process || !process.item || !process.item.Id) {
+  if (!process?.item?.Id) {
     return null;
   }
 

--- a/components/home/TVHeroCarousel.tsx
+++ b/components/home/TVHeroCarousel.tsx
@@ -351,7 +351,7 @@ export const TVHeroCarousel: React.FC<TVHeroCarouselProps> = ({
 
   // Get subtitle for episodes
   const episodeSubtitle = useMemo(() => {
-    if (!activeItem || activeItem.Type !== "Episode") return null;
+    if (activeItem?.Type !== "Episode") return null;
     return `S${activeItem.ParentIndexNumber} E${activeItem.IndexNumber} · ${activeItem.Name}`;
   }, [activeItem]);
 

--- a/components/livetv/TVChannelCard.tsx
+++ b/components/livetv/TVChannelCard.tsx
@@ -180,4 +180,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export { CARD_WIDTH, CARD_HEIGHT };
+export { CARD_HEIGHT, CARD_WIDTH };

--- a/components/livetv/TVLiveTVGuide.tsx
+++ b/components/livetv/TVLiveTVGuide.tsx
@@ -155,7 +155,7 @@ export const TVLiveTVGuide: React.FC = () => {
   );
 
   // Fetch programs for visible channels
-  const { data: programsData, isLoading: isLoadingPrograms } = useQuery({
+  const { data: programsData } = useQuery({
     queryKey: [
       "livetv",
       "tv-guide",

--- a/components/login/TVPasswordEntryModal.tsx
+++ b/components/login/TVPasswordEntryModal.tsx
@@ -14,6 +14,7 @@ import {
 } from "react-native";
 import { Text } from "@/components/common/Text";
 import { useTVFocusAnimation } from "@/components/tv";
+import { useTVBackPress } from "@/hooks/useTVBackPress";
 import { scaleSize } from "@/utils/scaleSize";
 
 interface TVPasswordEntryModalProps {
@@ -200,6 +201,13 @@ export const TVPasswordEntryModal: React.FC<TVPasswordEntryModalProps> = ({
     }
     setIsReady(false);
   }, [visible]);
+
+  // Close the modal on the TV remote back/menu button while it is open.
+  useTVBackPress(() => {
+    if (!visible) return false;
+    onClose();
+    return true;
+  }, [visible, onClose]);
 
   const handleSubmit = async () => {
     if (!password) {

--- a/components/video-player/controls/Controls.tv.tsx
+++ b/components/video-player/controls/Controls.tv.tsx
@@ -59,6 +59,7 @@ import { useRemoteControl } from "./hooks/useRemoteControl";
 import { useVideoTime } from "./hooks/useVideoTime";
 import { TechnicalInfoOverlay } from "./TechnicalInfoOverlay";
 import { TrickplayBubble } from "./TrickplayBubble";
+import type { Track } from "./types";
 import { useControlsTimeout } from "./useControlsTimeout";
 
 interface Props {
@@ -314,6 +315,20 @@ export const Controls: FC<Props> = ({
     },
     [onSubtitleIndexChange],
   );
+
+  // Re-fetch subtitle streams from the server (e.g. after a server-side
+  // download) and map them to the modal's Track shape. setTrack drives the
+  // player through the same handler used for manual subtitle selection.
+  const refreshSubtitleTracks = useCallback(async (): Promise<Track[]> => {
+    const streams = (await onRefreshSubtitleTracks?.()) ?? [];
+    return streams.map((stream) => ({
+      name:
+        stream.DisplayTitle ||
+        `${stream.Language || "Unknown"} (${stream.Codec})`,
+      index: stream.Index ?? -1,
+      setTrack: () => onSubtitleIndexChange?.(stream.Index ?? -1),
+    }));
+  }, [onRefreshSubtitleTracks, onSubtitleIndexChange]);
 
   const {
     trickPlayUrl,
@@ -572,6 +587,9 @@ export const Controls: FC<Props> = ({
         disableTrack?.setTrack();
       },
       onLocalSubtitleDownloaded: handleLocalSubtitleDownloaded,
+      refreshSubtitleTracks: onRefreshSubtitleTracks
+        ? refreshSubtitleTracks
+        : undefined,
     });
     controlsInteractionRef.current();
   }, [
@@ -581,6 +599,8 @@ export const Controls: FC<Props> = ({
     videoContextSubtitleTracks,
     subtitleIndex,
     handleLocalSubtitleDownloaded,
+    onRefreshSubtitleTracks,
+    refreshSubtitleTracks,
   ]);
 
   const handleToggleTechnicalInfo = useCallback(() => {

--- a/components/video-player/controls/Controls.tv.tsx
+++ b/components/video-player/controls/Controls.tv.tsx
@@ -320,14 +320,25 @@ export const Controls: FC<Props> = ({
   // download) and map them to the modal's Track shape. setTrack drives the
   // player through the same handler used for manual subtitle selection.
   const refreshSubtitleTracks = useCallback(async (): Promise<Track[]> => {
-    const streams = (await onRefreshSubtitleTracks?.()) ?? [];
-    return streams.map((stream) => ({
-      name:
-        stream.DisplayTitle ||
-        `${stream.Language || "Unknown"} (${stream.Codec})`,
-      index: stream.Index ?? -1,
-      setTrack: () => onSubtitleIndexChange?.(stream.Index ?? -1),
-    }));
+    try {
+      const streams = (await onRefreshSubtitleTracks?.()) ?? [];
+      // Skip streams without a real index: `?? -1` would alias them to the
+      // "disable subtitles" sentinel and mis-route selection.
+      return streams
+        .filter((stream) => typeof stream.Index === "number")
+        .map((stream) => {
+          const index = stream.Index as number;
+          return {
+            name:
+              stream.DisplayTitle ||
+              `${stream.Language || "Unknown"} (${stream.Codec})`,
+            index,
+            setTrack: () => onSubtitleIndexChange?.(index),
+          };
+        });
+    } catch {
+      return [];
+    }
   }, [onRefreshSubtitleTracks, onSubtitleIndexChange]);
 
   const {

--- a/components/video-player/controls/types.ts
+++ b/components/video-player/controls/types.ts
@@ -28,4 +28,4 @@ type Track = {
   localPath?: string;
 };
 
-export type { EmbeddedSubtitle, ExternalSubtitle, TranscodedSubtitle, Track };
+export type { EmbeddedSubtitle, ExternalSubtitle, Track, TranscodedSubtitle };

--- a/hooks/usePlaybackManager.ts
+++ b/hooks/usePlaybackManager.ts
@@ -80,7 +80,7 @@ export const usePlaybackManager = ({
   const { data: adjacentItems } = useQuery({
     queryKey: ["adjacentItems", item?.Id, item?.SeriesId, isOffline],
     queryFn: async (): Promise<BaseItemDto[] | null> => {
-      if (!item || !item.SeriesId) {
+      if (!item?.SeriesId) {
         return null;
       }
 

--- a/hooks/useSessions.ts
+++ b/hooks/useSessions.ts
@@ -21,7 +21,7 @@ export const useSessions = ({
   const { data, isLoading } = useQuery({
     queryKey: ["sessions"],
     queryFn: async () => {
-      if (!api || !user || !user.Policy?.IsAdministrator) {
+      if (!api || !user?.Policy?.IsAdministrator) {
         return [];
       }
       const response = await getSessionApi(api).getSessions({
@@ -55,7 +55,7 @@ export const useAllSessions = ({
   const { data, isLoading } = useQuery({
     queryKey: ["allSessions"],
     queryFn: async () => {
-      if (!api || !user || !user.Policy?.IsAdministrator) {
+      if (!api || !user?.Policy?.IsAdministrator) {
         return [];
       }
       const response = await getSessionApi(api).getSessions({

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.28.6",
-    "@biomejs/biome": "2.3.11",
+    "@biomejs/biome": "2.4.16",
     "@react-native-community/cli": "20.1.3",
     "@react-native-tvos/config-tv": "0.1.6",
     "@types/jest": "29.5.14",

--- a/providers/WebSocketProvider.tsx
+++ b/providers/WebSocketProvider.tsx
@@ -122,7 +122,7 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
 
   const handlePlayCommand = useCallback(
     (data: any) => {
-      if (!data || !data.ItemIds || !data.ItemIds.length) {
+      if (!data?.ItemIds?.length) {
         return;
       }
 
@@ -150,7 +150,7 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
   }, [connectWebSocket]);
 
   useEffect(() => {
-    if (!deviceId || !api || !api?.accessToken || !isNetworkConnected) {
+    if (!deviceId || !api?.accessToken || !isNetworkConnected) {
       return;
     }
 

--- a/utils/streamRanker.ts
+++ b/utils/streamRanker.ts
@@ -156,4 +156,4 @@ class StreamRanker {
   }
 }
 
-export { StreamRanker, SubtitleStreamRanker, AudioStreamRanker };
+export { AudioStreamRanker, StreamRanker, SubtitleStreamRanker };


### PR DESCRIPTION
## Summary

This PR does three connected things:
1. Updates **Biome** (the tool that automatically checks our code) to the latest version.
2. Fixes everything the new version flags, so the codebase is "clean" again.
3. Along the way, fixes a **real bug** on the TV app where the password screen couldn't be closed with the remote.

Only ~34 files change — the giant formatting diff people worried about isn't here, the code was already formatted.

## What's inside

### 1. Update the linter (Biome `2.3.11` → `2.4.16`)
Biome is the tool that reads our code and points out style problems and likely mistakes. We bumped it to the newest version. The newer version checks more things, which surfaced the items below.

### 2. Make the whole codebase pass again
- **Renamed screen components to start with a capital letter.** Biome has a rule that checks React "hooks" are used correctly. It only treats a function as a screen if its name starts with a capital letter (e.g. `Page`, not `page`). Many of our screen files were named `page`, `search`, etc., so Biome *wrongly* thought 234 hooks were misused. Renaming them (`DownloadsPage`, `SearchPage`, …) clears all 234. **100% safe**: a screen's URL comes from the file's location, not the function's name.
- **Simplified some `if` checks.** Biome auto-rewrites things like `if (!user || !user.name)` into the shorter, identical `if (!user?.name)`. Same behavior, just tidier.

### 3. Fix 3 things Biome pointed at in the TV code
- **🐛 Password screen couldn't be closed (real bug).** On TV, picking a saved account that needs a password shows a password screen. Before this PR, pressing **Back** there didn't close it — it **kicked you out of the entire app to the Android TV home screen**. Now Back closes the password screen and returns you to the user list. (Before/after below.)
- **Subtitle list didn't refresh from the player.** While watching, downloading a new subtitle didn't update the list. Now it does.
- Removed one unused variable (no effect, cleanup).

## Before / after — the password screen bug
*(screenshots attached)*
- **Before:** open a password-protected user → press Back → ❌ the app **closes completely** (you land on the Android TV home screen).
- **After:** open a password-protected user → press Back → ✅ the password screen **closes** and you're back on "Select a user."

Tested live on an Android TV emulator.

## Why bundle this together?
All of it stems from the same Biome upgrade — Biome is what flagged the unused props, one of which turned out to be the real "can't close the modal" bug.

## Test plan
- [x] `bun run check` → no errors
- [x] `bun run typecheck` → passes
- [x] Builds & runs on Android TV; Home, Settings, login flow work (renames don't break routing)
- [x] Password modal: Back now closes it (verified before/after on emulator)
- [ ] Subtitle refresh: needs a server with a subtitle provider (OpenSubtitles) to verify — couldn't test locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TV remote back-press handling now available for password entry modal on compatible devices
  * Subtitle tracks are now refreshed when opening the subtitle selection menu in the video player

* **Bug Fixes**
  * Improved handling of user session queries for administrator accounts

* **Chores**
  * Updated code quality tooling from version 2.3.11 to 2.4.16
  * Applied code style improvements throughout the application

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/streamyfin/streamyfin/pull/1598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->