### PR TITLE
fix(music): use white tab labels instead of default blue

### DIFF
--- a/app/(auth)/(tabs)/(libraries)/music/[libraryId]/_layout.tsx
+++ b/app/(auth)/(tabs)/(libraries)/music/[libraryId]/_layout.tsx
@@ -40,6 +40,8 @@ const Layout = () => {
         keyboardDismissMode='none'
         screenOptions={{
           tabBarBounces: true,
+          tabBarActiveTintColor: "#FFFFFF",
+          tabBarInactiveTintColor: "#9CA3AF",
           tabBarLabelStyle: {
             fontSize: TAB_LABEL_FONT_SIZE,
             fontWeight: "600",


### PR DESCRIPTION
## What

The music library tab view (`app/(auth)/(tabs)/(libraries)/music/[libraryId]/_layout.tsx`) rendered its tab labels in blue instead of white.

## Why

The `screenOptions` set `tabBarLabelStyle` (font size/weight) and `tabBarIndicatorStyle`, but never set `tabBarActiveTintColor` / `tabBarInactiveTintColor`. React Navigation's material-top-tabs drives label color from those tint props (not from `color` in `tabBarLabelStyle`), so it fell back to the library's default blue active tint.

## Change

Added explicit tint colors to `screenOptions`:
- `tabBarActiveTintColor: "#FFFFFF"`
- `tabBarInactiveTintColor: "#9CA3AF"`

Scope is limited to the music page only, as requested. (Note: the Live TV tab layout has the same omission but is left untouched here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated music tab bar colors to enhance visual distinction between active and inactive tab states for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->