### PR TITLE
fix(item): dedupe top people sections by id

### DIFF
--- a/components/item/ItemPeopleSections.tsx
+++ b/components/item/ItemPeopleSections.tsx
@@ -37,7 +37,20 @@ export const ItemPeopleSections: React.FC<Props> = ({ item, ...props }) => {
     return { ...item, People: people } as BaseItemDto;
   }, [item, people]);
 
-  const topPeople = useMemo(() => people.slice(0, 3), [people]);
+  // Jellyfin can list the same person several times (e.g. an actor also
+  // credited as writer). Dedupe by Id so the same actor section isn't rendered
+  // twice and we still surface 3 distinct people.
+  const topPeople = useMemo(() => {
+    const seen = new Set<string>();
+    const unique: BaseItemPerson[] = [];
+    for (const person of people) {
+      if (!person.Id || seen.has(person.Id)) continue;
+      seen.add(person.Id);
+      unique.push(person);
+      if (unique.length >= 3) break;
+    }
+    return unique;
+  }, [people]);
 
   const renderActorSection = useCallback(
     (person: BaseItemPerson, idx: number, total: number) => {


### PR DESCRIPTION
## Problem

The item detail screen renders a "More with <actor>" section for each of the top 3 people. Jellyfin can list the same person more than once (e.g. credited as both actor and director/writer), so the same person could appear twice — producing a duplicate section and a React "two children with the same key" warning.

## Fix

Dedupe the people list by `Id` before taking the top 3, so we always surface 3 *distinct* people.

No behavior change otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate people entries appearing in sections; now displays only unique people up to a maximum of three.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->