### PR TITLE
ci: ARM Android runners, slimmer APK artifacts, Renovate-pinned tool versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,9 +30,17 @@
       "customType": "regex",
       "managerFilePatterns": ["/\\.ya?ml$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+xcode-version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+[A-Za-z0-9._-]+:\\s*[\"']?(?<currentValue>[^\"'\\s]+)"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the Bun version pinned in eas.json build profiles (strict JSON can't hold inline annotations)",
+      "managerFilePatterns": ["/(^|/)eas\\.json$/"],
+      "matchStrings": ["\"bun\"\\s*:\\s*\"(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "bun"
     }
   ],
   "customDatasources": {

--- a/.github/workflows/artifact-comment.yml
+++ b/.github/workflows/artifact-comment.yml
@@ -463,7 +463,7 @@ jobs:
               commentBody += `| 📺 Android TV APK | \`arm64-v8a\` + \`armeabi-v7a\` | Modern boxes **and** older / cheap 32-bit Android TV sticks. No x86_64. |\n`;
               commentBody += `| 🍎 iOS / tvOS IPA | \`arm64\` | iPhone / Apple TV (all current devices). |\n\n`;
               commentBody += `**Why no x86_64?** That slice only runs on Android emulators / Chromebooks, never a real phone or TV box — dropping it shrinks the APK and speeds up the build. Local \`bun run android\` is unaffected (it still builds x86_64 from \`app.json\`).\n\n`;
-              commentBody += `**Runners:** Android builds on free ARM64 GitHub runners (\`ubuntu-26.04-arm\`); iOS / tvOS on Apple Silicon (\`macos-26\`).\n`;
+              commentBody += `**Runners:** Android on \`ubuntu-26.04\`; iOS / tvOS on Apple Silicon (\`macos-26\`). The size/speed win comes from the ABI trim above, not the runner.\n`;
               commentBody += `</details>\n\n`;
             } else {
               commentBody += `⏳ **Builds are starting up...** This comment will update automatically as each build completes.\n\n`;

--- a/.github/workflows/artifact-comment.yml
+++ b/.github/workflows/artifact-comment.yml
@@ -451,6 +451,20 @@ jobs:
               commentBody += `- **Android APK**: Download and install directly on your device (enable "Install from unknown sources")\n`;
               commentBody += `- **iOS IPA**: Install using [AltStore](https://altstore.io/), [Sideloadly](https://sideloadly.io/), or Xcode\n\n`;
               commentBody += `> ⚠️ **Note**: Artifacts expire in 7 days from build date\n\n`;
+
+              // Collapsible rundown of the build optimisations + what each
+              // artifact actually installs on, so testers grab the right file.
+              commentBody += `<details>\n`;
+              commentBody += `<summary>📦 Build details &amp; device compatibility</summary>\n\n`;
+              commentBody += `These CI builds are trimmed for size and speed. What that means for installing them:\n\n`;
+              commentBody += `| Artifact | Architectures | Installs on |\n`;
+              commentBody += `|---|---|---|\n`;
+              commentBody += `| 🤖 Android Phone APK | \`arm64-v8a\` | Every 64-bit Android phone (all since ~2017). **Not** an x86_64 emulator or a 32-bit device. |\n`;
+              commentBody += `| 📺 Android TV APK | \`arm64-v8a\` + \`armeabi-v7a\` | Modern boxes **and** older / cheap 32-bit Android TV sticks. No x86_64. |\n`;
+              commentBody += `| 🍎 iOS / tvOS IPA | \`arm64\` | iPhone / Apple TV (all current devices). |\n\n`;
+              commentBody += `**Why no x86_64?** That slice only runs on Android emulators / Chromebooks, never a real phone or TV box — dropping it shrinks the APK and speeds up the build. Local \`bun run android\` is unaffected (it still builds x86_64 from \`app.json\`).\n\n`;
+              commentBody += `**Runners:** Android builds on free ARM64 GitHub runners (\`ubuntu-26.04-arm\`); iOS / tvOS on Apple Silicon (\`macos-26\`).\n`;
+              commentBody += `</details>\n\n`;
             } else {
               commentBody += `⏳ **Builds are starting up...** This comment will update automatically as each build completes.\n\n`;
             }

--- a/.github/workflows/artifact-comment.yml
+++ b/.github/workflows/artifact-comment.yml
@@ -18,7 +18,8 @@ jobs:
   comment-artifacts:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request')
     name: 📦 Post Build Artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/artifact-comment.yml
+++ b/.github/workflows/artifact-comment.yml
@@ -18,8 +18,7 @@ jobs:
   comment-artifacts:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request')
     name: 📦 Post Build Artifacts
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -68,6 +68,15 @@ jobs:
           bun install --frozen-lockfile
           bun run submodule-reload
 
+      - name: ☕ Set up JDK 17
+        # ubuntu-26.04 defaults to JDK 25, which breaks the RN/AGP native build
+        # (Kotlin falls back to JVM_23, the foojay toolchain + CMake configure
+        # fail). Pin Temurin 17 for a deterministic Android build.
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
       - name: 💾 Cache Gradle global
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -154,6 +163,15 @@ jobs:
         run: |
           bun install --frozen-lockfile
           bun run submodule-reload
+
+      - name: ☕ Set up JDK 17
+        # ubuntu-26.04 defaults to JDK 25, which breaks the RN/AGP native build
+        # (Kotlin falls back to JVM_23, the foojay toolchain + CMake configure
+        # fail). Pin Temurin 17 for a deterministic Android build.
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: "17"
 
       - name: 💾 Cache Gradle global
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -25,6 +25,7 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-26.04
     name: 🤖 Build Android APK (Phone)
+    timeout-minutes: 40
     permissions:
       contents: read
 
@@ -59,9 +60,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-bun-develop-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-bun-develop
+            ${{ runner.os }}-${{ runner.arch }}-bun-
 
       - name: 📦 Install dependencies and reload submodules
         run: |
@@ -121,6 +122,7 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-26.04
     name: 🤖 Build Android APK (TV)
+    timeout-minutes: 40
     permissions:
       contents: read
 
@@ -155,9 +157,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-bun-develop-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-bun-develop
+            ${{ runner.os }}-${{ runner.arch }}-bun-
 
       - name: 📦 Install dependencies and reload submodules
         run: |
@@ -216,6 +218,7 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'streamyfin/streamyfin'))
     runs-on: macos-26
     name: 🍎 Build iOS IPA (Phone)
