### PR TITLE
fix(auth): clear stored user on logout to prevent empty home on relaunch

### DIFF
--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -69,6 +69,13 @@ const initialApi = (() => {
 
 const initialUser = (() => {
   try {
+    // Only return a stored user if we also have a token. Otherwise the
+    // user atom would be populated while the api atom is null (e.g. after
+    // a logout that left stale user JSON in storage), which causes
+    // useProtectedRoute to keep us inside the (auth) group instead of
+    // redirecting to /login.
+    const token = storage.getString("token");
+    if (!token) return null;
     const userStr = storage.getString("user");
     if (userStr) {
       return JSON.parse(userStr) as UserDto;
@@ -402,6 +409,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         );
 
       storage.remove("token");
+      storage.remove("user");
       clearTVDiscoverySafely();
       setUser(null);
       setApi(null);


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Fix a bug where signing out and then closing/reopening the app dropped the user on an empty home screen instead of taking them back to the login page.

On logout, only the `token` was removed from MMKV while the `user` JSON was left behind. On next app launch, `initialUser` rehydrated `userAtom` from the stale storage while `apiAtom` was correctly `null`, so `useProtectedRoute` treated the session as authenticated and the user landed on an empty `(auth)/(tabs)/(home)` instead of `/login`.

**Changes:**
- Remove `"user"` from storage in `logoutMutation` alongside `"token"`.
- Make `initialUser` defensive: return `null` when no token is present so the user/api atoms stay consistent and any pre-existing stale state self-corrects on next launch.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A — no UI changes; behavior change only (post-logout cold start now correctly routes to `/login`).

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

**Repro (before fix):**
1. Sign in to a Jellyfin server.
2. Sign out from the account/settings screen.
3. Fully close the app (swipe away from app switcher — not just background).
4. Reopen the app.
5. Observe: app lands on an empty home tab instead of the login screen.

**Verify the fix:**
1. Pull this branch and run the app (`bun run ios` / `bun run android` / `bun run ios:tv` / `bun run android:tv`).
2. Sign in, then sign out.
3. Fully close and reopen the app → should land on `/login`.
4. Sign back in → home screen loads normally with data.
5. Quick-switch between saved accounts → still works (saved credentials are preserved on logout by design).

**Self-healing check (for users already affected by the previous bug):**
1. Before installing the fix, manually leave the app in the broken state (signed-out but stale `user` in storage).
2. Install this branch and relaunch → should route to `/login` automatically without requiring storage to be cleared.