### PR TITLE
fix(platform-dropdown-component): Auto-size iOS trigger wrapper to pr…

### DIFF
--- a/components/PlatformDropdown.tsx
+++ b/components/PlatformDropdown.tsx
@@ -1,13 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
-import React, { useEffect, useState } from "react";
-import {
-  type LayoutChangeEvent,
-  Platform,
-  StyleSheet,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import React, { useEffect } from "react";
+import { Platform, StyleSheet, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/common/Text";
 import { useGlobalModal } from "@/providers/GlobalModalProvider";
@@ -217,24 +211,6 @@ const PlatformDropdownComponent = ({
 }: PlatformDropdownProps) => {
   const { showModal, hideModal, isVisible } = useGlobalModal();
 
-  // @expo/ui's <Host> (SDK 55) fills its available space by default, and
-  // `matchContents` doesn't help here: it reports the native Menu's size via
-  // setStyleSize and overrides any explicit size. Instead we measure the
-  // trigger's intrinsic size in plain RN (off-layout) and pin it on the Host.
-  const [triggerSize, setTriggerSize] = useState<{
-    width: number;
-    height: number;
-  } | null>(null);
-
-  const handleMeasureTrigger = (e: LayoutChangeEvent) => {
-    const { width, height } = e.nativeEvent.layout;
-    setTriggerSize((prev) =>
-      prev && prev.width === width && prev.height === height
-        ? prev
-        : { width, height },
-    );
-  };
-
   // Handle controlled open state for Android
   useEffect(() => {
     if (Platform.OS === "android" && controlledOpen === true) {
@@ -265,25 +241,11 @@ const PlatformDropdownComponent = ({
   }, [isVisible, controlledOpen, controlledOnOpenChange]);
 
   if (Platform.OS === "ios" && !Platform.isTV) {
-    // Pin the wrapper to the measured trigger size. @expo/ui's <Host> (SDK 55)
-    // fills its parent and reports its own size via setStyleSize, so it can't
-    // size itself to content. If the wrapper has no size, the Host's `flex: 1`
-    // height depends on the parent while the parent depends on the Host — a
-    // circular dependency that collapses to 0 for any selector nested more than
-    // one level deep (so only the first, shallowest dropdown stays visible).
-    // Giving the wrapper the measured size breaks the cycle; the Host then
-    // fills a concrete box.
+    // @expo/ui's <Host> can't size to content, so an in-flow invisible copy of
+    // the trigger sizes the wrapper while the Host overlays the real Menu.
     return (
-      <View style={triggerSize ?? { opacity: 0 }}>
-        {/* Hidden measurer: lays the trigger out off-flow to capture its
-            intrinsic size. Absolutely positioned WITHOUT right/bottom so it
-            sizes to the trigger's content rather than to its parent. */}
-        <View
-          style={{ position: "absolute", top: 0, left: 0, opacity: 0 }}
-          pointerEvents='none'
-          aria-hidden
-          onLayout={handleMeasureTrigger}
-        >
+      <View>
+        <View pointerEvents='none' aria-hidden style={{ opacity: 0 }}>
           {trigger}
         </View>
         <Host style={[StyleSheet.absoluteFill, expoUIConfig?.hostStyle as any]}>


### PR DESCRIPTION
fix(dropdown): auto-size iOS trigger wrapper to prevent stale label wrapping

<!--
Use a conventional commit title for the PR title,
for example `feat(auth): add MFA`
All sections below are required. Write N/A if a section is not applicable.
If you use AI to help implement this PR, you must declare it below. It's very important that the feature or fix implemented has been tested thoroughly by you personally on all target platforms. Only adding AI generated code without proper testing is not allowed and this PR will be closed immediately.
-->

# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Fixes a layout bug in the season dropdown on iOS where the label wrapped onto two lines:

```
Season
1
```

instead of `Season 1`.

**Root cause:** the previous iOS `PlatformDropdown` implementation pinned the wrapper to a `useState`-stored measurement of the trigger taken via `onLayout`. On `SeasonDropdown`'s first render, `seasonIndex` is `undefined`, so the trigger reads `"Season "` (no number). The wrapper gets pinned to that narrow width. A `useEffect` then selects the first season, the trigger re-renders as `"Season 1"`, but the wrapper (and therefore the SwiftUI `<Menu>` label frame inside `<Host>`) is already locked at the stale width — so the new text wraps. This affects any dropdown whose label content can change after mount (bitrate, audio track, subtitle selectors, etc.).

**Fix:** replace the measured-pin approach with an in-flow invisible copy of the trigger that sizes the wrapper naturally on every render. The `<Host>` still overlays the real interactive `<Menu>` via `absoluteFill`, so:

- The wrapper auto-sizes to current trigger content — no state, no race, no stale measurement.
- The original SDK 55 fix (preventing stacked dropdowns from collapsing to 0 in the download sheet) is preserved: the wrapper still has a concrete non-zero size, and `<Host>`'s `absoluteFill` still breaks the flex circular dependency.
- Removed now-dead code: `triggerSize` state, `handleMeasureTrigger`, `useState` and `LayoutChangeEvent` imports.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

<!-- Add before/after screenshot of a series page season picker on iOS. -->

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

**Regression (the bug this PR fixes):**

1. Open the app on iOS and navigate to any series with multiple seasons.
2. Confirm the season picker shows `Season 1` (or whichever season was last selected) on a single line — not `Season` over `1`.
3. Open the dropdown and switch seasons; the label updates and continues to render on a single line.

**Preserve previous fix (stacked dropdowns):**

1. From a series episode, open the download sheet (download icon → choose a download quality flow).
2. Confirm **all** stacked dropdowns are visible and tappable: Quality, Video, Audio, Subtitle. None should collapse / disappear.

**Other dropdown call sites — smoke test:**

1. Library filter dropdowns on the libraries tab.
2. Audio / subtitle / bitrate selectors during playback.
3. Jellyse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified dropdown layout calculation logic for iOS devices while maintaining existing functionality across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->