### PR TITLE
fix(player): correct prev/next episode buttons at boundaries & for missing episodes

### DIFF
--- a/hooks/usePlaybackManager.ts
+++ b/hooks/usePlaybackManager.ts
@@ -109,30 +109,35 @@ export const usePlaybackManager = ({
     staleTime: 0,
   });
 
+  /**
+   * Derive prev/next from the current item's real position in the adjacent
+   * list rather than from the array length. `getEpisodes({ adjacentTo })` does
+   * not guarantee a fixed [prev, current, next] shape — at the first/last
+   * episode it can still return the current item as the first/last entry — so
+   * length-based indexing wrongly surfaces the current episode as "previous".
+   */
+  const currentIndex = useMemo(
+    () => adjacentItems?.findIndex((e) => e.Id === item?.Id) ?? -1,
+    [adjacentItems, item],
+  );
+
+  /** A neighbour is only navigable if it has an actual media file (not a
+   * "Virtual"/missing episode placeholder, e.g. an absent Special). */
+  const isNavigable = (episode?: BaseItemDto | null): episode is BaseItemDto =>
+    !!episode && episode.Id !== item?.Id && episode.LocationType !== "Virtual";
+
   const previousItem = useMemo(() => {
-    if (!adjacentItems || adjacentItems.length <= 1) {
-      return null;
-    }
-
-    if (adjacentItems.length === 2) {
-      return adjacentItems[0].Id === item?.Id ? null : adjacentItems[0];
-    }
-
-    return adjacentItems[0];
-  }, [adjacentItems, item]);
+    if (!adjacentItems || currentIndex <= 0) return null;
+    const candidate = adjacentItems[currentIndex - 1];
+    return isNavigable(candidate) ? candidate : null;
+  }, [adjacentItems, currentIndex, item]);
 
   /** The next item in the series */
   const nextItem = useMemo(() => {
-    if (!adjacentItems || adjacentItems.length <= 1) {
-      return null;
-    }
-
-    if (adjacentItems.length === 2) {
-      return adjacentItems[1].Id === item?.Id ? null : adjacentItems[1];
-    }
-
-    return adjacentItems[2];
-  }, [adjacentItems, item]);
+    if (!adjacentItems || currentIndex < 0) return null;
+    const candidate = adjacentItems[currentIndex + 1];
+    return isNavigable(candidate) ? candidate : null;
+  }, [adjacentItems, currentIndex, item]);
 
   /**
    * Reports playback progress.


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

The player's previous/next episode buttons were derived from the **length** of the `getEpisodes({ adjacentTo })` response (`hooks/usePlaybackManager.ts`). That heuristic breaks at series boundaries: `adjacentTo` does not guarantee a fixed `[prev, current, next]` shape, so on the **first episode** (e.g. S1E1) the current episode itself was surfaced as "previous" and a bogus **previous** button appeared. It also offered **"Virtual" (missing) episodes** — like an empty Specials (Season 0) entry with no media file — as navigation targets, and `nextItem` could make **autoplay** advance into a missing episode.

Fix: derive prev/next from the **current item's real index** in the adjacent list and skip any neighbour that is the current item or has `LocationType === "Virtual"`.

Covered edge cases:
- First episode → no false "previous" button.
- Last episode → no false "next" button.
- Missing / empty Specials → never offered as prev/next.
- Autoplay no longer advances into a missing episode.
- Offline path benefits too (now index-based for all list shapes).

## 🏷️ Ticket / Issue

N/A — bug found during testing. Previous button wrongly shown on Black Clover S1E1 (Specials/Season 0 empty).

### 🖼️ Screenshots / GIFs (if UI)

Without (button previously showing and throwing falied to get sream url) : 
<img width="1340" height="603" alt="qemu-system-x86_64_kooYScNAUK" src="https://github.com/user-attachments/assets/879e4aa1-422e-43c0-8441-93018dc62a1e" />
With (not showing on first episode) : 
<img width="1340" height="603" alt="qemu-system-x86_64_kOG0S377Qk" src="https://github.com/user-attachments/assets/1f27941e-622a-4c19-8b72-7c8f5c546d73" />

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms _(verifying live)_
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (AI-Assisted badge above)

## 🔍 Testing Instructions

1. Open a series whose **first** episode has no real previous (e.g. one with an empty/absent Specials season). Play **S1E1**.
2. Verify **no** "previous episode" button is shown in the player header.
3. Play a middle episode → both previous and next buttons appear and navigate correctly.
4. Play the **last** episode of the last season → **no** "next" button.
5. If the series has a missing episode (Jellyfin "Virtual" placeholder) adjacent to the current one, verify it is **not** offered as prev/next and autoplay does not jump to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced episode navigation to more accurately determine the current episode's position within available episodes and identify valid neighboring episodes for previous/next selection. The system now properly validates that previous and next episode navigation options exist and are selectable before presenting them as choices, while excluding certain unavailable episode types from the navigation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->