### PR TITLE
fix(series): filter Next Up items by SeriesId client-side

### DIFF
--- a/components/series/NextUp.tsx
+++ b/components/series/NextUp.tsx
@@ -3,6 +3,7 @@ import { FlashList } from "@shopify/flash-list";
 import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import type React from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
@@ -33,13 +34,16 @@ export const NextUp: React.FC<{ seriesId: string }> = ({ seriesId }) => {
     staleTime: 0,
   });
 
-  if (!items?.length)
-    return (
-      <View className='px-4'>
-        <Text className='text-lg font-bold mb-2'>{t("item_card.next_up")}</Text>
-        <Text className='opacity-50'>{t("item_card.no_items_to_display")}</Text>
-      </View>
-    );
+  // Defensive client-side filter: some Jellyfin server versions ignore the
+  // `seriesId` query param on /Shows/NextUp and return next-up items across all
+  // series (the same content as the home tab's Next Up row). Filter to ensure
+  // we only ever show episodes belonging to this series.
+  const filteredItems = useMemo(
+    () => items?.filter((item) => item.SeriesId === seriesId) ?? [],
+    [items, seriesId],
+  );
+
+  if (!filteredItems.length) return null;
 
   return (
     <View>
@@ -50,7 +54,7 @@ export const NextUp: React.FC<{ seriesId: string }> = ({ seriesId }) => {
         contentContainerStyle={{ paddingLeft: 16 }}
         horizontal
         showsHorizontalScrollIndicator={false}
-        data={items}
+        data={filteredItems}
         renderItem={({ item, index }) => (
           <TouchableItemRouter
             item={item}


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

The mobile series detail page's "Next Up" section calls `GET /Shows/NextUp` with a `seriesId` filter, but in practice the response can contain episodes from other series — the same content as the home tab's Next Up row. The result is that opening a series (e.g. from search) shows a "Next Up" row of unrelated episodes.

This PR adds a defensive client-side filter on the response so we only ever show episodes whose `SeriesId` matches the current page's `seriesId`. When nothing matches (e.g. an unwatched series, or every returned item belongs to a different show), the section is hidden entirely instead of rendering an empty "No items to display" block.

The filter is a no-op when the server's response is already correctly scoped.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A — section visibility only, no visual changes when populated.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. From the Search tab, search for a series you have **never watched** and tap it.
2. On the series detail page, scroll to the area above the season picker.
3. **Before this fix:** a "Next Up" row appears showing episodes from other series (matching what's on the Home tab's Next Up row).
4. **After this fix:** no "Next Up" section is rendered for an unwatched series.
5. Navigate to a series you **are** currently watching (e.g. from Home → Continue Watching).
6. Verify the "Next Up" section appears and that every episode in it belongs to the currently-opened series.
7. Repeat from the Libraries, Favorites, and Watchlists tabs to confirm parity.
8. Confirm TV (no changes) and offline mode (`NextUp` not rendered) still behave the same.