### PR TITLE
fix(renovate): resolve maven lookups, unnest config, gate Expo SDK updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,6 +52,20 @@
   },
   "packageRules": [
     {
+      "description": "Expo SDK coherence: expo, react, react-native and Expo-managed modules are pinned by the Expo SDK and must move together (via `expo install --fix`), so do not raise individual update PRs — group them and require manual approval from the Dependency Dashboard",
+      "matchPackageNames": [
+        "expo",
+        "react",
+        "react-dom",
+        "react-native",
+        "react-native-web",
+        "expo-*",
+        "@expo/*"
+      ],
+      "groupName": "Expo SDK",
+      "dependencyDashboardApproval": true
+    },
+    {
       "description": "Group minor and patch GitHub Action updates into a single PR",
       "matchManagers": ["github-actions"],
       "groupName": "CI dependencies",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,22 +44,28 @@
       ]
     }
   },
-  "lockFileMaintenance": {
-    "vulnerabilityAlerts": {
-      "enabled": true,
-      "addLabels": ["security", "vulnerability"],
-      "assigneesFromCodeOwners": true,
-      "commitMessageSuffix": " [SECURITY]"
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "addLabels": ["security", "vulnerability"],
+    "assigneesFromCodeOwners": true,
+    "commitMessageSuffix": " [SECURITY]"
+  },
+  "packageRules": [
+    {
+      "description": "Group minor and patch GitHub Action updates into a single PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "CI dependencies",
+      "groupSlug": "ci-deps",
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
+      "automerge": true
     },
-    "packageRules": [
-      {
-        "description": "Group minor and patch GitHub Action updates into a single PR",
-        "matchManagers": ["github-actions"],
-        "groupName": "CI dependencies",
-        "groupSlug": "ci-deps",
-        "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
-        "automerge": true
-      }
-    ]
-  }
+    {
+      "description": "androidx and other Google-hosted Maven packages resolve from Google's Maven repository (not Maven Central)",
+      "matchDatasources": ["maven"],
+      "registryUrls": [
+        "https://dl.google.com/dl/android/maven2/",
+        "https://repo.maven.apache.org/maven2/"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

# 📦 Pull Request

## 📝 Description

Fixes the errors surfaced by the Renovate Dependency Dashboard (#724) and calibrates Renovate for this Expo project.

**1. Maven lookup failures.** Renovate failed to look up `androidx.tvprovider:tvprovider` and `androidx.core:core-ktx` (used in `modules/tv-recommendations/android/build.gradle`) with `no-result`, because androidx packages are published to Google's Maven repository, not Maven Central. Added a `packageRule` setting `registryUrls` (Google Maven first, then Maven Central) for the `maven` datasource.

**2. Misplaced config.** `vulnerabilityAlerts` and the GitHub-Actions grouping `packageRule` were nested **inside** `lockFileMaintenance`, so they only applied during lock-file-maintenance runs (effectively never). Both are moved to the top level so they take effect. The now-empty `lockFileMaintenance` wrapper is removed — lock-file maintenance itself is **unaffected**, as it is enabled by the `config:best-practices` preset (via `:maintainLockFilesWeekly`), not by that wrapper.

**3. Expo SDK coherence (calibration).** `expo`, `react`, `react-native` and Expo-managed modules (`expo-*`, `@expo/*`) are pinned by the Expo SDK and must be upgraded together via `expo install --fix`. Individual Renovate PRs for them risk broken builds, so they are grouped as **"Expo SDK"** and require manual approval from the Dependency Dashboard instead of auto-raising update PRs.

## 🏷️ Ticket / Issue

Addresses the package-lookup warnings in #724.

### 🖼️ Screenshots / GIFs (if UI)

N/A — CI/configuration only.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms <!-- config-only; no platform runtime -->
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`) <!-- + `renovate-config-validator` passes -->
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

## 🔍 Testing Instructions

1. Run `bunx --package renovate renovate-config-validator .github/renovate.json` → prints `Config validated successfully`.
2. On the next Renovate run, the Dependency Dashboard (#724) no longer reports the `androidx.*` maven `no-result` lookup warnings.
3. `expo` / `react-native` / `expo-*` updates appear grouped under **"Expo SDK"** awaiting dashboard approval (no individual auto-PRs); weekly lock-file-maintenance PRs still run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security vulnerability management with automated issue labeling, code owner assignments, and standardized commit message prefixes for improved tracking and incident response
  * Extended Maven package resolution to support Google's Maven repository alongside Maven Central, enabling access to a broader range of dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->