### PR TITLE
feat(settings): show Actions run number for CI builds, hide store build number

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -12,10 +12,13 @@ on:
     branches: [develop, master]
 
 # Exposed to `expo prebuild` (app.config.js → extra.build) so Settings can show the
-# branch + commit a CI build was made from. EAS cloud builds use EAS_BUILD_* instead.
+# branch + commit + Actions run a CI build was made from. EAS cloud builds use
+# EAS_BUILD_* instead. The run number maps a sideloaded build back to its Actions
+# run (artifacts + logs) without needing Expo access.
 env:
   EXPO_PUBLIC_GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
   EXPO_PUBLIC_GIT_COMMIT: ${{ github.sha }}
+  EXPO_PUBLIC_GIT_RUN_NUMBER: ${{ github.run_number }}
 
 jobs:
   build-android-phone:
@@ -237,7 +240,9 @@ jobs:
       - name: 🚀 Build iOS app
         env:
           EXPO_TV: 0
-        run: eas build -p ios --local --non-interactive
+        # `ci` profile (extends production, autoIncrement off): keeps CI builds out of
+        # the production version tier and stops them inflating the store build counter.
+        run: eas build -p ios --local --non-interactive --profile ci
 
       - name: 📅 Set date tag
         run: echo "DATE_TAG=$(date +%d-%m-%Y_%H-%M-%S)" >> $GITHUB_ENV
@@ -362,7 +367,7 @@ jobs:
       - name: 🚀 Build iOS app
         env:
           EXPO_TV: 1
-        run: eas build -p ios --local --non-interactive
+        run: eas build -p ios --local --non-interactive --profile ci_tv
 
       - name: 📅 Set date tag
         run: echo "DATE_TAG=$(date +%d-%m-%Y_%H-%M-%S)" >> $GITHUB_ENV

--- a/app.config.js
+++ b/app.config.js
@@ -33,6 +33,12 @@ const buildMeta = {
     process.env.EAS_BUILD_PROFILE ||
     process.env.EXPO_PUBLIC_BUILD_PROFILE ||
     null,
+  // GitHub Actions run number (#2098) — lets anyone map a sideloaded CI build back
+  // to its Actions run (artifacts + logs) without Expo access. Null outside CI.
+  runNumber:
+    process.env.GITHUB_RUN_NUMBER ||
+    process.env.EXPO_PUBLIC_GIT_RUN_NUMBER ||
+    null,
   builtAt: new Date().toISOString(),
 };
 

