### PR TITLE
ci(build): drop free-disk-space apt-get warning + surface unsigned tvOS in artifact comment

### DIFF
--- a/.github/workflows/artifact-comment.yml
+++ b/.github/workflows/artifact-comment.yml
@@ -387,11 +387,12 @@ jobs:
               let status = '⏳ Pending';
               let downloadLink = '*Waiting for build...*';
 
-              // tvOS builds are temporarily disabled until feat/tv-interface
-              // is merged - show them as disabled instead of stuck pending.
-              if (target.name === 'tvOS' || target.name === 'tvOS Unsigned') {
+              // Signed tvOS stays disabled until EAS has tvOS provisioning
+              // profiles (app + TopShelf targets); non-interactive builds can't
+              // create them. Unsigned tvOS builds, so it flows through normally.
+              if (target.name === 'tvOS') {
                 status = '💤 Disabled';
-                downloadLink = '*Disabled until feat/tv-interface is merged*';
+                downloadLink = '*Disabled — signed tvOS needs EAS provisioning profiles*';
               } else if (matchingStatus) {
                 if (matchingStatus.conclusion === 'success' && matchingArtifact) {
                   status = '✅ Complete';

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -313,8 +313,10 @@ jobs:
           retention-days: 7
 
   build-ios-tv:
-    # Temporarily disabled until feat/tv-interface is merged (TV UI not ready).
-    # Re-enable by removing the `false &&` prefix below.
+    # Disabled: EAS has no provisioning profiles / distribution cert for the tvOS
+    # targets (app + StreamyfinTopShelf extension), so non-interactive signed
+    # builds fail. Set up tvOS credentials in EAS (`eas credentials`), then remove
+    # the `false &&` prefix below. Unsigned tvOS builds run (see job below).
     if: false && (!contains(github.event.head_commit.message, '[skip ci]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'streamyfin/streamyfin'))
     runs-on: macos-26
     name: 🍎 Build tvOS IPA

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -37,7 +37,7 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
           docker-images: true
           swap-storage: false
 
@@ -120,7 +120,7 @@ jobs:
           android: false
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
           docker-images: true
           swap-storage: false
 


### PR DESCRIPTION
# 📦 Pull Request

## 📝 Description

Two small CI / build-pipeline fixes.

### 1. Remove the only CI annotation (free-disk-space)

Every Android build (Phone + TV) emits this warning:

```
The command [sudo apt-get remove -y] failed to complete successfully. Proceeding...
```

It comes from the `large-packages` step of the `BRAINSia/free-disk-space` action: it runs `sudo apt-get remove --autoremove -y <glob list>` against packages that aren't all installed on the runner, so `apt-get` exits non-zero and the action itself prints a `::warning::`. It's harmless (best-effort cleanup) but shows up on every build, on PRs and on `develop`.

This sets `large-packages: false` (both job definitions). It's safe: `tool-cache: false` already leaves the largest reclaimable area (~10–25 GB) untouched and builds pass with comfortable headroom, so the ~3–5 GB freed by `large-packages` isn't needed. The other cleanup steps (dotnet, haskell, docker-images, mandb) are unchanged.

Switching to the upstream `jlumbroso/free-disk-space` was considered and rejected — it emits the same warning once *per* package group (more annotations, not fewer).

### 2. Surface the unsigned tvOS build in the artifact comment

Unsigned tvOS already builds in CI (`build-ios-tv-unsigned` is enabled and uploads an IPA), but the PR artifact comment still forced **both** tvOS rows to `💤 Disabled` / `Disabled until feat/tv-interface is merged`, hiding the unsigned download.

- **`artifact-comment.yml`**: only the **signed** `tvOS` row stays disabled; `tvOS Unsigned` now flows through the normal status logic, so it shows ✅ + a download link once the build succeeds.
- **`build-apps.yml`**: corrected the stale comment on the disabled signed `build-ios-tv` job. Signed tvOS is disabled because EAS has no provisioning profiles / distribution cert for the tvOS targets (app + `StreamyfinTopShelf` extension) — non-interactive signed builds fail with *"Credentials are not set up"*. It is **not** "TV UI not ready". Unsigned needs no Apple credentials, so it builds fine.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A — CI workflow only.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Trigger the **🏗️ Build Apps** workflow on this branch (any push / PR).
2. Open the **🤖 Build Android APK (Phone)** and **(TV)** checks — confirm they still complete successfully **and** no longer show the `apt-get remove` warning annotation.
3. On the PR's auto-generated **Build Status** comment, confirm:
   - the **🍎 tvOS Unsigned / 📺 TV Unsigned** row shows its real status (✅ + 📥 Download IPA), and
   - the **🍎 tvOS / 📺 TV** (signed) row shows `💤 Disabled — signed tvOS needs EAS provisioning profiles`.

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)
