### PR TITLE
ci(pr-validation): validate PR title + body against the template

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,38 +12,6 @@ permissions:
   contents: read
 
 jobs:
-  validate_pr_title:
-    name: "📝 Validate PR Title"
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-24.04
-    permissions:
-      pull-requests: write
-      contents: read
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        id: lint_pr_title
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
-        if: always() && (steps.lint_pr_title.outputs.error_message != null)
-        with:
-          header: pr-title-lint-error
-          message: |
-            Hey there and thank you for opening this pull request! 👋🏼
-            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
-
-            **Error details:**
-            ```
-            ${{ steps.lint_pr_title.outputs.error_message }}
-            ```
-
-      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
-        with:
-          header: pr-title-lint-error
-          delete: true
-
   dependency-review:
     name: 🔍 Vulnerable Dependencies
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   validate_pr_title:
     name: "📝 Validate PR Title"
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
@@ -51,7 +51,7 @@ jobs:
     name: "📋 Validate PR Template"
     # Skip pushes to an existing PR (the body rarely changes) and bot-authored PRs.
     if: >-
-      github.event_name == 'pull_request' &&
+      github.event_name == 'pull_request_target' &&
       github.event.action != 'synchronize' &&
       github.actor != 'renovate[bot]' &&
       github.actor != 'github-actions[bot]'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -111,8 +111,8 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
             const marker = "<!-- pr-template-check -->";
-            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
-            const existing = comments.data.find((c) => c.body?.includes(marker));
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+            const existing = comments.find((c) => c.body?.includes(marker));
             const payload = `${marker}\n${body}`;
             if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
             else await github.rest.issues.createComment({ owner, repo, issue_number, body: payload });
@@ -130,7 +130,7 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
             const marker = "<!-- pr-template-check -->";
-            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
-            const existing = comments.data.find((c) => c.body?.includes(marker));
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+            const existing = comments.find((c) => c.body?.includes(marker));
             if (existing) await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
             try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: "blocked: template" }); } catch {}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,136 @@
+name: 🚦 PR Validation
+
+# Uses pull_request_target so the jobs get a write token even on fork PRs (to comment
+# and label) — same as seerr. SECURITY: never check out or run the PR head's code here;
+# we only read the title/body from the event payload and run our own scripts from the base.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: pr-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate_pr_title:
+    name: "📝 Validate PR Title"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+
+            **Error details:**
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: pr-title-lint-error
+          delete: true
+
+  validate_pr_template:
+    name: "📋 Validate PR Template"
+    # Skip pushes to an existing PR (the body rarely changes) and bot-authored PRs.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action != 'synchronize' &&
+      github.actor != 'renovate[bot]' &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: "📥 Checkout"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: "🍞 Setup Bun"
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: "📝 Write PR body to file"
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s' "$PR_BODY" > /tmp/pr-body.txt
+
+      - name: "📂 List changed files"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename' > /tmp/pr-files.txt
+
+      - name: "🔎 Validate body against template"
+        id: check
+        env:
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_FILES: /tmp/pr-files.txt
+        run: |
+          set +e
+          bun scripts/check-pr-template.mjs /tmp/pr-body.txt > /tmp/pr-issues.json
+          echo "code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: "💬 Report problems"
+        if: steps.check.outputs.code != '0'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            let issues;
+            try { issues = JSON.parse(fs.readFileSync('/tmp/pr-issues.json', 'utf8')); }
+            catch { issues = ["The PR template check could not parse the description. Please make sure it follows the template."]; }
+            if (!Array.isArray(issues) || issues.length === 0) issues = ["The PR description does not follow the template."];
+            const body = [
+              "👋 Thanks for the PR! A few things in the description need attention before review:",
+              "",
+              ...issues.map((i) => `- ${i}`),
+              "",
+              "Please update the PR description ([template](https://github.com/${{ github.repository }}/blob/develop/.github/pull_request_template.md)). This check re-runs when you edit it.",
+            ].join("\n");
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const marker = "<!-- pr-template-check -->";
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find((c) => c.body?.includes(marker));
+            const payload = `${marker}\n${body}`;
+            if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
+            else await github.rest.issues.createComment({ owner, repo, issue_number, body: payload });
+            const label = "blocked: template";
+            try { await github.rest.issues.getLabel({ owner, repo, name: label }); }
+            catch { await github.rest.issues.createLabel({ owner, repo, name: label, color: "d93f0b", description: "PR description does not follow the template" }); }
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+            core.setFailed(`PR template check failed:\n- ${issues.join("\n- ")}`);
+
+      - name: "✅ Clear problems on success"
+        if: steps.check.outputs.code == '0'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v8.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const marker = "<!-- pr-template-check -->";
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find((c) => c.body?.includes(marker));
+            if (existing) await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+            try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: "blocked: template" }); } catch {}

