### PR TITLE
fix(downloads): poster images not showing for downloaded content

### DIFF
--- a/hooks/useImageStorage.ts
+++ b/hooks/useImageStorage.ts
@@ -1,3 +1,4 @@
+import { File, Paths } from "expo-file-system";
 import { useCallback } from "react";
 import { storage } from "@/utils/mmkv";
 
@@ -12,36 +13,32 @@ const useImageStorage = () => {
     }
   }, []);
 
+  /**
+   * expo-file-system instead of fetch+Blob+FileReader: the latter silently
+   * resolves to an empty payload under RN's New Architecture.
+   */
   const image2Base64 = useCallback(async (url?: string | null) => {
     if (!url) return null;
 
-    let blob: Blob;
+    const tmpFile = new File(
+      Paths.cache,
+      `img-${Date.now()}-${Math.random().toString(36).slice(2)}.jpg`,
+    );
     try {
-      // Fetch the data from the URL
-      const response = await fetch(url);
-      blob = await response.blob();
+      const downloaded = await File.downloadFileAsync(url, tmpFile, {
+        idempotent: true,
+      });
+      return await downloaded.base64();
     } catch (error) {
       console.warn("Error fetching image:", error);
       return null;
+    } finally {
+      try {
+        if (tmpFile.exists) tmpFile.delete();
+      } catch {
+        // best-effort cleanup
+      }
     }
-
-    // Create a FileReader instance
-    const reader = new FileReader();
-
-    // Convert blob to base64
-    return new Promise<string>((resolve, reject) => {
-      reader.onloadend = () => {
-        if (typeof reader.result === "string") {
-          // Extract the base64 string (remove the data URL prefix)
-          const base64 = reader.result.split(",")[1];
-          resolve(base64);
-        } else {
-          reject(new Error("Failed to convert image to base64"));
-        }
-      };
-      reader.onerror = reject;
-      reader.readAsDataURL(blob);
-    });
   }, []);
 
   const saveImage = useCallback(

--- a/hooks/useImageStorage.ts
+++ b/hooks/useImageStorage.ts
@@ -33,11 +33,7 @@ const useImageStorage = () => {
       console.warn("Error fetching image:", error);
       return null;
     } finally {
-      try {
-        if (tmpFile.exists) tmpFile.delete();
-      } catch {
-        // best-effort cleanup
-      }
+      if (tmpFile.exists) tmpFile.delete();
     }
   }, []);
 


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Downloaded items were rendering the placeholder poster instead of the actual cover art. Root cause is in `hooks/useImageStorage.ts`: the `fetch(url) → response.blob() → FileReader.readAsDataURL(blob)` pipeline silently resolves to an empty payload under React Native's New Architecture, so we end up writing an empty/invalid base64 string into MMKV.

This PR swaps just the download-and-decode step for `expo-file-system`'s `File.downloadFileAsync(url) → file.base64()` (the same primitive already used for trickplay and subtitles), and cleans up the temp file in `Paths.cache` afterward. The MMKV key/value format is unchanged (still base64 stored under the item id), so every consumer (`MovieCard`, `SeriesCard`, `DownloadCard`, offline series page) keeps working without modification.

Note: storing posters as base64 in MMKV is not ideal long-term (memory-mapped, ~33% size overhead) — but that's a separate refactor. This PR is the minimal fix to restore the broken behavior.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

<!-- Add before/after screenshots of the Downloads tab on iOS and Android showing posters now rendering. -->

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Start from a clean state (or clear the existing downloaded image cache by deleting and re-downloading an item).
2. Download a movie and a TV episode from a Jellyfin library.
3. Open the Downloads tab and verify the movie poster, series poster, and per-episode card all show the real artwork instead of the placeholder.
4. Open the downloaded series detail page while offline and verify the backdrop/poster renders.
5. Force-quit and relaunch the app; verify posters still render (i.e., persisted in MMKV correctly).
6. Repeat on both iOS and Android with the New Architecture enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for image downloads and caching; failed downloads now handled gracefully with appropriate fallback behavior.

* **Refactor**
  * Optimized image storage mechanism for improved performance and more efficient file management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->