### PR TITLE
feat(settings): graduated version tracking (build, branch, commit)

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -11,6 +11,12 @@ on:
   push:
     branches: [develop, master]
 
+# Exposed to `expo prebuild` (app.config.js → extra.build) so Settings can show the
+# branch + commit a CI build was made from. EAS cloud builds use EAS_BUILD_* instead.
+env:
+  EXPO_PUBLIC_GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+  EXPO_PUBLIC_GIT_COMMIT: ${{ github.sha }}
+
 jobs:
   build-android-phone:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))

--- a/app.config.js
+++ b/app.config.js
@@ -1,3 +1,41 @@
+const { execFileSync } = require("node:child_process");
+
+// Build metadata, injected into `extra.build` and read at runtime via
+// expo-constants (see utils/version.ts). Sources in priority order:
+// EAS cloud build → GitHub Actions → explicit EXPO_PUBLIC_* → local git → null.
+const git = (args) => {
+  try {
+    return execFileSync("git", args, { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+};
+
+const buildMeta = {
+  commit:
+    (
+      process.env.EAS_BUILD_GIT_COMMIT_HASH ||
+      process.env.GITHUB_SHA ||
+      process.env.EXPO_PUBLIC_GIT_COMMIT ||
+      git(["rev-parse", "HEAD"]) ||
+      ""
+    ).slice(0, 7) || null,
+  branch:
+    process.env.EAS_BUILD_GIT_BRANCH ||
+    process.env.GITHUB_HEAD_REF ||
+    process.env.GITHUB_REF_NAME ||
+    process.env.EXPO_PUBLIC_GIT_BRANCH ||
+    git(["rev-parse", "--abbrev-ref", "HEAD"]) ||
+    null,
+  profile:
+    process.env.EAS_BUILD_PROFILE ||
+    process.env.EXPO_PUBLIC_BUILD_PROFILE ||
+    null,
+  builtAt: new Date().toISOString(),
+};
+
 module.exports = ({ config }) => {
   if (process.env.EXPO_TV !== "1") {
     config.plugins.push("expo-background-task");
@@ -21,6 +59,8 @@ module.exports = ({ config }) => {
   if (process.env.GOOGLE_SERVICES_JSON) {
     androidConfig.googleServicesFile = process.env.GOOGLE_SERVICES_JSON;
   }
+
+  config.extra = { ...config.extra, build: buildMeta };
 
   return {
     ...(Object.keys(androidConfig).length > 0 && { android: androidConfig }),

--- a/components/settings/UserInfo.tsx
+++ b/components/settings/UserInfo.tsx
@@ -1,8 +1,8 @@
-import * as Application from "expo-application";
 import { useAtom } from "jotai";
 import { useTranslation } from "react-i18next";
 import { View, type ViewProps } from "react-native";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
+import { getVersionInfo } from "@/utils/version";
 import { ListGroup } from "../list/ListGroup";
 import { ListItem } from "../list/ListItem";
 
@@ -13,13 +13,9 @@ export const UserInfo: React.FC<Props> = ({ ...props }) => {
   const [user] = useAtom(userAtom);
   const { t } = useTranslation();
 
-  // Show "0.54.1 (42)": the build number (CFBundleVersion / versionCode, auto-incremented
-  // by EAS) uniquely identifies a build, so TestFlight/dev reports still pin the exact build.
-  const appVersion = Application?.nativeApplicationVersion;
-  const buildVersion = Application?.nativeBuildVersion;
-  const version = appVersion
-    ? `${appVersion}${buildVersion ? ` (${buildVersion})` : ""}`
-    : buildVersion || "N/A";
+  // Graduated build identifier — see utils/version.ts:
+  // dev → "0.54.1 · branch · commit", develop/CI → "0.54.1 · commit", production → "0.54.1 (42)".
+  const { display: version } = getVersionInfo();
 
   return (
     <View {...props}>

--- a/components/settings/UserInfo.tsx
+++ b/components/settings/UserInfo.tsx
@@ -13,10 +13,13 @@ export const UserInfo: React.FC<Props> = ({ ...props }) => {
   const [user] = useAtom(userAtom);
   const { t } = useTranslation();
 
-  const version =
-    Application?.nativeApplicationVersion ||
-    Application?.nativeBuildVersion ||
-    "N/A";
+  // Show "0.54.1 (42)": the build number (CFBundleVersion / versionCode, auto-incremented
+  // by EAS) uniquely identifies a build, so TestFlight/dev reports still pin the exact build.
+  const appVersion = Application?.nativeApplicationVersion;
+  const buildVersion = Application?.nativeBuildVersion;
+  const version = appVersion
+    ? `${appVersion}${buildVersion ? ` (${buildVersion})` : ""}`
+    : buildVersion || "N/A";
 
   return (
     <View {...props}>

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/utils/secureCredentials";
 import { store } from "@/utils/store";
 import { clearTVDiscoverySafely } from "@/utils/tvDiscovery/sync";
+import { APP_VERSION } from "@/utils/version";
 
 interface Server {
   address: string;
@@ -53,7 +54,7 @@ const initialApi = (() => {
       const id = getOrSetDeviceId();
       const deviceName = getDeviceNameSync();
       const jellyfinInstance = new Jellyfin({
-        clientInfo: { name: "Streamyfin", version: "0.54.1" },
+        clientInfo: { name: "Streamyfin", version: APP_VERSION },
         deviceInfo: {
           name: deviceName,
           id,
@@ -135,7 +136,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       const id = getOrSetDeviceId();
       const deviceName = getDeviceNameSync();
       return new Jellyfin({
-        clientInfo: { name: "Streamyfin", version: "0.54.1" },
+        clientInfo: { name: "Streamyfin", version: APP_VERSION },
         deviceInfo: {
           name: deviceName,
           id,
@@ -169,7 +170,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
     return {
       authorization: `MediaBrowser Client="Streamyfin", Device=${
         Platform.OS === "android" ? "Android" : "iOS"
-      }, DeviceId="${deviceId}", Version="0.54.1"`,
+      }, DeviceId="${deviceId}", Version="${APP_VERSION}"`,
     };
   }, [deviceId]);
 

--- a/utils/version.ts
+++ b/utils/version.ts
@@ -1,0 +1,86 @@
+import * as Application from "expo-application";
+import Constants from "expo-constants";
+
+/** Raw marketing version (app.json `version`), e.g. "0.54.1". Exposed so the Jellyfin
+ * clientInfo auto-tracks the app version instead of a hardcoded string. */
+export const APP_VERSION = Application.nativeApplicationVersion ?? "unknown";
+
+/** Build metadata injected at build time by `app.config.js` into `extra.build`. */
+export interface BuildMeta {
+  commit?: string | null;
+  branch?: string | null;
+  profile?: string | null;
+  builtAt?: string | null;
+}
+
+export interface VersionInfo {
+  /** Marketing version (CFBundleShortVersionString / android versionName), e.g. "0.54.1". */
+  version: string | null;
+  /** Build number (CFBundleVersion / versionCode), e.g. "42". */
+  build: string | null;
+  /** Short git commit the build was made from, e.g. "a1b2c3d". */
+  commit: string | null;
+  /** Git branch the build was made from, e.g. "develop". */
+  branch: string | null;
+  /** EAS build profile, e.g. "production", "preview", or null for local. */
+  profile: string | null;
+  isDev: boolean;
+  isProduction: boolean;
+  /** Graduated label for the Settings "App version" row (see tiering below). */
+  display: string;
+}
+
+/**
+ * Resolve a graduated version string for Settings.
+ *
+ * Tiering (most → least detailed):
+ *  - dev / local build   → `version · branch · commit`   (full context for debugging)
+ *  - develop / CI / preview → `version · commit`          (pin the exact source)
+ *  - production (store / TestFlight) → `version (build)`   (store-correlatable; the
+ *      build number lets TestFlight reports pin a build whose version isn't a
+ *      published release. Note: TestFlight and the public App Store ship the same
+ *      binary — telling them apart needs a runtime iOS receipt check, intentionally
+ *      not done here.)
+ */
+export function getVersionInfo(): VersionInfo {
+  // Read native/config values defensively — a version string must never crash Settings
+  // (e.g. a dev build whose native expo-constants is out of sync with the JS).
+  const read = <T>(fn: () => T): T | null => {
+    try {
+      return fn() ?? null;
+    } catch {
+      return null;
+    }
+  };
+
+  const version = read(() => Application.nativeApplicationVersion);
+  const build = read(() => Application.nativeBuildVersion);
+  const meta = (read(() => Constants.expoConfig?.extra?.build) ??
+    {}) as BuildMeta;
+  const commit = meta.commit ?? null;
+  const branch = meta.branch ?? null;
+  const profile = meta.profile ?? null;
+  const isDev = __DEV__ === true;
+  const isProduction =
+    typeof profile === "string" && profile.startsWith("production");
+
+  let display: string;
+  if (isDev) {
+    display = [version ?? "dev", branch, commit].filter(Boolean).join(" · ");
+  } else if (isProduction) {
+    display = build ? `${version} (${build})` : (version ?? "N/A");
+  } else {
+    display = [version, commit].filter(Boolean).join(" · ") || version || "N/A";
+  }
+
+  return {
+    version,
+    build,
+    commit,
+    branch,
+    profile,
+    isDev,
+    isProduction,
+    display,
+  };
+}

--- a/utils/version.ts
+++ b/utils/version.ts
@@ -68,7 +68,8 @@ export function getVersionInfo(): VersionInfo {
   if (isDev) {
     display = [version ?? "dev", branch, commit].filter(Boolean).join(" · ");
   } else if (isProduction) {
-    display = build ? `${version} (${build})` : (version ?? "N/A");
+    display =
+      version && build ? `${version} (${build})` : (version ?? build ?? "N/A");
   } else {
     display = [version, commit].filter(Boolean).join(" · ") || version || "N/A";
   }


### PR DESCRIPTION
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

# 📦 Pull Request

## 📝 Description

Turns the Settings **App version** row into a **graduated build identifier**, and makes the Jellyfin client version auto-track the real app version.

**Settings → User info → App version** now adapts to the build type — resolved by `utils/version.ts` (`getVersionInfo()`), read defensively so it never crashes the screen:

| Build | Shows |
|-------|-------|
| dev / local | `0.54.1 · branch · commit` |
| develop / CI / preview | `0.54.1 · commit` |
| production (store / TestFlight) | `0.54.1 (42)` |

**Why:** a build's marketing version (`0.54.1`) is identical across TestFlight and the public release, so a report from a non-published build couldn't be pinned to an exact build. The **short commit** (works for every build type) and the **build number** (store-correlatable) make any build identifiable.

**How the metadata is wired:**
- `app.config.js` injects `extra.build = { commit, branch, profile, builtAt }`, sourced in order from `EAS_BUILD_*` (EAS cloud / release) → `GITHUB_*` (CI) → `EXPO_PUBLIC_GIT_*` → local `git` (dev) → null. Read at runtime via `expo-constants`.
- `build-apps.yml` passes the branch + commit (PR branch via `github.head_ref`).
- `release.yml` (EAS) uses `EAS_BUILD_*` automatically — no change needed.

**Also:** `JellyfinProvider` now sends `APP_VERSION` (auto-synced from `expo-application`) in its `clientInfo` + auth header, instead of a hardcoded `"0.54.1"` that had drifted — the Jellyfin dashboard now shows the real client version.

> **Version scheme unchanged** — the leading `0.` major is kept intentionally (still beta-like, per staff). TestFlight vs public App Store are not split (same binary; would require a runtime iOS receipt check).

## 🏷️ Ticket / Issue

N/A — follow-up to the issue-form version work in #1641.

### 🖼️ Screenshots / GIFs (if UI)

<img width="357" height="815" alt="8w9skYhKcY" src="https://github.com/user-attachments/assets/357d0792-eaae-458c-a1fe-5371d21f4b80" />

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

## 🔍 Testing Instructions

1. **Settings → User info → App version** shows `version · commit` on a dev/CI build, `version (build)` on a production build.
2. In the **Jellyfin dashboard**, this client reports the real app version (not a stale hardcoded one).
3. No crash if `expo-constants` is unavailable — the row falls back to the version alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings page now displays comprehensive build metadata for continuous integration builds, including Git commit hash, branch name, build profile, and build timestamp.
  * App version information system improved with enhanced resolution logic and robust fallback handling to ensure reliable version detection across all scenarios.
  * Media server integration updated to use correctly determined application version for improved server communication and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->