+    timeout-minutes: 60
     permissions:
       contents: read
 
@@ -238,9 +241,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-cache-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-cache
+            ${{ runner.os }}-${{ runner.arch }}-bun-
 
       - name: 📦 Install dependencies and reload submodules
         run: |
@@ -284,6 +287,7 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: macos-26
     name: 🍎 Build iOS IPA (Phone - Unsigned)
+    timeout-minutes: 60
     permissions:
       contents: read
 
@@ -306,9 +310,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-cache-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-cache
+            ${{ runner.os }}-${{ runner.arch }}-bun-
 
       - name: 📦 Install dependencies and reload submodules
         run: |
@@ -347,6 +351,7 @@ jobs:
     if: false && (!contains(github.event.head_commit.message, '[skip ci]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'streamyfin/streamyfin'))
     runs-on: macos-26
     name: 🍎 Build tvOS IPA
+    timeout-minutes: 60
     permissions:
       contents: read
 
@@ -369,9 +374,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-cache-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-cache
+            ${{ runner.os }}-${{ runner.arch }}-bun-
 
       - name: 📦 Install dependencies and reload submodules
         run: |
@@ -416,6 +421,7 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: macos-26
     name: 🍎 Build tvOS IPA (Unsigned)
+    timeout-minutes: 60
     permissions:
       contents: read
 
@@ -438,9 +444,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-cache-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-cache
+            ${{ runner.os }}-${{ runner.arch }}-bun-
 
       - name: 📦 Install dependencies and reload submodules
         run: |

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -25,7 +25,6 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-26.04
     name: 🤖 Build Android APK (Phone)
-    timeout-minutes: 40
     permissions:
       contents: read
 
@@ -122,7 +121,6 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: ubuntu-26.04
     name: 🤖 Build Android APK (TV)
-    timeout-minutes: 40
     permissions:
       contents: read
 
@@ -218,7 +216,6 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'streamyfin/streamyfin'))
     runs-on: macos-26
     name: 🍎 Build iOS IPA (Phone)
