### PR TITLE
fix(android): resolve mpv-player Kotlin smart-cast build error

### DIFF
--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MPVLayerRenderer.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MPVLayerRenderer.kt
@@ -715,9 +715,7 @@ class MPVLayerRenderer(private val context: Context) : MPVLib.EventObserver {
                 // dropped), so we (re)apply here for embedded and external alike.
                 // This is what makes a carried-over subtitle show up on the next
                 // episode without a manual re-selection.
-                if (initialAudioId != null && initialAudioId > 0) {
-                    setAudioTrack(initialAudioId)
-                }
+                initialAudioId?.let { if (it > 0) setAudioTrack(it) }
                 initialSubtitleId?.let { setSubtitleTrack(it) } ?: disableSubtitles()
 
                 if (!isReadyToSeek) {


### PR DESCRIPTION
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

# 📦 Pull Request

## 📝 Description

The Android APK build (Phone + TV) has been failing on `develop` at `:mpv-player:compileReleaseKotlin`:

```
e: MPVLayerRenderer.kt:718 Smart cast to 'Int' is impossible, because
   'initialAudioId' is a mutable property that could be mutated concurrently.
```

In the `MPV_EVENT_FILE_LOADED` handler, `initialAudioId` resolves to the mutable property (`private var initialAudioId: Int?`), which Kotlin refuses to smart-cast to non-null after a `!= null` check. Switched to the null-safe `?.let` idiom — matching the `initialSubtitleId?.let { … }` line directly below — so the value is captured locally before use.

```kotlin
// before
if (initialAudioId != null && initialAudioId > 0) {
    setAudioTrack(initialAudioId)
}
// after
initialAudioId?.let { if (it > 0) setAudioTrack(it) }
```

The earlier check at the same call site operates on an immutable function **parameter** of the same name (smart-casts fine), so it's left untouched. Behavior is unchanged: the audio track is set only when the id is non-null and > 0.

## 🏷️ Ticket / Issue

N/A — fixes the failing Android APK CI build on `develop`.

### 🖼️ Screenshots / GIFs (if UI)

N/A — native build fix, no UI change.

## ✅ Checklist
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

> ⚠️ **Verification note:** Diagnosed from the failing CI Gradle log; the fix is a standard Kotlin idiom matching adjacent code. A full local Android compile was not run. Please confirm the Android APK CI build goes green.

## 🔍 Testing Instructions
1. Android APK build (Phone + TV) compiles past `:mpv-player:compileReleaseKotlin` (previously failed there).
2. Playback: starting a video that carries over an audio-track selection still applies that track on load.