### PR TITLE
fix(player): re-enable controls auto-hide + keep it open while settings popover is open

### DIFF
--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -4,7 +4,7 @@ import type {
   MediaSourceInfo,
 } from "@jellyfin/sdk/lib/generated-client";
 import { useLocalSearchParams } from "expo-router";
-import { type FC, useCallback, useEffect, useState } from "react";
+import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { StyleSheet, useWindowDimensions, View } from "react-native";
 import Animated, {
   Easing,
@@ -30,6 +30,7 @@ import { ticksToMs } from "@/utils/time";
 import { BottomControls } from "./BottomControls";
 import { CenterControls } from "./CenterControls";
 import { CONTROLS_CONSTANTS } from "./constants";
+import { ControlsProvider } from "./contexts/ControlsContext";
 import { EpisodeList } from "./EpisodeList";
 import { GestureOverlay } from "./GestureOverlay";
 import { HeaderControls } from "./HeaderControls";
@@ -110,6 +111,12 @@ export const Controls: FC<Props> = ({
 
   const [episodeView, setEpisodeView] = useState(false);
   const [showAudioSlider, setShowAudioSlider] = useState(false);
+  // Pause the controls auto-hide while the player settings popover is open so
+  // it can't be dismissed out from under the user (notably the iOS popover,
+  // which lives inside the controls and closes when they fade out). The popover
+  // reports its open state through ControlsContext rather than prop drilling.
+  const [settingsMenuOpen, setSettingsMenuOpen] = useState(false);
+  const controlsContextValue = useMemo(() => ({ setSettingsMenuOpen }), []);
 
   const { height: screenHeight, width: screenWidth } = useWindowDimensions();
   const { previousItem, nextItem } = usePlaybackManager({
@@ -467,7 +474,7 @@ export const Controls: FC<Props> = ({
     episodeView,
     onHideControls: hideControls,
     timeout: CONTROLS_CONSTANTS.TIMEOUT,
-    disabled: true,
+    disabled: settingsMenuOpen,
   });
 
   const switchOnEpisodeMode = useCallback(() => {
@@ -478,122 +485,124 @@ export const Controls: FC<Props> = ({
   }, [isPlaying, togglePlay]);
 
   return (
-    <View style={styles.controlsContainer} pointerEvents='box-none'>
-      {episodeView ? (
-        <EpisodeList
-          item={item}
-          close={() => setEpisodeView(false)}
-          goToItem={goToItemCommon}
-        />
-      ) : (
-        <>
-          <GestureOverlay
-            screenWidth={screenWidth}
-            screenHeight={screenHeight}
-            showControls={showControls}
-            onToggleControls={toggleControls}
-            onSkipForward={handleSkipForward}
-            onSkipBackward={handleSkipBackward}
+    <ControlsProvider value={controlsContextValue}>
+      <View style={styles.controlsContainer} pointerEvents='box-none'>
+        {episodeView ? (
+          <EpisodeList
+            item={item}
+            close={() => setEpisodeView(false)}
+            goToItem={goToItemCommon}
           />
-          {/* Technical Info Overlay - rendered outside animated views to stay visible */}
-          {getTechnicalInfo && (
-            <TechnicalInfoOverlay
+        ) : (
+          <>
+            <GestureOverlay
+              screenWidth={screenWidth}
+              screenHeight={screenHeight}
               showControls={showControls}
-              visible={showTechnicalInfo}
-              getTechnicalInfo={getTechnicalInfo}
-              playMethod={playMethod}
-              transcodeReasons={transcodeReasons}
-              mediaSource={mediaSource}
+              onToggleControls={toggleControls}
+              onSkipForward={handleSkipForward}
+              onSkipBackward={handleSkipBackward}
             />
-          )}
-          <Animated.View
-            style={headerAnimatedStyle}
-            pointerEvents={showControls ? "auto" : "none"}
-          >
-            <HeaderControls
-              item={item}
-              showControls={showControls}
-              offline={offline}
-              mediaSource={mediaSource}
-              startPictureInPicture={startPictureInPicture}
-              switchOnEpisodeMode={switchOnEpisodeMode}
-              goToPreviousItem={goToPreviousItem}
-              goToNextItem={goToNextItem}
-              previousItem={previousItem}
-              nextItem={nextItem}
-              aspectRatio={aspectRatio}
-              isZoomedToFill={isZoomedToFill}
-              onZoomToggle={onZoomToggle}
-              playbackSpeed={playbackSpeed}
-              setPlaybackSpeed={setPlaybackSpeed}
-              showTechnicalInfo={showTechnicalInfo}
-              onToggleTechnicalInfo={onToggleTechnicalInfo}
-            />
-          </Animated.View>
-          <Animated.View
-            style={centerAnimatedStyle}
-            pointerEvents={showControls ? "box-none" : "none"}
-          >
-            <CenterControls
-              showControls={showControls}
-              isPlaying={isPlaying}
-              isBuffering={isBuffering}
-              showAudioSlider={showAudioSlider}
-              setShowAudioSlider={setShowAudioSlider}
-              togglePlay={togglePlay}
-              handleSkipBackward={handleSkipBackward}
-              handleSkipForward={handleSkipForward}
-              hasChapters={hasChapters}
-              hasPreviousChapter={hasPreviousChapter}
-              hasNextChapter={hasNextChapter}
-              goToPreviousChapter={goToPreviousChapter}
-              goToNextChapter={goToNextChapter}
-            />
-          </Animated.View>
-          <Animated.View
-            style={bottomAnimatedStyle}
-            pointerEvents={showControls ? "auto" : "none"}
-          >
-            <BottomControls
-              item={item}
-              chapters={item.Chapters}
-              durationMs={maxMs}
-              showControls={showControls}
-              isSliding={isSliding}
-              showRemoteBubble={showRemoteBubble}
-              currentTime={currentTime}
-              remainingTime={remainingTime}
-              showSkipButton={showSkipButton}
-              showSkipCreditButton={showSkipCreditButton}
-              hasContentAfterCredits={hasContentAfterCredits}
-              skipIntro={skipIntro}
-              skipCredit={skipCredit}
-              nextItem={nextItem}
-              handleNextEpisodeAutoPlay={handleNextEpisodeAutoPlay}
-              handleNextEpisodeManual={handleNextEpisodeManual}
-              handleControlsInteraction={handleControlsInteraction}
-              min={min}
-              max={max}
-              effectiveProgress={effectiveProgress}
-              cacheProgress={cacheProgress}
-              handleSliderStart={handleSliderStart}
-              handleSliderComplete={handleSliderComplete}
-              handleSliderChange={handleSliderChange}
-              handleTouchStart={handleTouchStart}
-              handleTouchEnd={handleTouchEnd}
-              seekTo={seekTo}
-              trickPlayUrl={trickPlayUrl}
-              trickplayInfo={trickplayInfo}
-              time={isSliding || showRemoteBubble ? time : remoteTime}
-              chapterPositions={chapterPositions}
-            />
-          </Animated.View>
-        </>
-      )}
-      {settings.maxAutoPlayEpisodeCount.value !== -1 && (
-        <ContinueWatchingOverlay goToNextItem={handleContinueWatching} />
-      )}
-    </View>
+            {/* Technical Info Overlay - rendered outside animated views to stay visible */}
+            {getTechnicalInfo && (
+              <TechnicalInfoOverlay
+                showControls={showControls}
+                visible={showTechnicalInfo}
+                getTechnicalInfo={getTechnicalInfo}
+                playMethod={playMethod}
+                transcodeReasons={transcodeReasons}
+                mediaSource={mediaSource}
+              />
+            )}
+            <Animated.View
+              style={headerAnimatedStyle}
+              pointerEvents={showControls ? "auto" : "none"}
+            >
+              <HeaderControls
+                item={item}
+                showControls={showControls}
+                offline={offline}
+                mediaSource={mediaSource}
+                startPictureInPicture={startPictureInPicture}
+                switchOnEpisodeMode={switchOnEpisodeMode}
+                goToPreviousItem={goToPreviousItem}
+                goToNextItem={goToNextItem}
+                previousItem={previousItem}
+                nextItem={nextItem}
+                aspectRatio={aspectRatio}
+                isZoomedToFill={isZoomedToFill}
+                onZoomToggle={onZoomToggle}
+                playbackSpeed={playbackSpeed}
+                setPlaybackSpeed={setPlaybackSpeed}
+                showTechnicalInfo={showTechnicalInfo}
+                onToggleTechnicalInfo={onToggleTechnicalInfo}
+              />
+            </Animated.View>
+            <Animated.View
+              style={centerAnimatedStyle}
+              pointerEvents={showControls ? "box-none" : "none"}
+            >
+              <CenterControls
+                showControls={showControls}
+                isPlaying={isPlaying}
+                isBuffering={isBuffering}
+                showAudioSlider={showAudioSlider}
+                setShowAudioSlider={setShowAudioSlider}
+                togglePlay={togglePlay}
+                handleSkipBackward={handleSkipBackward}
+                handleSkipForward={handleSkipForward}
+                hasChapters={hasChapters}
+                hasPreviousChapter={hasPreviousChapter}
+                hasNextChapter={hasNextChapter}
+                goToPreviousChapter={goToPreviousChapter}
+                goToNextChapter={goToNextChapter}
+              />
+            </Animated.View>
+            <Animated.View
+              style={bottomAnimatedStyle}
+              pointerEvents={showControls ? "auto" : "none"}
+            >
+              <BottomControls
+                item={item}
+                chapters={item.Chapters}
+                durationMs={maxMs}
+                showControls={showControls}
+                isSliding={isSliding}
+                showRemoteBubble={showRemoteBubble}
+                currentTime={currentTime}
+                remainingTime={remainingTime}
+                showSkipButton={showSkipButton}
+                showSkipCreditButton={showSkipCreditButton}
+                hasContentAfterCredits={hasContentAfterCredits}
+                skipIntro={skipIntro}
+                skipCredit={skipCredit}
+                nextItem={nextItem}
+                handleNextEpisodeAutoPlay={handleNextEpisodeAutoPlay}
+                handleNextEpisodeManual={handleNextEpisodeManual}
+                handleControlsInteraction={handleControlsInteraction}
+                min={min}
+                max={max}
+                effectiveProgress={effectiveProgress}
+                cacheProgress={cacheProgress}
+                handleSliderStart={handleSliderStart}
+                handleSliderComplete={handleSliderComplete}
+                handleSliderChange={handleSliderChange}
+                handleTouchStart={handleTouchStart}
+                handleTouchEnd={handleTouchEnd}
+                seekTo={seekTo}
+                trickPlayUrl={trickPlayUrl}
+                trickplayInfo={trickplayInfo}
+                time={isSliding || showRemoteBubble ? time : remoteTime}
+                chapterPositions={chapterPositions}
+              />
+            </Animated.View>
+          </>
+        )}
+        {settings.maxAutoPlayEpisodeCount.value !== -1 && (
+          <ContinueWatchingOverlay goToNextItem={handleContinueWatching} />
+        )}
+      </View>
+    </ControlsProvider>
   );
 };
 

--- a/components/video-player/controls/contexts/ControlsContext.tsx
+++ b/components/video-player/controls/contexts/ControlsContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext } from "react";
+
+interface ControlsContextProps {
+  /**
+   * Lets descendants (e.g. the settings popover) pause the controls auto-hide
+   * while an interactive menu is open, so it can't be dismissed out from under
+   * the user. Mirrors the `settingsMenuOpen` state owned by `Controls`.
+   */
+  setSettingsMenuOpen: (open: boolean) => void;
+}
+
+const ControlsContext = createContext<ControlsContextProps | undefined>(
+  undefined,
+);
+
+export const ControlsProvider = ControlsContext.Provider;
+
+export const useControlsContext = () => {
+  const ctx = useContext(ControlsContext);
+  if (!ctx) {
+    throw new Error(
+      "useControlsContext must be used within a ControlsProvider",
+    );
+  }
+  return ctx;
+};

--- a/components/video-player/controls/dropdown/DropdownView.tsx
+++ b/components/video-player/controls/dropdown/DropdownView.tsx
@@ -7,6 +7,7 @@ import { PLAYBACK_SPEEDS } from "@/components/PlaybackSpeedSelector";
 import useRouter from "@/hooks/useAppRouter";
 import { useOfflineMode } from "@/providers/OfflineModeProvider";
 import { useSettings } from "@/utils/atoms/settings";
+import { useControlsContext } from "../contexts/ControlsContext";
 import { usePlayerContext } from "../contexts/PlayerContext";
 import { useVideoContext } from "../contexts/VideoContext";
 import { PlaybackSpeedScope } from "../utils/playback-speed-settings";
@@ -30,6 +31,8 @@ const DropdownView = ({
 }: DropdownViewProps) => {
   const { subtitleTracks, audioTracks } = useVideoContext();
   const { item, mediaSource } = usePlayerContext();
+  // Report popover open/close so Controls can pause auto-hide while it's open.
+  const { setSettingsMenuOpen } = useControlsContext();
   const { settings, updateSettings } = useSettings();
   const router = useRouter();
   const isOffline = useOfflineMode();
@@ -223,6 +226,7 @@ const DropdownView = ({
       groups={optionGroups}
       trigger={trigger}
       expoUIConfig={{}}
+      onOpenChange={setSettingsMenuOpen}
       bottomSheetConfig={{
         enablePanDownToClose: true,
       }}


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

> ⚠️ **Stacked on #1621** (`feat/player-settings-popover`). The base branch is set to that branch — merge #1621 first, then this will be retargeted to `develop`.

## 📝 Description

In the player, tapping to reveal the controls showed them permanently — they never auto-hid after the inactivity timeout (`CONTROLS_CONSTANTS.TIMEOUT`, 4s). Root cause: `useControlsTimeout` was called with `disabled: true` hardcoded (introduced in the KSPlayer PR #1266), so the auto-hide timer was never armed.

Simply removing that override re-introduced a regression flagged on iOS: with auto-hide back on, the timer fired **while the settings popover was open**, dismissing it mid-interaction (subtitle / audio / speed selection). On iOS the popover lives inside the controls and closes when they fade out.

This PR therefore does two things:

1. Removes the hardcoded `disabled: true` → auto-hide works again.
2. Surfaces the settings popover's open state through a small **`ControlsContext`** (provided by `Controls`, consumed directly by `DropdownView`) and feeds it to `useControlsTimeout`'s `disabled` flag, so auto-hide **pauses while the menu is open** and re-arms once it closes. `HeaderControls` stays out of it — no prop drilling.

It's stacked on #1621 because the new `PlayerSettingsPopover` reports its open/close state on **both** platforms (the SwiftUI `Popover` `isPresented` binding on iOS), which the old native `Menu` could not. Android's menu is a separate global bottom-sheet modal, unaffected by controls hiding.

> Addresses the prop-drilling review feedback (@Alexk2309) by routing the popover open state through context instead of threading it `Controls → HeaderControls → DropdownView`.

## 🏷️ Ticket / Issue

Fixes #1243 — in-player settings menu closing on its own after 1-2s on iOS (couldn't toggle subtitles/audio).

Regression from #1266. Depends on #1621.

### 🖼️ Screenshots / GIFs (if UI)

N/A — behavioural change (timing of controls visibility). Best verified live; see testing steps.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms _(needs live iOS + Android confirmation)_
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`) _(changed files; the one remaining `tsc` error lives on the #1621 base branch — `jellyseerr/page.tsx` BottomSheetModal ref — and clears once #1621 lands)_
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (AI-Assisted badge above)

## 🔍 Testing Instructions

**iOS**
1. Play any item in the direct player.
2. Tap to show the controls, then do nothing for >4s → controls fade out. ✅
3. Tap to show the controls, open the `…` settings popover, wait >4s → popover stays open and controls stay visible. ✅
4. Pick a subtitle/audio track or close the popover → controls auto-hide 4s later. ✅

**Android**
1. Same as steps 1–2 (auto-hide after 4s).
2. The settings menu is a bottom-sheet modal, so it is unaffected by the controls hiding — behaviour unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed video player controls from auto-hiding while the settings menu is open, ensuring controls remain visible when adjusting playback settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