-    timeout-minutes: 60
     permissions:
       contents: read
 
@@ -287,7 +284,6 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: macos-26
     name: 🍎 Build iOS IPA (Phone - Unsigned)
-    timeout-minutes: 60
     permissions:
       contents: read
 
@@ -351,7 +347,6 @@ jobs:
     if: false && (!contains(github.event.head_commit.message, '[skip ci]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'streamyfin/streamyfin'))
     runs-on: macos-26
     name: 🍎 Build tvOS IPA
-    timeout-minutes: 60
     permissions:
       contents: read
 
@@ -421,7 +416,6 @@ jobs:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
     runs-on: macos-26
     name: 🍎 Build tvOS IPA (Unsigned)
-    timeout-minutes: 60
     permissions:
       contents: read
 

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   build-android-phone:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
-    runs-on: ubuntu-26.04-arm
+    runs-on: ubuntu-26.04
     name: 🤖 Build Android APK (Phone)
     permissions:
       contents: read
@@ -62,7 +62,6 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-bun-develop-${{ hashFiles('bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-bun-develop
-            ${{ runner.os }}-bun-develop
 
       - name: 📦 Install dependencies and reload submodules
         run: |
@@ -78,26 +77,6 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-gradle-
-
-      - name: 🤖 Set up Android SDK
-        # arm64 runners don't ship the Android SDK (x64 images do), so install it
-        # and accept licences. Gradle then auto-pulls the NDK/build-tools it needs.
-        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
-        with:
-          # Skip the default `tools` package: it's obsolete and on arm64 pulls a
-          # missing `emulator` dependency, failing the step. Gradle auto-installs
-          # the build-tools / platform / NDK it needs from the cmdline-tools.
-          packages: platform-tools
-
-      - name: 💾 Cache Android NDK
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          # Only the NDK is worth caching (big, slow download). build-tools/platforms
-          # are small and refetch fast — keeps us well under the 10 GB cache budget.
-          path: ${{ env.ANDROID_HOME }}/ndk
-          key: ${{ runner.os }}-${{ runner.arch }}-android-ndk-${{ hashFiles('app.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-android-ndk-
 
       - name: 🛠️ Generate project files
         run: bun run prebuild
@@ -131,7 +110,7 @@ jobs:
 
   build-android-tv:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
-    runs-on: ubuntu-26.04-arm
+    runs-on: ubuntu-26.04
     name: 🤖 Build Android APK (TV)
     permissions:
       contents: read
@@ -170,7 +149,6 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-bun-develop-${{ hashFiles('bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-bun-develop
-            ${{ runner.os }}-bun-develop
 
       - name: 📦 Install dependencies and reload submodules
         run: |
@@ -186,26 +164,6 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-gradle-
-
-      - name: 🤖 Set up Android SDK
-        # arm64 runners don't ship the Android SDK (x64 images do), so install it
-        # and accept licences. Gradle then auto-pulls the NDK/build-tools it needs.
-        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
-        with:
-          # Skip the default `tools` package: it's obsolete and on arm64 pulls a
-          # missing `emulator` dependency, failing the step. Gradle auto-installs
-          # the build-tools / platform / NDK it needs from the cmdline-tools.
-          packages: platform-tools
-
-      - name: 💾 Cache Android NDK
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          # Only the NDK is worth caching (big, slow download). build-tools/platforms
-          # are small and refetch fast — keeps us well under the 10 GB cache budget.
-          path: ${{ env.ANDROID_HOME }}/ndk
-          key: ${{ runner.os }}-${{ runner.arch }}-android-ndk-${{ hashFiles('app.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-android-ndk-
 
       - name: 🛠️ Generate project files
         run: bun run prebuild:tv

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            ~/.gradle/caches
+            ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
           key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
@@ -83,18 +83,21 @@ jobs:
         # arm64 runners don't ship the Android SDK (x64 images do), so install it
         # and accept licences. Gradle then auto-pulls the NDK/build-tools it needs.
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+        with:
+          # Skip the default `tools` package: it's obsolete and on arm64 pulls a
+          # missing `emulator` dependency, failing the step. Gradle auto-installs
+          # the build-tools / platform / NDK it needs from the cmdline-tools.
+          packages: platform-tools
 
-      - name: 💾 Cache Android SDK (NDK + build-tools)
+      - name: 💾 Cache Android NDK
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: |
-            ${{ env.ANDROID_HOME }}/ndk
-            ${{ env.ANDROID_HOME }}/build-tools
-            ${{ env.ANDROID_HOME }}/platforms
-            ${{ env.ANDROID_HOME }}/cmake
-          key: ${{ runner.os }}-${{ runner.arch }}-android-sdk-${{ hashFiles('app.json') }}
+          # Only the NDK is worth caching (big, slow download). build-tools/platforms
+          # are small and refetch fast — keeps us well under the 10 GB cache budget.
+          path: ${{ env.ANDROID_HOME }}/ndk
+          key: ${{ runner.os }}-${{ runner.arch }}-android-ndk-${{ hashFiles('app.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-android-sdk-
+            ${{ runner.os }}-${{ runner.arch }}-android-ndk-
 
       - name: 🛠️ Generate project files
         run: bun run prebuild
@@ -178,7 +181,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            ~/.gradle/caches
+            ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
           key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
@@ -188,18 +191,21 @@ jobs:
         # arm64 runners don't ship the Android SDK (x64 images do), so install it
         # and accept licences. Gradle then auto-pulls the NDK/build-tools it needs.
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+        with:
+          # Skip the default `tools` package: it's obsolete and on arm64 pulls a
+          # missing `emulator` dependency, failing the step. Gradle auto-installs
+          # the build-tools / platform / NDK it needs from the cmdline-tools.
+          packages: platform-tools
 
-      - name: 💾 Cache Android SDK (NDK + build-tools)
+      - name: 💾 Cache Android NDK
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: |
-            ${{ env.ANDROID_HOME }}/ndk
-            ${{ env.ANDROID_HOME }}/build-tools
-            ${{ env.ANDROID_HOME }}/platforms
-            ${{ env.ANDROID_HOME }}/cmake
-          key: ${{ runner.os }}-${{ runner.arch }}-android-sdk-${{ hashFiles('app.json') }}
+          # Only the NDK is worth caching (big, slow download). build-tools/platforms
+          # are small and refetch fast — keeps us well under the 10 GB cache budget.
+          path: ${{ env.ANDROID_HOME }}/ndk
+          key: ${{ runner.os }}-${{ runner.arch }}-android-ndk-${{ hashFiles('app.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-android-sdk-
+            ${{ runner.os }}-${{ runner.arch }}-android-ndk-
 
       - name: 🛠️ Generate project files
         run: bun run prebuild:tv

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -79,6 +79,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-gradle-
 
+      - name: 🤖 Set up Android SDK
+        # arm64 runners don't ship the Android SDK (x64 images do), so install it
+        # and accept licences. Gradle then auto-pulls the NDK/build-tools it needs.
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: 💾 Cache Android SDK (NDK + build-tools)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ env.ANDROID_HOME }}/ndk
+            ${{ env.ANDROID_HOME }}/build-tools
+            ${{ env.ANDROID_HOME }}/platforms
+            ${{ env.ANDROID_HOME }}/cmake
+          key: ${{ runner.os }}-${{ runner.arch }}-android-sdk-${{ hashFiles('app.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-android-sdk-
+
       - name: 🛠️ Generate project files
         run: bun run prebuild
 
@@ -166,6 +183,23 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-gradle-
+
+      - name: 🤖 Set up Android SDK
+        # arm64 runners don't ship the Android SDK (x64 images do), so install it
+        # and accept licences. Gradle then auto-pulls the NDK/build-tools it needs.
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: 💾 Cache Android SDK (NDK + build-tools)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ env.ANDROID_HOME }}/ndk
+            ${{ env.ANDROID_HOME }}/build-tools
+            ${{ env.ANDROID_HOME }}/platforms
+            ${{ env.ANDROID_HOME }}/cmake
+          key: ${{ runner.os }}-${{ runner.arch }}-android-sdk-${{ hashFiles('app.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-android-sdk-
 
       - name: 🛠️ Generate project files
         run: bun run prebuild:tv

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   build-android-phone:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04-arm
     name: 🤖 Build Android APK (Phone)
     permissions:
       contents: read
@@ -52,7 +52,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -74,9 +75,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-${{ runner.arch }}-gradle-
 
       - name: 🛠️ Generate project files
         run: bun run prebuild
@@ -85,12 +86,16 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: android/.gradle
-          key: ${{ runner.os }}-android-gradle-develop-${{ hashFiles('android/**/build.gradle', 'android/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-android-gradle-develop
+          key: ${{ runner.os }}-${{ runner.arch }}-android-gradle-develop-${{ hashFiles('android/**/build.gradle', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-android-gradle-develop
 
       - name: 🚀 Build APK
         env:
           EXPO_TV: 0
+          # CI artifact ships arm64 only (phones; emulators/Chromebooks not a
+          # sideload target). Overrides app.json buildArchs for this build only,
+          # so local `bun run android` (x86_64 emulator) is unaffected.
+          ORG_GRADLE_PROJECT_reactNativeArchitectures: arm64-v8a
         run: bun run build:android:local
 
       - name: 📅 Set date tag
@@ -106,7 +111,7 @@ jobs:
 
   build-android-tv:
     if: (!contains(github.event.head_commit.message, '[skip ci]'))
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04-arm
     name: 🤖 Build Android APK (TV)
     permissions:
       contents: read
@@ -135,7 +140,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -157,9 +163,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-${{ runner.arch }}-gradle-
 
       - name: 🛠️ Generate project files
         run: bun run prebuild:tv
@@ -168,12 +174,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: android/.gradle
-          key: ${{ runner.os }}-android-gradle-develop-${{ hashFiles('android/**/build.gradle', 'android/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-android-gradle-develop
+          key: ${{ runner.os }}-${{ runner.arch }}-android-gradle-develop-${{ hashFiles('android/**/build.gradle', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-android-gradle-develop
 
       - name: 🚀 Build APK
         env:
           EXPO_TV: 1
+          # TV artifact keeps armeabi-v7a too: many older/cheap Android TV boxes
+          # and sticks are still 32-bit ARM. Drops only x86_64. CI build only.
+          ORG_GRADLE_PROJECT_reactNativeArchitectures: arm64-v8a,armeabi-v7a
         run: bun run build:android:local
 
       - name: 📅 Set date tag
@@ -206,7 +215,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -273,7 +283,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -335,7 +346,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -403,7 +415,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/check-lockfile.yml
+++ b/.github/workflows/check-lockfile.yml
@@ -13,8 +13,7 @@ concurrency:
 jobs:
   check-lockfile:
     name: 🔍 Check bun.lock and package.json consistency
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
 

--- a/.github/workflows/check-lockfile.yml
+++ b/.github/workflows/check-lockfile.yml
@@ -29,7 +29,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/check-lockfile.yml
+++ b/.github/workflows/check-lockfile.yml
@@ -14,6 +14,7 @@ jobs:
   check-lockfile:
     name: 🔍 Check bun.lock and package.json consistency
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -37,7 +38,9 @@ jobs:
         with:
           path: |
             ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-bun-
 
       - name: 🛡️ Verify lockfile consistency
         run: |

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -8,11 +8,15 @@ on:
   schedule:
     - cron: '24 2 * * *'
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
     name: 🔎 Analyze with CodeQL
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -15,8 +15,7 @@ concurrency:
 jobs:
   analyze:
     name: 🔎 Analyze with CodeQL
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/conflict.yml
+++ b/.github/workflows/conflict.yml
@@ -10,8 +10,7 @@ on:
 jobs:
   label:
     name: 🏷️ Labeling Merge Conflicts
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    runs-on: ubuntu-26.04
     if: ${{ github.repository == 'streamyfin/streamyfin' }}
     permissions:
       contents: read

--- a/.github/workflows/conflict.yml
+++ b/.github/workflows/conflict.yml
@@ -11,6 +11,7 @@ jobs:
   label:
     name: 🏷️ Labeling Merge Conflicts
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     if: ${{ github.repository == 'streamyfin/streamyfin' }}
     permissions:
       contents: read

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -19,7 +19,8 @@ permissions:
 
 jobs:
   sync-translations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     steps:
       - name: 📥 Checkout Repository

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -19,8 +19,7 @@ permissions:
 
 jobs:
   sync-translations:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    runs-on: ubuntu-26.04
 
     steps:
       - name: 📥 Checkout Repository

--- a/.github/workflows/detect-duplicate.yml
+++ b/.github/workflows/detect-duplicate.yml
@@ -16,6 +16,7 @@ jobs:
     name: 🔍 Find similar issues
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/detect-duplicate.yml
+++ b/.github/workflows/detect-duplicate.yml
@@ -26,7 +26,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 🔍 Detect duplicate issues
         run: bun scripts/detect-duplicate-issue.mjs

--- a/.github/workflows/detect-duplicate.yml
+++ b/.github/workflows/detect-duplicate.yml
@@ -15,8 +15,7 @@ jobs:
   detect:
     name: 🔍 Find similar issues
     if: github.actor != 'github-actions[bot]'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    runs-on: ubuntu-26.04
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,6 +16,7 @@ jobs:
     name: "📝 Validate PR Title"
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       pull-requests: write
       contents: read
@@ -47,6 +48,7 @@ jobs:
   dependency-review:
     name: 🔍 Vulnerable Dependencies
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -65,8 +67,8 @@ jobs:
 
   expo-doctor:
     name: 🚑 Expo Doctor Check
-    if: false
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: 🛒 Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -85,11 +87,15 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: 🚑 Run Expo Doctor
+        # Re-enabled but non-blocking: surfaces doctor warnings in the logs
+        # without failing the gate (some checks are known-noisy for this setup).
+        continue-on-error: true
         run: bun expo-doctor
 
   code_quality:
     name: "🔍 Lint & Test (${{ matrix.command }})"
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -78,7 +78,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 📦 Install dependencies (bun)
         run: bun install --frozen-lockfile
@@ -110,12 +111,14 @@ jobs:
       - name: "🟢 Setup Node.js"
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24.x'
+          # renovate: datasource=node-version depName=node versioning=node
+          node-version: "24.16.0"
 
       - name: "🍞 Setup Bun"
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: "📦 Install dependencies"
         run: bun install --frozen-lockfile

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,8 +15,7 @@ jobs:
   validate_pr_title:
     name: "📝 Validate PR Title"
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    runs-on: ubuntu-26.04
     permissions:
       pull-requests: write
       contents: read
@@ -47,8 +46,7 @@ jobs:
 
   dependency-review:
     name: 🔍 Vulnerable Dependencies
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -67,8 +65,7 @@ jobs:
 
   expo-doctor:
     name: 🚑 Expo Doctor Check
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    runs-on: ubuntu-26.04
     steps:
       - name: 🛒 Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -94,8 +91,7 @@ jobs:
 
   code_quality:
     name: "🔍 Lint & Test (${{ matrix.command }})"
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -12,8 +12,7 @@ on:
 
 jobs:
   notify:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    runs-on: ubuntu-26.04
     if: github.event_name == 'pull_request'
     steps:
       - name: 🛎️ Notify Discord
@@ -30,8 +29,7 @@ jobs:
             🔗 ${{ github.event.pull_request.html_url }}
 
   notify-on-failure:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    runs-on: ubuntu-26.04
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: 🚨 Notify Discord on Failure

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
       - name: 🛎️ Notify Discord
@@ -30,6 +31,7 @@ jobs:
 
   notify-on-failure:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: 🚨 Notify Discord on Failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,7 @@ on:
 jobs:
   approve:
     name: 🔐 Approve release
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    runs-on: ubuntu-26.04
     environment: production
     permissions: {}
     steps:
@@ -33,8 +32,7 @@ jobs:
   build:
     name: 🚀 ${{ matrix.name }}
     needs: approve
-    runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     strategy:
@@ -180,8 +178,7 @@ jobs:
     name: 📦 Draft GitHub Release
     needs: build
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       actions: read # required for `gh run download` to list/fetch this run's artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     name: 🔐 Approve release
     runs-on: ubuntu-24.04
     environment: production
+    permissions: {}
     steps:
       - name: ✅ Release approved
         run: echo "Release approved for ${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
   approve:
     name: 🔐 Approve release
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     environment: production
     permissions: {}
     steps:
@@ -33,6 +34,7 @@ jobs:
     name: 🚀 ${{ matrix.name }}
     needs: approve
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: read
     strategy:
@@ -80,9 +82,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-cache-${{ hashFiles('bun.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-bun-cache
+            ${{ runner.os }}-${{ runner.arch }}-bun-
 
       - name: 📦 Install dependencies and reload submodules
         run: |
@@ -179,6 +181,7 @@ jobs:
     needs: build
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: write
       actions: read # required for `gh run download` to list/fetch this run's artifacts

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -22,6 +22,7 @@ jobs:
   trivy:
     name: 🔎 Filesystem scan
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       contents: read
       security-events: write # upload SARIF to code scanning
@@ -29,19 +30,9 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Rotate the DB cache weekly (matches the scheduled scan): cache hits within the week
-      # instead of a fresh immutable entry per run, still refreshing the DB every week.
-      - name: 🗓️ Compute weekly Trivy cache key
-        id: trivy-cache-key
-        run: echo "value=trivy-db-${{ runner.os }}-$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-
-      - name: 💾 Cache Trivy vulnerability DB
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/trivy
-          key: ${{ steps.trivy-cache-key.outputs.value }}
-          restore-keys: trivy-db-${{ runner.os }}-
-
+      # Trivy's own action caches the vulnerability DB + binary internally
+      # (cache-trivy-* / trivy-binary-* entries), so no manual ~/.cache/trivy
+      # step is needed — it only duplicated the cache.
       - name: 🔎 Run Trivy filesystem scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -21,8 +21,7 @@ concurrency:
 jobs:
   trivy:
     name: 🔎 Filesystem scan
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       security-events: write # upload SARIF to code scanning

--- a/.github/workflows/update-issue-form.yml
+++ b/.github/workflows/update-issue-form.yml
@@ -21,6 +21,7 @@ jobs:
   update-issue-form:
     name: 🔢 Populate version dropdown
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-issue-form.yml
+++ b/.github/workflows/update-issue-form.yml
@@ -20,8 +20,7 @@ permissions:
 jobs:
   update-issue-form:
     name: 🔢 Populate version dropdown
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    runs-on: ubuntu-26.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-issue-form.yml
+++ b/.github/workflows/update-issue-form.yml
@@ -36,7 +36,8 @@ jobs:
       - name: 🍞 Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          # renovate: datasource=npm depName=bun
+          bun-version: "1.3.14"
 
       - name: 🔢 Populate version dropdown from GitHub releases
         id: populate

--- a/eas.json
+++ b/eas.json
@@ -52,7 +52,7 @@
       }
     },
     "production": {
-      "bun": "1.3.5",
+      "bun": "1.3.14",
       "environment": "production",
       "autoIncrement": true,
       "android": {
@@ -64,7 +64,7 @@
       }
     },
     "production-apk": {
-      "bun": "1.3.5",
+      "bun": "1.3.14",
       "environment": "production",
       "autoIncrement": true,
       "android": {
@@ -74,7 +74,7 @@
       }
     },
     "production-apk-tv": {
-      "bun": "1.3.5",
+      "bun": "1.3.14",
       "environment": "production",
       "autoIncrement": true,
       "android": {
@@ -87,7 +87,7 @@
       }
     },
     "production_tv": {
-      "bun": "1.3.5",
+      "bun": "1.3.14",
       "environment": "production",
       "autoIncrement": true,
       "env": {

--- a/scripts/ios/build-ios.ts
+++ b/scripts/ios/build-ios.ts
@@ -302,7 +302,7 @@ function parseArgs(argv: string[]): BuildOptions {
         if (!configArg) {
           throw new Error("--configuration requires an argument");
         }
-        options.configuration = (configArg as "Debug" | "Release") || "Debug";
+        options.configuration = configArg as "Debug" | "Release";
         break;
       }
       case "--device":
@@ -997,10 +997,6 @@ async function waitForSimulatorBoot(
       }
     } catch {
       // Simulator not found or not booted yet, continue polling
-      if (pollIntervalMs > 1000) {
-        // Only log if we've been waiting a while to avoid spam
-        // console.warn("Simulator polling failed, retrying...");
-      }
     }
 
     // Wait before next poll


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Slims down and speeds up the Android CI builds, modernises the runner + toolchain, tidies the workflows, and makes all tool versions Renovate-updatable.

### 📉 Smaller APKs (main win)
The CI APKs drop the unused **`x86_64`** ABI (emulator / Chromebook only) via a **build-only** `ORG_GRADLE_PROJECT_reactNativeArchitectures` override — `app.json` is untouched, so local `bun run android` (x86_64 emulator) is unaffected.

| Artifact | ABIs shipped |
|---|---|
| 🤖 Android Phone | `arm64-v8a` |
| 📺 Android TV | `arm64-v8a` + `armeabi-v7a` (keeps older 32-bit Android TV boxes working) |

### 🏗️ Runner + toolchain
- **All jobs → `ubuntu-26.04`** (latest image; iOS / tvOS stay on Apple Silicon `macos-26`).
- Android jobs pin **Temurin JDK 17** — `ubuntu-26.04` defaults to JDK 25, which breaks the RN/AGP native build (Kotlin falls back to JVM_23, `configureCMake` fails). The lighter jobs (lint, CodeQL, etc.) have no Android toolchain dependency, so they need no JDK pin.
- Gradle cache trimmed to `caches/modules-2` (+ wrapper), keyed by `runner.arch`.

> ℹ️ **Why not arm64 runners?** Evaluated first, but the Android NDK ships only an `x86_64`-host toolchain (no official `linux-aarch64` prebuilt), so native C++ modules fail at `configureCMake` on an arm64 host. x64 it is.

### 🧹 Workflow tidy-up
- **Re-enabled `expo-doctor`** (was `if: false`) as **non-blocking** (`continue-on-error`) — its warnings surface in the logs without failing the gate.
- Added `concurrency` cancel-in-progress to the CodeQL workflow so runs don't pile up.

### 🗃️ Cache budget (10 GB repo limit)
- Trimmed the Gradle global cache (full `~/.gradle/caches` was ~2.9 GB → `modules-2` only).
- **Unified the Bun cache keys** to a single `${os}-${arch}-bun-<lock>` scheme (was three: `bun-develop` / `bun-cache` / `bun`) so the Linux jobs share one cache.
- Dropped the redundant manual `~/.cache/trivy` step (the trivy-action caches the DB + binary itself).

### 🔄 Renovate coverage
- Pin **Bun → `1.3.14`** and **Node → `24.16.0`** across every workflow (+ `eas.json`) with `# renovate:` annotations.
- Generalised the Renovate `customManager` regex to track any annotated `*-version:` field, plus a `customManager` that keeps the Bun version in `eas.json` updated.

### 🛡️ Code scanning (CodeQL)
- `release.yml` approve job: `permissions: {}` — least privilege (#328).
- `scripts/ios/build-ios.ts`: drop the dead `|| "Debug"` (#285) and the empty `if (pollIntervalMs > 1000)` block (#286).

## ⚡ Benchmarks (before → after)

| Job | Build time | APK size |
|---|---|---|
| 🤖 Android Phone | 25m58s → **~18 min** (~30%) | 94.04 MB → **52.56 MB** (−44%) |
| 📺 Android TV | 26m43s → **~21 min** (~21%) | 91.13 MB → **69.38 MB** (−24%) |

> _Warm-cache runs are faster again; the remaining floor is the native C++/Kotlin compile._

## 🏷️ Ticket / Issue

N/A — CI / infrastructure improvement. Resolves CodeQL alerts #328, #285, #286.

### 🖼️ Screenshots / GIFs (if UI)

N/A — CI configuration only, no app UI.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected — full Build Apps run green (Android phone/TV, iOS phone signed + unsigned, tvOS unsigned)
- [x] Code passes lint/formatting and type checks — every workflow YAML, the github-script JS, the Renovate regexes, and `build-ios.ts` (biome) validated locally
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (AI-Assisted badge above)

## 🔍 Testing Instructions

- This PR's own **Build Apps** run is the test: Android phone/TV build green on `ubuntu-26.04`, and the produced APKs install on a real arm64 device (phone arm64-only; TV also covers armeabi-v7a).
- Sanity-check the slimmed APKs install + launch on a phone (arm64) and an Android TV box.
- ⚠️ `ubuntu-26.04` is currently a **preview** image; `ubuntu-24.04` is a drop-in fallback if it ever regresses.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced PR artifact comments with build details, including device compatibility information and architecture mappings
  * Optimized dependency caching strategies across CI pipelines

* **Chores**
  * Standardized build infrastructure and pinned critical dependency versions for reproducible builds
  * Configured platform-specific architecture targets for optimized binary generation

* **Refactor**
  * Removed unused code from iOS build scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->