### PR TITLE
fix(chapters): keep landscape when opening chapter list on iOS

### DIFF
--- a/components/chapters/ChapterList.tsx
+++ b/components/chapters/ChapterList.tsx
@@ -74,6 +74,9 @@ function ChapterListComponent({
       transparent
       animationType='slide'
       onRequestClose={onClose}
+      // iOS defaults <Modal> to portrait-only; without this it rotates the app
+      // back to portrait when opened from the landscape player. Android ignores it.
+      supportedOrientations={["portrait", "landscape"]}
     >
       <Pressable onPress={onClose} style={styles.backdrop}>
         <Pressable onPress={(e) => e.stopPropagation()} style={styles.sheet}>


### PR DESCRIPTION
## Problem

On iOS, opening the chapter list while the player is in landscape rotates the whole app back to portrait. The list then shows in portrait instead of over the landscape video.

## Cause

`components/chapters/ChapterList.tsx` renders a React Native `<Modal>` without `supportedOrientations`. iOS defaults modals to portrait-only, so presenting one in landscape forces the app to rotate.

## Fix

Set `supportedOrientations={["portrait", "landscape"]}` on the modal so it opens in the current orientation. The prop is iOS-only; Android ignores it, so no cross-platform change.

Follow-up to the merged chapters feature (#1586).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal to remain usable when device orientation changes between portrait and landscape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->