### PR TITLE
fix(mpv): force software decoding on Android emulator

### DIFF
--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MPVLayerRenderer.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MPVLayerRenderer.kt
@@ -4,6 +4,7 @@ import android.app.UiModeManager
 import android.content.Context
 import android.content.res.Configuration
 import android.content.res.AssetManager
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -33,6 +34,30 @@ class MPVLayerRenderer(private val context: Context) : MPVLib.EventObserver {
     private fun isTvDevice(): Boolean {
         val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
         return uiModeManager.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
+    }
+
+    /**
+     * True only on the Android emulator. Its goldfish/ranchu MediaCodec can't bind a
+     * decode output surface (decode opens with surface 0x0): HEVC then fails cleanly and
+     * mpv auto-falls-back to software, but H.264 "opens" deceptively and wedges the core
+     * (no fallback) — black video, then any command (seek/pause) deadlocks the UI thread
+     * → ANR. We force software decoding here.
+     *
+     * Only QEMU/SDK-exclusive signals are checked so a real device can never match — a
+     * false positive would needlessly drop shipping hardware to software decoding. The
+     * emulator reports ro.hardware=goldfish|ranchu, an sdk_* product, or a generic/
+     * emulator build fingerprint, none of which appear on real devices.
+     */
+    private fun isEmulator(): Boolean {
+        val hardware = Build.HARDWARE.lowercase()
+        if (hardware == "goldfish" || hardware == "ranchu") return true
+
+        val product = Build.PRODUCT
+        if (product == "sdk" || product.startsWith("sdk_")) return true
+
+        val fingerprint = Build.FINGERPRINT
+        return fingerprint.startsWith("generic") ||
+            fingerprint.contains("emulator", ignoreCase = true)
     }
 
     interface Delegate {
@@ -169,15 +194,21 @@ class MPVLayerRenderer(private val context: Context) : MPVLib.EventObserver {
             MPVLib.setOptionString("gpu-context", "android")
             MPVLib.setOptionString("opengl-es", "yes")
             
-            // Hardware video decoding
-            // TV: zero-copy (mediacodec) for better performance on low-power devices
-            // Mobile: copy mode (mediacodec-copy) for better compatibility
-            val isTV = isTvDevice()
-            if (isTV) {
-                MPVLib.setOptionString("hwdec", "mediacodec")
-                MPVLib.setOptionString("profile", "fast")
-            } else {
-                MPVLib.setOptionString("hwdec", "mediacodec-copy")
+            // Hardware decode path:
+            //  - Real TV hardware: zero-copy `mediacodec` (fastest on low-power devices).
+            //  - Real phone: `mediacodec-copy` (broadest compatibility).
+            //  - Emulator: software decode. Its MediaCodec can't bind an output surface
+            //    (surface 0x0); HEVC then fails cleanly and mpv auto-falls-back to software,
+            //    but H.264 "opens" deceptively and wedges the core with no fallback (black
+            //    video, then any command — seek/pause — deadlocks the UI thread → ANR).
+            //    hwdec=no makes every codec render via the gpu-next VO. Real devices unaffected.
+            when {
+                isEmulator() -> MPVLib.setOptionString("hwdec", "no")
+                isTvDevice() -> {
+                    MPVLib.setOptionString("hwdec", "mediacodec")
+                    MPVLib.setOptionString("profile", "fast")
+                }
+                else -> MPVLib.setOptionString("hwdec", "mediacodec-copy")
             }
             MPVLib.setOptionString("hwdec-codecs", "h264,hevc,mpeg4,mpeg2video,vp8,vp9,av1")
             


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Playing certain titles on the **Android TV emulator** showed only the controls overlay with no video, and the app ANR'd ("crashed") on the next remote command (seek or pause). H.264 content was the trigger; HEVC happened to work.

Root cause is in the native MPV renderer's hardware-decode setup. On the emulator, MediaCodec can't bind a decode output surface — mpv logs `Both surface and native_window are NULL` / `Using surface 0x0`:

- **HEVC**: MediaCodec `failed to start` → `Could not open codec` → mpv cleanly **falls back to software decoding** → renders.
- **H.264**: `h264_mediacodec` "opens" deceptively with surface `0x0`, reports `Selected decoder: h264`, then chokes (`MediaCodec discarded an unknown buffer`, `MediaCodec_loop` spinning) with **no fallback** → the video pipeline wedges (black screen). The next `mpv_command` (seek/pause) then runs synchronously on the UI thread and blocks in `futex_wait` → `Input dispatching timed out, Waited 5000ms for KeyEvent` → ANR.

The fix detects the emulator via QEMU/SDK-exclusive `Build` signals (`ro.hardware` = `goldfish`/`ranchu`, an `sdk_*` product, or a generic/emulator fingerprint) and forces `hwdec=no` (pure software decoding) there, so every codec renders through the `gpu-next` VO. Detection uses only signals that never appear on shipping hardware, so a real device can't be misclassified (and even if it were, the worst case is software decode, not a crash).

Real-device decode paths are **unchanged**: real Android TV keeps zero-copy `mediacodec`, real phone keeps `mediacodec-copy`.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A (native decode configuration, no UI change)

## ✅ Checklist

- [x] I've read the contribution guidelines
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`) — N/A, Kotlin-only change
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

## 🔍 Testing Instructions

On an **Android TV emulator** (`ro.hardware=ranchu`):

1. Play an H.264 title (e.g. a 1080p anime) — previously black video + ANR/crash on pressing pause or seeking.
2. Verify the video now renders, and pause/seek work without freezing or crashing.
3. Play an HEVC title and confirm it still renders.
4. `adb logcat | grep mpv` shows `Using software decoding` and no `Waited 5000ms for KeyEvent` ANR.

On a **real Android TV / phone**, playback is unchanged (still hardware-decoded via `mediacodec` / `mediacodec-copy`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video playback compatibility on Android emulators by forcing software decoding when needed.

* **Performance**
  * Optimized hardware decoding on Android TV devices using zero-copy rendering and fast settings.
  * Improved hardware decoding strategy on standard Android devices using MediaCodec acceleration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->