### PR TITLE
fix: remove empty sections from section tree

### DIFF
--- a/components/home/Home.tsx
+++ b/components/home/Home.tsx
@@ -490,12 +490,18 @@ const HomeMobile = () => {
 
   const sections = settings?.home?.sections ? customSections : defaultSections;
 
+  const serializeSectionKey = useCallback(
+    (queryKey: (string | undefined | null)[]) =>
+      JSON.stringify(queryKey.map((k) => k ?? null)),
+    [],
+  );
+
   // Get all high priority section keys and check if all have loaded
   const highPrioritySectionKeys = useMemo(() => {
     return sections
       .filter((s) => s.priority === 1)
-      .map((s) => s.queryKey.join("-"));
-  }, [sections]);
+      .map((s) => serializeSectionKey(s.queryKey));
+  }, [sections, serializeSectionKey]);
 
   const allHighPriorityLoaded = useMemo(() => {
     return highPrioritySectionKeys.every((key) => loadedSections.has(key));
@@ -503,18 +509,26 @@ const HomeMobile = () => {
 
   const markSectionLoaded = useCallback(
     (queryKey: (string | undefined | null)[]) => {
-      const key = queryKey.join("-");
+      const key = serializeSectionKey(queryKey);
       setLoadedSections((prev) => new Set(prev).add(key));
     },
-    [],
+    [serializeSectionKey],
   );
 
-  const markSectionEmpty = useCallback(
-    (queryKey: (string | undefined | null)[]) => {
-      const key = queryKey.join("-");
-      setEmptySections((prev) => new Set(prev).add(key));
+  const handleSectionEmptyChange = useCallback(
+    (queryKey: (string | undefined | null)[], isEmpty: boolean) => {
+      const key = serializeSectionKey(queryKey);
+      setEmptySections((prev) => {
+        const next = new Set(prev);
+        if (isEmpty) {
+          next.add(key);
+        } else {
+          next.delete(key);
+        }
+        return next;
+      });
     },
-    [],
+    [serializeSectionKey],
   );
 
   if (!isConnected || serverConnected !== true) {
@@ -658,7 +672,7 @@ const HomeMobile = () => {
             ) : null;
           if (section.type === "InfiniteScrollingCollectionList") {
             const isHighPriority = section.priority === 1;
-            const sectionKey = section.queryKey.join("-");
+            const sectionKey = serializeSectionKey(section.queryKey);
             const isHidden = emptySections.has(sectionKey);
             const handleSeeAll = section.parentId
               ? () => {
@@ -674,7 +688,7 @@ const HomeMobile = () => {
               : undefined;
             return (
               <View
-                key={index}
+                key={sectionKey}
                 className='flex flex-col space-y-4'
                 style={isHidden ? { display: "none" } : undefined}
               >
@@ -691,7 +705,9 @@ const HomeMobile = () => {
                       ? () => markSectionLoaded(section.queryKey)
                       : undefined
                   }
-                  onEmpty={() => markSectionEmpty(section.queryKey)}
+                  onEmptyChange={(isEmpty) =>
+                    handleSectionEmptyChange(section.queryKey, isEmpty)
+                  }
                   onPressSeeAll={handleSeeAll}
                 />
                 {streamystatsSections}
@@ -699,8 +715,9 @@ const HomeMobile = () => {
             );
           }
           if (section.type === "MediaListSection") {
+            const sectionKey = serializeSectionKey(section.queryKey);
             return (
-              <View key={index} className='flex flex-col space-y-4'>
+              <View key={sectionKey} className='flex flex-col space-y-4'>
                 <MediaListSection
                   queryKey={section.queryKey}
                   queryFn={section.queryFn}

--- a/components/home/Home.tsx
+++ b/components/home/Home.tsx
@@ -88,6 +88,7 @@ const HomeMobile = () => {
   } = useNetworkStatus();
   const invalidateCache = useInvalidatePlaybackProgressCache();
   const [loadedSections, setLoadedSections] = useState<Set<string>>(new Set());
+  const [emptySections, setEmptySections] = useState<Set<string>>(new Set());
   const { showIntro } = useIntroSheet();
 
   // Fallback refresh for newly added content when returning to the home screen
@@ -205,6 +206,7 @@ const HomeMobile = () => {
   const refetch = async () => {
     setLoading(true);
     setLoadedSections(new Set());
+    setEmptySections(new Set());
     await refreshStreamyfinPluginSettings();
     await invalidateCache();
     setLoading(false);
@@ -507,6 +509,14 @@ const HomeMobile = () => {
     [],
   );
 
+  const markSectionEmpty = useCallback(
+    (queryKey: (string | undefined | null)[]) => {
+      const key = queryKey.join("-");
+      setEmptySections((prev) => new Set(prev).add(key));
+    },
+    [],
+  );
+
   if (!isConnected || serverConnected !== true) {
     let title = "";
     let subtitle = "";
@@ -648,6 +658,8 @@ const HomeMobile = () => {
             ) : null;
           if (section.type === "InfiniteScrollingCollectionList") {
             const isHighPriority = section.priority === 1;
+            const sectionKey = section.queryKey.join("-");
+            const isHidden = emptySections.has(sectionKey);
             const handleSeeAll = section.parentId
               ? () => {
                   router.push({
@@ -661,7 +673,11 @@ const HomeMobile = () => {
                 }
               : undefined;
             return (
-              <View key={index} className='flex flex-col space-y-4'>
+              <View
+                key={index}
+                className='flex flex-col space-y-4'
+                style={isHidden ? { display: "none" } : undefined}
+              >
                 <InfiniteScrollingCollectionList
                   title={section.title}
                   queryKey={section.queryKey}
@@ -675,6 +691,7 @@ const HomeMobile = () => {
                       ? () => markSectionLoaded(section.queryKey)
                       : undefined
                   }
+                  onEmpty={() => markSectionEmpty(section.queryKey)}
                   onPressSeeAll={handleSeeAll}
                 />
                 {streamystatsSections}

--- a/components/home/InfiniteScrollingCollectionList.tsx
+++ b/components/home/InfiniteScrollingCollectionList.tsx
@@ -32,7 +32,7 @@ interface Props extends ViewProps {
   onPressSeeAll?: () => void;
   enabled?: boolean;
   onLoaded?: () => void;
-  onEmpty?: () => void;
+  onEmptyChange?: (isEmpty: boolean) => void;
 }
 
 export const InfiniteScrollingCollectionList: React.FC<Props> = ({
@@ -46,11 +46,12 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
   onPressSeeAll,
   enabled = true,
   onLoaded,
-  onEmpty,
+  onEmptyChange,
   ...props
 }) => {
   const effectivePageSize = Math.max(1, pageSize);
   const hasCalledOnLoaded = useRef(false);
+  const lastReportedEmpty = useRef<boolean | null>(null);
   const {
     data,
     isLoading,
@@ -105,12 +106,15 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
     return deduped;
   }, [data]);
 
-  // Notify parent when section is empty (so wrapper can be hidden from layout)
   useEffect(() => {
-    if (isSuccess && hideIfEmpty && allItems.length === 0) {
-      onEmpty?.();
+    if (isSuccess && hideIfEmpty) {
+      const isEmpty = allItems.length === 0;
+      if (isEmpty !== lastReportedEmpty.current) {
+        lastReportedEmpty.current = isEmpty;
+        onEmptyChange?.(isEmpty);
+      }
     }
-  }, [isSuccess, hideIfEmpty, allItems.length, onEmpty]);
+  }, [isSuccess, hideIfEmpty, allItems.length, onEmptyChange]);
 
   const snapOffsets = useMemo(() => {
     const itemWidth = orientation === "horizontal" ? 184 : 120; // w-44 (176px) + mr-2 (8px) or w-28 (112px) + mr-2 (8px)

--- a/components/home/InfiniteScrollingCollectionList.tsx
+++ b/components/home/InfiniteScrollingCollectionList.tsx
@@ -32,6 +32,7 @@ interface Props extends ViewProps {
   onPressSeeAll?: () => void;
   enabled?: boolean;
   onLoaded?: () => void;
+  onEmpty?: () => void;
 }
 
 export const InfiniteScrollingCollectionList: React.FC<Props> = ({
@@ -45,6 +46,7 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
   onPressSeeAll,
   enabled = true,
   onLoaded,
+  onEmpty,
   ...props
 }) => {
   const effectivePageSize = Math.max(1, pageSize);
@@ -102,6 +104,13 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
 
     return deduped;
   }, [data]);
+
+  // Notify parent when section is empty (so wrapper can be hidden from layout)
+  useEffect(() => {
+    if (isSuccess && hideIfEmpty && allItems.length === 0) {
+      onEmpty?.();
+    }
+  }, [isSuccess, hideIfEmpty, allItems.length, onEmpty]);
 
   const snapOffsets = useMemo(() => {
     const itemWidth = orientation === "horizontal" ? 184 : 120; // w-44 (176px) + mr-2 (8px) or w-28 (112px) + mr-2 (8px)


### PR DESCRIPTION
Empty sections would still take up space. This PR hides the section that are empty. 

Because loading logic lives in the section itself we have to signal the wrapper for it. (i dont wanna refactor)

before:
<img width="585" height="1266" alt="IMG_1799" src="https://github.com/user-attachments/assets/8515f23e-d81f-40b3-a9b1-40ec79784a70" />

after:

![image](https://github.com/user-attachments/assets/f03a1cc3-9707-416e-b534-c35490148a57)
