### PR TITLE
fix(renovate): resolve maven lookup failures and unnest misplaced config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,22 +44,28 @@
       ]
     }
   },
-  "lockFileMaintenance": {
-    "vulnerabilityAlerts": {
-      "enabled": true,
-      "addLabels": ["security", "vulnerability"],
-      "assigneesFromCodeOwners": true,
-      "commitMessageSuffix": " [SECURITY]"
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "addLabels": ["security", "vulnerability"],
+    "assigneesFromCodeOwners": true,
+    "commitMessageSuffix": " [SECURITY]"
+  },
+  "packageRules": [
+    {
+      "description": "Group minor and patch GitHub Action updates into a single PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "CI dependencies",
+      "groupSlug": "ci-deps",
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
+      "automerge": true
     },
-    "packageRules": [
-      {
-        "description": "Group minor and patch GitHub Action updates into a single PR",
-        "matchManagers": ["github-actions"],
-        "groupName": "CI dependencies",
-        "groupSlug": "ci-deps",
-        "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
-        "automerge": true
-      }
-    ]
-  }
+    {
+      "description": "androidx and other Google-hosted Maven packages resolve from Google's Maven repository (not Maven Central)",
+      "matchDatasources": ["maven"],
+      "registryUrls": [
+        "https://dl.google.com/dl/android/maven2/",
+        "https://repo.maven.apache.org/maven2/"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## 📝 Description

Fixes two issues surfaced by the Renovate Dependency Dashboard (#724).

**1. Maven lookup failures.** Renovate failed to look up `androidx.tvprovider:tvprovider` and `androidx.core:core-ktx` (used in `modules/tv-recommendations/android/build.gradle`) with `no-result`, because androidx packages are published to Google's Maven repository, not Maven Central. Added a `packageRule` that sets `registryUrls` (Google Maven first, then Maven Central) for the `maven` datasource so these resolve.

**2. Misplaced config.** `vulnerabilityAlerts` and the GitHub-Actions grouping `packageRule` were nested **inside** `lockFileMaintenance`, so they only applied during lock-file-maintenance runs (effectively never). Both are moved to the top level so they take effect as intended.

The now-empty `lockFileMaintenance` wrapper is removed. **Lock-file maintenance itself is unaffected** — it is enabled by the `config:best-practices` preset (via `:maintainLockFilesWeekly`, which still runs weekly), not by that wrapper, which contained no lock-file-maintenance settings.

## ✅ Testing

- `renovate-config-validator` → `Config validated successfully`.

## 🔗 Related

Addresses the package-lookup warnings in #724.
