### PR TITLE
fix(mpv): release audio session on player exit so other apps' audio resumes

### DIFF
--- a/modules/mpv-player/ios/MpvPlayerView.swift
+++ b/modules/mpv-player/ios/MpvPlayerView.swift
@@ -140,6 +140,8 @@ class MpvPlayerView: ExpoView {
 		CATransaction.commit()
 	}
 
+	// MARK: - Audio Session & Notifications
+
 	private func configureAudioSession() {
 		let session = AVAudioSession.sharedInstance()
 		do {
@@ -158,7 +160,6 @@ class MpvPlayerView: ExpoView {
 		try? session.setActive(false, options: .notifyOthersOnDeactivation)
 		try? session.setCategory(.ambient, mode: .default, options: [.mixWithOthers])
 	}
-	// MARK: - Audio Session & Notifications
 
 	private func setupNotifications() {
 		// Handle audio session interruptions (e.g., incoming calls, other apps playing audio)

--- a/modules/mpv-player/ios/MpvPlayerView.swift
+++ b/modules/mpv-player/ios/MpvPlayerView.swift
@@ -81,7 +81,6 @@ class MpvPlayerView: ExpoView {
 	private func setupView() {
 		clipsToBounds = true
 		backgroundColor = .black
-		configureAudioSession()
 
 		videoContainer = UIView()
 		videoContainer.translatesAutoresizingMaskIntoConstraints = false
@@ -142,18 +141,22 @@ class MpvPlayerView: ExpoView {
 	}
 
 	private func configureAudioSession() {
-		let audioSession = AVAudioSession.sharedInstance()
+		let session = AVAudioSession.sharedInstance()
 		do {
-			try audioSession.setCategory(
-				.playback,
-				mode: .moviePlayback,
-				policy: .longFormAudio,
-				options: []
-			)
-			try audioSession.setActive(true)
+			try session.setCategory(.playback, mode: .moviePlayback, policy: .longFormAudio, options: [])
+			try session.setActive(true)
 		} catch {
 			print("Failed to configure audio session: \(error)")
 		}
+	}
+
+	/// Deactivate the session AND reset the category — `setActive(false)` alone
+	/// leaves `.playback`/`.longFormAudio` on the shared singleton, so any later
+	/// reactivation (foreground, route change, other modules) re-steals audio.
+	private func tearDownAudioSession() {
+		let session = AVAudioSession.sharedInstance()
+		try? session.setActive(false, options: .notifyOthersOnDeactivation)
+		try? session.setCategory(.ambient, mode: .default, options: [.mixWithOthers])
 	}
 	// MARK: - Audio Session & Notifications
 
@@ -270,6 +273,7 @@ class MpvPlayerView: ExpoView {
 
 	func play() {
 		intendedPlayState = true
+		configureAudioSession()
 		setupRemoteCommands()
 		renderer?.play()
 		pipController?.setPlaybackRate(1.0)
@@ -440,6 +444,7 @@ class MpvPlayerView: ExpoView {
 		renderer?.stop()
 		displayLayer.removeFromSuperlayer()
 		clearNowPlayingInfo()
+		tearDownAudioSession()
 		NotificationCenter.default.removeObserver(self)
 	}
 }
@@ -519,9 +524,7 @@ extension MpvPlayerView: MPVLayerRendererDelegate {
 	}
 
 	func renderer(_: MPVLayerRenderer, didSelectAudioOutput audioOutput: String) {
-		// Audio output is now active - this is the right time to activate audio session and set Now Playing
-		print("[MPV] Audio output ready (\(audioOutput)), activating audio session and syncing Now Playing")
-		nowPlayingManager.activateAudioSession()
+		print("[MPV] Audio output ready (\(audioOutput)), syncing Now Playing")
 		syncNowPlaying(isPlaying: !isPaused())
 	}
 }


### PR DESCRIPTION
# 📦 Pull Request

<!-- 
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#) -->

## 📝 Description

When exiting the MPV player on iOS, audio from other apps (Spotify, Apple Music, podcasts, etc.) would not resume playback — even after the user returned to the home screen and closed Streamyfin. The audio session was being activated eagerly in `setupView()` with `.playback` / `.longFormAudio` / `.moviePlayback` and was never properly torn down on exit, so the system kept Streamyfin marked as the active long-form audio owner and refused to hand control back.

This PR fixes the lifecycle of the shared `AVAudioSession`:

- **Defer activation until playback actually starts.** Removed `configureAudioSession()` from `setupView()` and moved it into `play()`, so the session is only claimed when the user actually begins watching.
- **Add `tearDownAudioSession()`** that does both:
  1. `setActive(false, options: .notifyOthersOnDeactivation)` so iOS notifies other apps they may resume.
  2. Resets the category to `.ambient` / `.mixWithOthers`. Without this reset, `.playback` / `.longFormAudio` remains on the shared singleton and any later route change, foreground event, or other module that reactivates audio re-steals it from the other app.
- **Invoke `tearDownAudioSession()` on cleanup** alongside renderer/displayLayer teardown and `NotificationCenter` removal.
- **Removed the redundant `nowPlayingManager.activateAudioSession()` call** in the `didSelectAudioOutput` renderer delegate — activation now happens once, intentionally, in `play()`.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A — native iOS audio-session behavior change, no UI surface.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

iOS only (MPV player is iOS-only). Test on a physical device — the Simulator does not reproduce audio-session ownership behavior reliably.

1. Open Spotify / Apple Music / a podcast app and start playback.
2. Open Streamyfin and start playing any video with the MPV player. Confirm the other app's audio is paused (expected — MPV takes over for video playback).
3. Stop / exit the video back to the Streamyfin UI.
4. **Verify the other app's audio resumes automatically** (or can be resumed by pressing play from Control Center / lock screen) without having to force-quit Streamyfin.
5. Background Streamyfin, then foreground it again — confirm the other app's audio is **not** re-interrupted while Streamyfin is idle (no active playback).
6. Start a new MPV playback session and confirm video audio still plays correctly through the speaker / headphones / AirPlay route.
7. Repeat with a Bluetooth route change mid-playback to confirm normal MPV audio still works.