### PR TITLE
fix(i18n): make two hardcoded titles translatable

### DIFF
--- a/components/settings/LibraryOptionsSheet.tsx
+++ b/components/settings/LibraryOptionsSheet.tsx
@@ -229,7 +229,7 @@ export const LibraryOptionsSheet: React.FC<Props> = ({
             />
           </OptionGroup>
 
-          <OptionGroup title='Options'>
+          <OptionGroup title={t("library.options.options_title")}>
             <ToggleItem
               label={t("library.options.show_titles")}
               value={settings.showTitles}

--- a/modules/mpv-player/src/MpvPlayerView.web.tsx
+++ b/modules/mpv-player/src/MpvPlayerView.web.tsx
@@ -1,11 +1,13 @@
+import { useTranslation } from "react-i18next";
 import { MpvPlayerViewProps } from "./MpvPlayer.types";
 
 export default function MpvPlayerView(props: MpvPlayerViewProps) {
   const url = props.source?.url ?? "";
+  const { t } = useTranslation();
   return (
     <div>
       <iframe
-        title='MPV Player'
+        title={t("player.mpv_player_title")}
         style={{ flex: 1 }}
         src={url}
         onLoad={() => props.onLoad?.({ nativeEvent: { url } })}

--- a/translations/en.json
+++ b/translations/en.json
@@ -652,7 +652,8 @@
       "poster": "Poster",
       "cover": "Cover",
       "show_titles": "Show Titles",
-      "show_stats": "Show Stats"
+      "show_stats": "Show Stats",
+      "options_title": "Options"
     },
     "filters": {
       "genres": "Genres",
@@ -682,6 +683,7 @@
   },
   "player": {
     "live": "LIVE",
+    "mpv_player_title": "MPV Player",
     "error": "Error",
     "failed_to_get_stream_url": "Failed to get the stream URL",
     "an_error_occured_while_playing_the_video": "An error occurred while playing the video. Check logs in settings.",


### PR DESCRIPTION
## Summary

Two UI titles were hardcoded English strings. This makes them translatable:

- `components/settings/LibraryOptionsSheet.tsx` — `OptionGroup title='Options'` → `t("library.options.options_title")`
- `modules/mpv-player/src/MpvPlayerView.web.tsx` — iframe `title='MPV Player'` → `t("player.mpv_player_title")`

Adds the two **new** source keys to `translations/en.json` only. Other locales fall back to English until translated via Crowdin — and since both strings were already hardcoded English, there is **no regression**, just newfound translatability.

## Notes

Split out of #1347. Scoped to safe, app-side i18n only. The broader translation cleanup in that PR (typo key renames like `select_liraries`→`select_libraries`, `centralised`→`centralized`, and capitalization) touches keys present in all ~35 locale files, so it belongs in Crowdin / the upcoming full translation pass rather than an app PR (renaming a key app-side would orphan every locale's existing translation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Options section header now uses localized text
- MPV Player window title now uses localized text
- Enhanced localization infrastructure for UI labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->