### PR TITLE
fix(ci): grant actions:read to github-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      actions: read # required for `gh run download` to list/fetch this run's artifacts
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Follow-up to #1632 review (Copilot + @Gauvino). The `github-release` job uses `gh run download` to fetch the APK artifacts, which requires `actions: read` on `GITHUB_TOKEN` — `contents: write` alone causes a 403. Adds the missing permission.