--- a/scripts/check-pr-template.mjs
+++ b/scripts/check-pr-template.mjs
@@ -29,15 +29,25 @@ try {
 const association = (process.env.AUTHOR_ASSOCIATION || "").toUpperCase();
 const isMaintainer = ["OWNER", "MEMBER", "COLLABORATOR"].includes(association);
 
-// Strip HTML comments in a single linear pass: remove complete `<!-- … -->`
-// blocks, then drop any leftover unterminated `<!-- …` to end-of-string. This
-// leaves no `<!--` behind (satisfies CodeQL) without the quadratic re-scan loop
-// a malicious deeply-nested body could abuse for CPU-DoS.
-const stripComments = (s) =>
-  s
-    .replace(/<!--[\s\S]*?-->/g, "")
-    .replace(/<!--[\s\S]*$/, "")
-    .trim();
+// Strip HTML comments in a single linear pass (indexOf scan): no regex backtracking
+// and no loop-until-stable, so a crafted body can't drive it into super-linear time,
+// and it leaves no `<!--` behind. An unterminated `<!-- …` drops to end-of-string.
+const stripComments = (s) => {
+  let out = "";
+  let i = 0;
+  for (;;) {
+    const start = s.indexOf("<!--", i);
+    if (start === -1) {
+      out += s.slice(i);
+      break;
+    }
+    out += s.slice(i, start);
+    const end = s.indexOf("-->", start + 4);
+    if (end === -1) break; // unterminated comment: drop the rest
+    i = end + 3;
+  }
+  return out.trim();
+};
 
 // Grab the text under a heading whose title contains `keyword`, up to the next heading
 // or the end of the body.

--- a/scripts/check-pr-template.mjs
+++ b/scripts/check-pr-template.mjs
@@ -23,18 +23,15 @@ const body = readFileSync(bodyFile, "utf8").replace(/\r\n/g, "\n");
 const association = (process.env.AUTHOR_ASSOCIATION || "").toUpperCase();
 const isMaintainer = ["OWNER", "MEMBER", "COLLABORATOR"].includes(association);
 
-// Strip HTML comments robustly: loop until stable so nested/overlapping `<!--`
-// markers can't survive a single pass, then drop any unterminated trailing
-// comment. (Also satisfies CodeQL's "incomplete multi-character sanitization".)
-const stripComments = (s) => {
-  let out = s;
-  let prev;
-  do {
-    prev = out;
-    out = out.replace(/<!--[\s\S]*?-->/g, "");
-  } while (out !== prev);
-  return out.replace(/<!--[\s\S]*$/, "").trim();
-};
+// Strip HTML comments in a single linear pass: remove complete `<!-- … -->`
+// blocks, then drop any leftover unterminated `<!-- …` to end-of-string. This
+// leaves no `<!--` behind (satisfies CodeQL) without the quadratic re-scan loop
+// a malicious deeply-nested body could abuse for CPU-DoS.
+const stripComments = (s) =>
+  s
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<!--[\s\S]*$/, "")
+    .trim();
 
 // Grab the text under a heading whose title contains `keyword`, up to the next heading
 // or the end of the body.