--- a/components/settings/UserInfo.tsx
+++ b/components/settings/UserInfo.tsx
@@ -14,7 +14,7 @@ export const UserInfo: React.FC<Props> = ({ ...props }) => {
   const { t } = useTranslation();
 
   // Graduated build identifier — see utils/version.ts:
-  // dev → "0.54.1 · branch · commit", develop/CI → "0.54.1 · commit", production → "0.54.1 (42)".
+  // dev → "0.54.1 · branch · commit", develop/CI → "0.54.1 · commit · #run", production → "0.54.1".
   const { display: version } = getVersionInfo();
 
   return (

--- a/eas.json
+++ b/eas.json
@@ -97,6 +97,14 @@
         "credentialsSource": "local",
         "config": "ios-production.yml"
       }
+    },
+    "ci": {
+      "extends": "production",
+      "autoIncrement": false
+    },
+    "ci_tv": {
+      "extends": "production_tv",
+      "autoIncrement": false
     }
   },
   "submit": {

--- a/utils/version.ts
+++ b/utils/version.ts
@@ -10,6 +10,7 @@ export interface BuildMeta {
   commit?: string | null;
   branch?: string | null;
   profile?: string | null;
+  runNumber?: string | null;
   builtAt?: string | null;
 }
 
@@ -22,8 +23,10 @@ export interface VersionInfo {
   commit: string | null;
   /** Git branch the build was made from, e.g. "develop". */
   branch: string | null;
-  /** EAS build profile, e.g. "production", "preview", or null for local. */
+  /** EAS build profile, e.g. "production", "ci", "preview", or null for local. */
   profile: string | null;
+  /** GitHub Actions run number the build came from, e.g. "2098". Null outside CI. */
+  runNumber: string | null;
   isDev: boolean;
   isProduction: boolean;
   /** Graduated label for the Settings "App version" row (see tiering below). */
@@ -34,13 +37,13 @@ export interface VersionInfo {
  * Resolve a graduated version string for Settings.
  *
  * Tiering (most → least detailed):
- *  - dev / local build   → `version · branch · commit`   (full context for debugging)
- *  - develop / CI / preview → `version · commit`          (pin the exact source)
- *  - production (store / TestFlight) → `version (build)`   (store-correlatable; the
- *      build number lets TestFlight reports pin a build whose version isn't a
- *      published release. Note: TestFlight and the public App Store ship the same
- *      binary — telling them apart needs a runtime iOS receipt check, intentionally
- *      not done here.)
+ *  - dev / local build   → `version · branch · commit`     (full context for debugging)
+ *  - develop / CI / preview → `version · commit · #run`     (pin the exact source; the
+ *      Actions run number maps the build to its run — artifacts + logs — without
+ *      Expo access)
+ *  - production (store / TestFlight) → `version`             (build number intentionally
+ *      not shown: TestFlight already displays it to testers, and the commit pins the
+ *      binary better)
  */
 export function getVersionInfo(): VersionInfo {
   // Read native/config values defensively — a version string must never crash Settings
@@ -60,6 +63,7 @@ export function getVersionInfo(): VersionInfo {
   const commit = meta.commit ?? null;
   const branch = meta.branch ?? null;
   const profile = meta.profile ?? null;
+  const runNumber = meta.runNumber ?? null;
   const isDev = __DEV__ === true;
   const isProduction =
     typeof profile === "string" && profile.startsWith("production");
@@ -68,10 +72,12 @@ export function getVersionInfo(): VersionInfo {
   if (isDev) {
     display = [version ?? "dev", branch, commit].filter(Boolean).join(" · ");
   } else if (isProduction) {
-    display =
-      version && build ? `${version} (${build})` : (version ?? build ?? "N/A");
+    display = version ?? build ?? "N/A";
   } else {
-    display = [version, commit].filter(Boolean).join(" · ") || version || "N/A";
+    display =
+      [version, commit, runNumber && `#${runNumber}`]
+        .filter(Boolean)
+        .join(" · ") || "N/A";
   }
 
   return {
@@ -80,6 +86,7 @@ export function getVersionInfo(): VersionInfo {
     commit,
     branch,
     profile,
+    runNumber,
     isDev,
     isProduction,
     display,


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Follow-up to #1677. Two changes to the graduated version display:

**CI builds now show the GitHub Actions run number** — `0.54.1 · 0a2dadf · #2098` instead of `0.54.1 · 0a2dadf`. Anyone can map a sideloaded build back to its Actions run (artifacts + logs) by searching the run number in the Actions tab — no Expo access needed.

**Store builds show the bare version** — `0.54.1` instead of `0.54.1 (241)`. The build number row was misleading: signed CI builds were running on the default `production` EAS profile with `autoIncrement: true`, so every develop push bumped the store build counter (the counter was at 241 while the last actual TestFlight upload was build 92). TestFlight already surfaces the build number to testers, and the commit pins a binary better.

To fix both at once, signed CI iOS builds move to a dedicated `ci` EAS profile (`extends: production`, `autoIncrement: false`):
- `EAS_BUILD_PROFILE=ci` puts CI builds in the correct (middle) display tier instead of the production tier
- the store build counter stops inflating — next real TestFlight upload continues from ~242 instead of climbing with every CI run

Resulting display per build type:

| Build | Display |
|---|---|
| dev / local | `0.54.1 · branch · commit` (unchanged) |
| CI (signed + unsigned, iOS/Android) | `0.54.1 · 0a2dadf · #2098` |
| Store / TestFlight (EAS cloud) | `0.54.1` |

## 🏷️ Ticket / Issue

Follow-up to #1677. N/A otherwise.

### 🖼️ Screenshots / GIFs (if UI)

Text-only change in the Settings → User Info "App version" row (see display table above).

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Wait for the build workflow on this PR, download the signed iOS IPA artifact (or any APK), install it
2. Open Settings → check the "App version" row: it should read `0.54.1 · <commit> · #<run number>` where the run number matches this PR's Actions run
3. In the Actions tab, search the run number — it should land on the run that produced the artifact
4. Check the signed iOS job logs: no `Incrementing buildNumber` line should appear (the `ci` profile freezes the counter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated build version display format in settings to include run number information for better build identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->