### PR TITLE
feat(mpv-ios): Fix controls not pressable after resuming from PIP

### DIFF
--- a/modules/mpv-player/ios/MpvPlayerModule.swift
+++ b/modules/mpv-player/ios/MpvPlayerModule.swift
@@ -213,7 +213,7 @@ public class MpvPlayerModule: Module {
       }
 
       // Defines events that the view can send to JavaScript
-      Events("onLoad", "onPlaybackStateChange", "onProgress", "onError", "onTracksReady")
+      Events("onLoad", "onPlaybackStateChange", "onProgress", "onError", "onTracksReady", "onPictureInPictureChange")
     }
   }
 }

--- a/modules/mpv-player/ios/MpvPlayerView.swift
+++ b/modules/mpv-player/ios/MpvPlayerView.swift
@@ -61,6 +61,7 @@ class MpvPlayerView: ExpoView {
 	let onProgress = EventDispatcher()
 	let onError = EventDispatcher()
 	let onTracksReady = EventDispatcher()
+	let onPictureInPictureChange = EventDispatcher()
 
 	private var currentURL: URL?
 	private var cachedPosition: Double = 0
@@ -637,6 +638,9 @@ extension MpvPlayerView: PiPControllerDelegate {
 		print("PiP did start: \(didStartPictureInPicture)")
 		// Ensure current time is synced when PiP starts
 		pipController?.setCurrentTimeFromSeconds(cachedPosition, duration: cachedDuration)
+		// Notify JS of the actual PiP active state. `didStartPictureInPicture`
+		// is `false` when AVKit reports a failure to start, so reflect that.
+		onPictureInPictureChange(["isActive": didStartPictureInPicture])
 	}
 	
 	func pipController(_ controller: PiPController, willStopPictureInPicture: Bool) {
@@ -655,6 +659,9 @@ extension MpvPlayerView: PiPControllerDelegate {
 		if _isZoomedToFill {
 			displayLayer.videoGravity = .resizeAspectFill
 		}
+		// Notify JS that PiP has fully stopped so the controls overlay can
+		// be re-mounted when the user returns to full screen.
+		onPictureInPictureChange(["isActive": false])
 	}
 	
 	func pipController(_ controller: PiPController, restoreUserInterfaceForPictureInPictureStop completionHandler: @escaping (Bool) -> Void) {


### PR DESCRIPTION
<!-- 
Use a conventional commit title for the PR title, 
for example `feat(auth): add MFA`
All sections below are required. Write N/A if a section is not applicable.
If you use AI to help implement this PR, you must declare it below. It's very important that the feature or fix implemented has been tested thoroughly by you personally on all target platforms. Only adding AI generated code without proper testing is not allowed and this PR will be closed immediately.
-->

# 📦 Pull Request

<!-- 
  🤖 AI ASSISTED? 
  Uncomment the line below if AI was used to assist with this PR:
-->
<!-- 
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#) -->

## 📝 Description

Fixes a bug on iOS where, after entering Picture-in-Picture in the MPV player and then returning to full screen, the player controls overlay became unresponsive (taps on play/pause/seek/close did nothing).

Root cause: the JS layer in [app/(auth)/player/direct-player.tsx](app/(auth)/player/direct-player.tsx#L840) already listens for an `onPictureInPictureChange` event to drive `isPipMode` (which controls whether the overlay is mounted/interactive), and the Android native view already dispatches it from [modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt](modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MpvPlayerView.kt#L113). The iOS native module, however, never declared or fired this event — so when PiP stopped, `isPipMode` stayed `true` on iOS and the controls overlay remained in its PiP (non‑interactive) state.

Changes:
- Register `onPictureInPictureChange` in the iOS module's `Events(...)` list in [modules/mpv-player/ios/MpvPlayerModule.swift](modules/mpv-player/ios/MpvPlayerModule.swift#L216).
- Add an `onPictureInPictureChange` `EventDispatcher` on `MpvPlayerView` in [modules/mpv-player/ios/MpvPlayerView.swift](modules/mpv-player/ios/MpvPlayerView.swift#L64).
- Dispatch `{ isActive: didStartPictureInPicture }` from `pipController(_:didStartPictureInPicture:)` so a failed PiP start is reflected as `false` rather than always `true`.
- Dispatch `{ isActive: false }` from `pipController(_:didStopPictureInPicture:)` so JS re-mounts / re-enables the controls overlay when returning from PiP.

Brings iOS to parity with Android for the PiP lifecycle event.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A — behavior-only fix; no visual changes to the controls themselves.

## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

iOS (MPV player, real device recommended — PiP requires it):
1. Open any video and start playback using the MPV player on iOS.
2. Trigger Picture-in-Picture from the player controls.
3. Confirm the app minimises into a PiP window and playback continues.
4. Tap the PiP window's "return to app" button (or reopen the app) to restore full‑screen playback.
5. Tap the screen to bring up the controls overlay and verify:
   - Play / pause works.
   - Seeking via the progress bar works.
   - The close button works.
   - The