--- a/scripts/check-pr-template.mjs
+++ b/scripts/check-pr-template.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env bun
+/**
+ * Validates that a pull request body follows .github/pull_request_template.md:
+ * required sections are filled in and the key checklist items are ticked.
+ *
+ * Usage:   bun scripts/check-pr-template.mjs <path-to-pr-body.txt>
+ * Output:  a JSON array of human-readable problems (empty array = all good).
+ * Exit:    0 = ok, 1 = one or more problems, 2 = no body file given.
+ *
+ * Env:     AUTHOR_ASSOCIATION — when OWNER/MEMBER/COLLABORATOR, the AI-disclosure
+ *          check is skipped (maintainers self-police).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+
+const bodyFile = process.argv[2];
+if (!bodyFile) {
+  console.error("usage: bun scripts/check-pr-template.mjs <pr-body-file>");
+  process.exit(2);
+}
+
+const body = readFileSync(bodyFile, "utf8").replace(/\r\n/g, "\n");
+const association = (process.env.AUTHOR_ASSOCIATION || "").toUpperCase();
+const isMaintainer = ["OWNER", "MEMBER", "COLLABORATOR"].includes(association);
+
+// Strip HTML comments robustly: loop until stable so nested/overlapping `<!--`
+// markers can't survive a single pass, then drop any unterminated trailing
+// comment. (Also satisfies CodeQL's "incomplete multi-character sanitization".)
+const stripComments = (s) => {
+  let out = s;
+  let prev;
+  do {
+    prev = out;
+    out = out.replace(/<!--[\s\S]*?-->/g, "");
+  } while (out !== prev);
+  return out.replace(/<!--[\s\S]*$/, "").trim();
+};
+
+// Grab the text under a heading whose title contains `keyword`, up to the next heading
+// or the end of the body.
+const section = (keyword) => {
+  const re = new RegExp(
+    `(?:^|\\n)#{1,4}\\s*[^\\n]*${keyword}[^\\n]*\\n([\\s\\S]*?)(?=\\n#{1,4}\\s|$)`,
+    "i",
+  );
+  const m = body.match(re);
+  return m ? m[1] : null;
+};
+
+const isFilled = (content) => {
+  if (content == null) return false;
+  // Template guidance lives in HTML comments; once stripped, a real answer remains.
+  return stripComments(content).length > 0;
+};
+
+const issues = [];
+
+if (section("Description") === null)
+  issues.push("The **Description** section is missing.");
+else if (!isFilled(section("Description")))
+  issues.push(
+    "The **Description** section is empty — describe what changed and why.",
+  );
+
+if (section("Ticket") === null)
+  issues.push("The **Ticket / Issue** section is missing.");
+else if (!isFilled(section("Ticket")))
+  issues.push(
+    "The **Ticket / Issue** section is empty — link an issue or write `N/A`.",
+  );
+
+if (section("Testing Instructions") === null)
+  issues.push("The **Testing Instructions** section is missing.");
+else if (!isFilled(section("Testing Instructions")))
+  issues.push(
+    "The **Testing Instructions** section is empty — tell reviewers how to test this, or write `N/A`.",
+  );
+
+const checklist = section("Checklist");
+if (checklist === null) {
+  issues.push("The **Checklist** section is missing.");
+} else {
+  if (!/- \[x\][^\n]*contribution guidelines/i.test(checklist))
+    issues.push(
+      "Please read and tick the **contribution guidelines** checklist item.",
+    );
+  if (!isMaintainer && !/- \[x\][^\n]*declared if AI/i.test(checklist))
+    issues.push(
+      "Please tick the **AI disclosure** checklist item (declare whether AI was used).",
+    );
+}
+
+// Require the Screenshots section when the PR changes UI (.tsx under app/ or components/).
+// PR_FILES points to a newline list of changed paths (provided by the workflow).
+const filesPath = process.env.PR_FILES;
+if (filesPath && existsSync(filesPath)) {
+  const changed = readFileSync(filesPath, "utf8").split("\n").filter(Boolean);
+  const touchesUI = changed.some(
+    (f) =>
+      /^(app|components)\/.*\.tsx$/.test(f) && !/\.(test|spec)\.tsx$/.test(f),
+  );
+  if (touchesUI) {
+    const shots = section("Screenshots");
+    if (shots === null)
+      issues.push(
+        "This PR changes UI (`.tsx`) — add the **Screenshots / GIFs** section with before/after media.",
+      );
+    else if (!isFilled(shots))
+      issues.push(
+        "This PR changes UI — the **Screenshots / GIFs** section is empty; add screenshots (or write `N/A` if it's genuinely not visual).",
+      );
+  }
+}
+
+console.log(JSON.stringify(issues));
+process.exit(issues.length ? 1 : 0);

--- a/scripts/check-pr-template.mjs
+++ b/scripts/check-pr-template.mjs
@@ -19,7 +19,13 @@ if (!bodyFile) {
   process.exit(2);
 }
 
-const body = readFileSync(bodyFile, "utf8").replace(/\r\n/g, "\n");
+let body;
+try {
+  body = readFileSync(bodyFile, "utf8").replace(/\r\n/g, "\n");
+} catch (e) {
+  console.error(`cannot read body file ${bodyFile}: ${e.message}`);
+  process.exit(2);
+}
 const association = (process.env.AUTHOR_ASSOCIATION || "").toUpperCase();
 const isMaintainer = ["OWNER", "MEMBER", "COLLABORATOR"].includes(association);
 


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Adds `.github/workflows/pr-validation.yml` (inspired by seerr) that groups the PR-meta checks:
(Also need to add crowdin pr in the exclude list)

- **PR title** — Conventional Commits check, **moved here** out of `🚦 Security & Quality Gate` (`linting.yml`) so it isn't mixed with code checks (no duplication).
- **PR template** — `scripts/check-pr-template.mjs` verifies the description follows this very template: **Description**, **Ticket / Issue** and **Testing Instructions** are filled (`N/A` accepted), and the **contribution guidelines** + **AI disclosure** checklist items are ticked. Maintainers (`OWNER`/`MEMBER`/`COLLABORATOR`) bypass the AI box.

On failure it posts one sticky comment listing what's missing and adds a `blocked: template` label; both are cleared automatically once the description is fixed (re-runs on edit). Skips bot PRs and `synchronize` events. Action SHAs pinned (Renovate-managed).

## 🏷️ Ticket / Issue

N/A — implements seerr's `pr-validation.yml` for Streamyfin.

### 🖼️ Screenshots / GIFs (if UI)

N/A — CI/tooling only, no app UI.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. `bun scripts/check-pr-template.mjs <file>` against an empty template body → lists the missing sections and exits `1`; against a filled body → prints `[]` and exits `0`.
2. As a non-maintainer (`AUTHOR_ASSOCIATION=CONTRIBUTOR`) without the AI box ticked → reports the AI-disclosure item; as `MEMBER` → bypassed.
3. This PR's own description is a live example — the `📋 Validate PR Template` job should pass on it.
