### PR TITLE
chore(mpv-player): Update to MPVKIT 0.41

### DIFF
--- a/app.json
+++ b/app.json
@@ -124,8 +124,8 @@
       [
         "./plugins/withGitPod.js",
         {
-          "podName": "MPVKit-GPL",
-          "podspecUrl": "https://raw.githubusercontent.com/streamyfin/MPVKit/0.40.0-av/MPVKit-GPL.podspec"
+          "podName": "MPVKit",
+          "podspecUrl": "https://raw.githubusercontent.com/mpv-ios/MPVKit/0.41.0-av/MPVKit.podspec"
         }
       ]
     ],

--- a/modules/mpv-player/ios/MpvPlayer.podspec
+++ b/modules/mpv-player/ios/MpvPlayer.podspec
@@ -1,32 +1,19 @@
 Pod::Spec.new do |s|
-  s.name           = 'MpvPlayer'
-  s.version        = '1.0.0'
-  s.summary        = 'MPVKit for Expo'
-  s.description    = 'MPVKit for Expo'
-  s.author         = 'mpvkit'
-  s.homepage       = 'https://github.com/mpvkit/MPVKit'
-  s.platforms      = {
-    :ios => '15.1',
-    :tvos => '15.1'
-  }
-  s.source         = { git: 'https://github.com/mpvkit/MPVKit.git' }
+  s.name             = 'MpvPlayer'
+  s.version          = '1.0.0'
+  s.summary          = 'MPV-based video player for Streamyfin (Expo module)'
+  s.author           = 'Streamyfin'
+  s.homepage         = 'https://github.com/streamyfin/streamyfin'
+  s.platforms        = { :ios => '15.1', :tvos => '15.1' }
+  s.source           = { git: '' }
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MPVKit-GPL'
+  s.dependency 'MPVKit'
 
-  # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    'VALID_ARCHS' => 'arm64',
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
-    'DEBUG_INFORMATION_FORMAT' => 'dwarf',
-    'STRIP_INSTALLED_PRODUCT' => 'YES',
-    'DEPLOYMENT_POSTPROCESSING' => 'YES',
-  }
-
-  s.user_target_xcconfig = {
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386'
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
 
   s.source_files = "*.{h,m,mm,swift,hpp,cpp}"


### PR DESCRIPTION
# 📦 Pull Request

**Suggested PR title:** `chore(mpv): update MPVKit to 0.41.0`

<!-- 
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#) -->

## 📝 Description

Updates the iOS MPV player module to MPVKit `0.41.0` and switches from the Streamyfin fork of the GPL build (`streamyfin/MPVKit` @ `0.40.0-av`, podspec `MPVKit-GPL`) to the upstream `mpv-ios/MPVKit` @ `0.41.0-av` (podspec `MPVKit`).

Also cleans up `modules/mpv-player/ios/MpvPlayer.podspec`:

- Renames the `MPVKit-GPL` dependency to `MPVKit` to match the new upstream podspec.
- Drops the arch/strip workarounds that were only needed for the older fork:
  - `VALID_ARCHS = arm64`
  - `EXCLUDED_ARCHS[sdk=iphonesimulator*] = i386` (in both `pod_target_xcconfig` and `user_target_xcconfig`)
  - `DEBUG_INFORMATION_FORMAT = dwarf`
  - `STRIP_INSTALLED_PRODUCT = YES`
  - `DEPLOYMENT_POSTPROCESSING = YES`
- Adds `SWIFT_COMPILATION_MODE = wholemodule`.
- Tidies the spec metadata (summary/author/homepage) to point at Streamyfin.

The corresponding `withGitPod` entry in `app.json` is updated to fetch the new podspec URL.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A — no UI changes. Internal native dependency upgrade only.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms <!-- iOS / tvOS only; Android unaffected -->
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Pull this branch and run `bun i && bun run submodule-reload`.
2. Regenerate the iOS project: `bun run prebuild` (and `bun run prebuild:tv` for the TV target).
3. Confirm that during `pod install` MPVKit `0.41.0-av` is fetched from `https://raw.githubusercontent.com/mpv-ios/MPVKit/0.41.0-av/MPVKit.podspec` and that the old `MPVKit-GPL` pod is no longer present in `Podfile.lock`.
4. Build and launch the app on a physical iOS device (`bun run ios`) and on Apple TV (`bun run ios:tv`).
5. Play a video using the MPV player:
   - Verify playback starts and seeking/pause/resume work.
   - Verify audio and subtitle track switching still work.
   - Verify exiting the player returns cleanly to the previous screen (no UI freeze / no crash).
6. Confirm no new warnings/errors related to MPVKit appear in the Xcode build log or runtime console.