### PR TITLE
fix(seerr): request user without permission

### DIFF
--- a/app/(auth)/tv-request-modal.tsx
+++ b/app/(auth)/tv-request-modal.tsx
@@ -27,6 +27,10 @@ import type {
   Tag,
 } from "@/utils/jellyseerr/server/api/servarr/base";
 import type { MediaRequestBody } from "@/utils/jellyseerr/server/interfaces/api/requestInterfaces";
+import {
+  hasPermission,
+  Permission,
+} from "@/utils/jellyseerr/server/lib/permissions";
 import { store } from "@/utils/store";
 
 export default function TVRequestModalPage() {
@@ -36,11 +40,17 @@ export default function TVRequestModalPage() {
   const { t } = useTranslation();
   const { jellyseerrApi, jellyseerrUser, requestMedia } = useJellyseerr();
 
+  const canManageUsers = useMemo(
+    () =>
+      !!jellyseerrUser &&
+      hasPermission(Permission.MANAGE_REQUESTS, jellyseerrUser.permissions),
+    [jellyseerrUser],
+  );
+
   const [isReady, setIsReady] = useState(false);
   const [requestOverrides, setRequestOverrides] = useState<MediaRequestBody>({
     mediaId: modalState?.id ? Number(modalState.id) : 0,
     mediaType: modalState?.mediaType,
-    userId: jellyseerrUser?.id,
   });
 
   const [activeSelector, setActiveSelector] = useState<
@@ -90,7 +100,8 @@ export default function TVRequestModalPage() {
     queryKey: ["jellyseerr", "users"],
     queryFn: async () =>
       jellyseerrApi?.user({ take: 1000, sort: "displayname" }),
-    enabled: !!jellyseerrApi && !!jellyseerrUser && !!modalState,
+    enabled:
+      !!jellyseerrApi && !!jellyseerrUser && !!modalState && canManageUsers,
   });
 
   const defaultService = useMemo(
@@ -274,7 +285,7 @@ export default function TVRequestModalPage() {
   const handleRequest = useCallback(() => {
     if (!modalState) return;
 
-    const body = {
+    const body: MediaRequestBody = {
       is4k: defaultService?.is4k || defaultServiceDetails?.server.is4k,
       profileId: defaultProfile?.id,
       rootFolder: defaultFolder?.path,
@@ -282,6 +293,10 @@ export default function TVRequestModalPage() {
       ...modalState.requestBody,
       ...requestOverrides,
     };
+
+    if (!canManageUsers) {
+      delete body.userId;
+    }
 
     const seasonTitle =
       modalState.requestBody?.seasons?.length === 1
@@ -312,13 +327,15 @@ export default function TVRequestModalPage() {
     requestMedia,
     router,
     t,
+    canManageUsers,
   ]);
 
   if (!modalState) {
     return null;
   }
 
-  const isDataLoaded = defaultService && defaultServiceDetails && users;
+  const isDataLoaded =
+    defaultService && defaultServiceDetails && (!canManageUsers || !!users);
 
   return (
     <Animated.View style={[styles.overlay, { opacity: overlayOpacity }]}>
@@ -361,11 +378,13 @@ export default function TVRequestModalPage() {
                     value={selectedFolderName}
                     onPress={() => setActiveSelector("folder")}
                   />
-                  <TVRequestOptionRow
-                    label={t("jellyseerr.request_as")}
-                    value={selectedUserName}
-                    onPress={() => setActiveSelector("user")}
-                  />
+                  {canManageUsers && (
+                    <TVRequestOptionRow
+                      label={t("jellyseerr.request_as")}
+                      value={selectedUserName}
+                      onPress={() => setActiveSelector("user")}
+                    />
+                  )}
 
                   {tagItems.length > 0 && (
                     <TVToggleOptionRow
@@ -428,14 +447,16 @@ export default function TVRequestModalPage() {
         cancelLabel={t("jellyseerr.cancel")}
         cardWidth={280}
       />
-      <TVOptionSelector
-        visible={activeSelector === "user"}
-        title={t("jellyseerr.request_as")}
-        options={userOptions}
-        onSelect={handleUserChange}
-        onClose={() => setActiveSelector(null)}
-        cancelLabel={t("jellyseerr.cancel")}
-      />
+      {canManageUsers && (
+        <TVOptionSelector
+          visible={activeSelector === "user"}
+          title={t("jellyseerr.request_as")}
+          options={userOptions}
+          onSelect={handleUserChange}
+          onClose={() => setActiveSelector(null)}
+          cancelLabel={t("jellyseerr.cancel")}
+        />
+      )}
     </Animated.View>
   );
 }

--- a/components/jellyseerr/RequestModal.tsx
+++ b/components/jellyseerr/RequestModal.tsx
@@ -20,6 +20,10 @@ import type {
 } from "@/utils/jellyseerr/server/api/servarr/base";
 import type { MediaType } from "@/utils/jellyseerr/server/constants/media";
 import type { MediaRequestBody } from "@/utils/jellyseerr/server/interfaces/api/requestInterfaces";
+import {
+  hasPermission,
+  Permission,
+} from "@/utils/jellyseerr/server/lib/permissions";
 import { writeDebugLog } from "@/utils/log";
 
 interface Props {
@@ -42,10 +46,17 @@ const RequestModal = forwardRef<
     ref,
   ) => {
     const { jellyseerrApi, jellyseerrUser, requestMedia } = useJellyseerr();
+
+    const canManageUsers = useMemo(
+      () =>
+        !!jellyseerrUser &&
+        hasPermission(Permission.MANAGE_REQUESTS, jellyseerrUser.permissions),
+      [jellyseerrUser],
+    );
+
     const [requestOverrides, setRequestOverrides] = useState<MediaRequestBody>({
       mediaId: Number(id),
       mediaType: type,
-      userId: jellyseerrUser?.id,
     });
 
     const [qualityProfileOpen, setQualityProfileOpen] = useState(false);
@@ -76,7 +87,7 @@ const RequestModal = forwardRef<
       queryKey: ["jellyseerr", "users"],
       queryFn: async () =>
         jellyseerrApi?.user({ take: 1000, sort: "displayname" }),
-      enabled: !!jellyseerrApi && !!jellyseerrUser,
+      enabled: !!jellyseerrApi && !!jellyseerrUser && canManageUsers,
       refetchOnMount: "always",
     });
 
@@ -259,7 +270,7 @@ const RequestModal = forwardRef<
     );
 
     const request = useCallback(() => {
-      const body = {
+      const body: MediaRequestBody = {
         is4k: defaultService?.is4k || defaultServiceDetails?.server.is4k,
         profileId: defaultProfile?.id,
         rootFolder: defaultFolder?.path,
@@ -267,6 +278,10 @@ const RequestModal = forwardRef<
         ...requestBody,
         ...requestOverrides,
       };
+
+      if (!canManageUsers) {
+        delete body.userId;
+      }
 
       writeDebugLog("Sending Jellyseerr advanced request", body);
 
@@ -281,6 +296,7 @@ const RequestModal = forwardRef<
       defaultProfile,
       defaultFolder,
       defaultTags,
+      canManageUsers,
     ]);
 
     return (
@@ -315,116 +331,121 @@ const RequestModal = forwardRef<
               )}
             </View>
             <View className='flex flex-col space-y-2'>
-              {defaultService && defaultServiceDetails && users && (
-                <>
-                  <View className='flex flex-col'>
-                    <Text className='opacity-50 mb-1 text-xs'>
-                      {t("jellyseerr.quality_profile")}
-                    </Text>
-                    <PlatformDropdown
-                      groups={qualityProfileOptions}
-                      trigger={
-                        <View className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'>
-                          <Text numberOfLines={1}>
-                            {defaultServiceDetails.profiles.find(
-                              (p) =>
-                                p.id ===
-                                (requestOverrides.profileId ||
-                                  defaultProfile?.id),
-                            )?.name || defaultProfile?.name}
-                          </Text>
-                        </View>
-                      }
-                      title={t("jellyseerr.quality_profile")}
-                      open={qualityProfileOpen}
-                      onOpenChange={setQualityProfileOpen}
-                    />
-                  </View>
+              {defaultService &&
+                defaultServiceDetails &&
+                (!canManageUsers || users) && (
+                  <>
+                    <View className='flex flex-col'>
+                      <Text className='opacity-50 mb-1 text-xs'>
+                        {t("jellyseerr.quality_profile")}
+                      </Text>
+                      <PlatformDropdown
+                        groups={qualityProfileOptions}
+                        trigger={
+                          <View className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'>
+                            <Text numberOfLines={1}>
+                              {defaultServiceDetails.profiles.find(
+                                (p) =>
+                                  p.id ===
+                                  (requestOverrides.profileId ||
+                                    defaultProfile?.id),
+                              )?.name || defaultProfile?.name}
+                            </Text>
+                          </View>
+                        }
+                        title={t("jellyseerr.quality_profile")}
+                        open={qualityProfileOpen}
+                        onOpenChange={setQualityProfileOpen}
+                      />
+                    </View>
 
-                  <View className='flex flex-col'>
-                    <Text className='opacity-50 mb-1 text-xs'>
-                      {t("jellyseerr.root_folder")}
-                    </Text>
-                    <PlatformDropdown
-                      groups={rootFolderOptions}
-                      trigger={
-                        <View className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'>
-                          <Text numberOfLines={1}>
-                            {defaultServiceDetails.rootFolders.find(
-                              (f) =>
-                                f.path ===
-                                (requestOverrides.rootFolder ||
-                                  defaultFolder?.path),
-                            )
-                              ? pathTitleExtractor(
-                                  defaultServiceDetails.rootFolders.find(
-                                    (f) =>
-                                      f.path ===
-                                      (requestOverrides.rootFolder ||
-                                        defaultFolder?.path),
-                                  )!,
-                                )
-                              : pathTitleExtractor(defaultFolder!)}
-                          </Text>
-                        </View>
-                      }
-                      title={t("jellyseerr.root_folder")}
-                      open={rootFolderOpen}
-                      onOpenChange={setRootFolderOpen}
-                    />
-                  </View>
-
-                  <View className='flex flex-col'>
-                    <Text className='opacity-50 mb-1 text-xs'>
-                      {t("jellyseerr.tags")}
-                    </Text>
-                    <PlatformDropdown
-                      groups={tagsOptions}
-                      trigger={
-                        <View className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'>
-                          <Text numberOfLines={1}>
-                            {requestOverrides.tags
-                              ? defaultServiceDetails.tags
-                                  .filter((t) =>
-                                    requestOverrides.tags!.includes(t.id),
+                    <View className='flex flex-col'>
+                      <Text className='opacity-50 mb-1 text-xs'>
+                        {t("jellyseerr.root_folder")}
+                      </Text>
+                      <PlatformDropdown
+                        groups={rootFolderOptions}
+                        trigger={
+                          <View className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'>
+                            <Text numberOfLines={1}>
+                              {defaultServiceDetails.rootFolders.find(
+                                (f) =>
+                                  f.path ===
+                                  (requestOverrides.rootFolder ||
+                                    defaultFolder?.path),
+                              )
+                                ? pathTitleExtractor(
+                                    defaultServiceDetails.rootFolders.find(
+                                      (f) =>
+                                        f.path ===
+                                        (requestOverrides.rootFolder ||
+                                          defaultFolder?.path),
+                                    )!,
                                   )
-                                  .map((t) => t.label)
-                                  .join(", ") ||
-                                defaultTags.map((t) => t.label).join(", ")
-                              : defaultTags.map((t) => t.label).join(", ")}
-                          </Text>
-                        </View>
-                      }
-                      title={t("jellyseerr.tags")}
-                      open={tagsOpen}
-                      onOpenChange={setTagsOpen}
-                    />
-                  </View>
+                                : pathTitleExtractor(defaultFolder!)}
+                            </Text>
+                          </View>
+                        }
+                        title={t("jellyseerr.root_folder")}
+                        open={rootFolderOpen}
+                        onOpenChange={setRootFolderOpen}
+                      />
+                    </View>
 
-                  <View className='flex flex-col'>
-                    <Text className='opacity-50 mb-1 text-xs'>
-                      {t("jellyseerr.request_as")}
-                    </Text>
-                    <PlatformDropdown
-                      groups={usersOptions}
-                      trigger={
-                        <View className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'>
-                          <Text numberOfLines={1}>
-                            {users.find(
-                              (u) =>
-                                u.id ===
-                                (requestOverrides.userId || jellyseerrUser?.id),
-                            )?.displayName || jellyseerrUser!.displayName}
-                          </Text>
-                        </View>
-                      }
-                      title={t("jellyseerr.request_as")}
-                      open={usersOpen}
-                      onOpenChange={setUsersOpen}
-                    />
-                  </View>
-                </>
-              )}
+                    <View className='flex flex-col'>
+                      <Text className='opacity-50 mb-1 text-xs'>
+                        {t("jellyseerr.tags")}
+                      </Text>
+                      <PlatformDropdown
+                        groups={tagsOptions}
+                        trigger={
+                          <View className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'>
+                            <Text numberOfLines={1}>
+                              {requestOverrides.tags
+                                ? defaultServiceDetails.tags
+                                    .filter((t) =>
+                                      requestOverrides.tags!.includes(t.id),
+                                    )
+                                    .map((t) => t.label)
+                                    .join(", ") ||
+                                  defaultTags.map((t) => t.label).join(", ")
+                                : defaultTags.map((t) => t.label).join(", ")}
+                            </Text>
+                          </View>
+                        }
+                        title={t("jellyseerr.tags")}
+                        open={tagsOpen}
+                        onOpenChange={setTagsOpen}
+                      />
+                    </View>
+
+                    {canManageUsers && users && (
+                      <View className='flex flex-col'>
+                        <Text className='opacity-50 mb-1 text-xs'>
+                          {t("jellyseerr.request_as")}
+                        </Text>
+                        <PlatformDropdown
+                          groups={usersOptions}
+                          trigger={
+                            <View className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'>
+                              <Text numberOfLines={1}>
+                                {users.find(
+                                  (u) =>
+                                    u.id ===
+                                    (requestOverrides.userId ||
+                                      jellyseerrUser?.id),
+                                )?.displayName || jellyseerrUser!.displayName}
+                              </Text>
+                            </View>
+                          }
+                          title={t("jellyseerr.request_as")}
+                          open={usersOpen}
+                          onOpenChange={setUsersOpen}
+                        />
+                      </View>
+                    )}
+                  </>
+                )}
             </View>
             <Button className='mt-auto' onPress={request} color='purple'>
               {t("jellyseerr.request_button")}

--- a/utils/_jellyseerr/useJellyseerrCanRequest.ts
+++ b/utils/_jellyseerr/useJellyseerrCanRequest.ts
@@ -63,5 +63,13 @@ export const useJellyseerrCanRequest = (
     );
   }, [jellyseerrUser]);
 
-  return [canRequest, hasAdvancedRequestPermission];
+  const canManageUsers = useMemo(() => {
+    if (!jellyseerrUser) return false;
+    return hasPermission(
+      Permission.MANAGE_REQUESTS,
+      jellyseerrUser.permissions,
+    );
+  }, [jellyseerrUser]);
+
+  return [canRequest, hasAdvancedRequestPermission, canManageUsers];
 };


### PR DESCRIPTION
# 📦 Pull Request
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=claude&logoColor=orange)](#)
Claude was used to generate the code following my instructions. The testing and PR were made manually.

## 📝 Description
Seerr requests were broken when an user had the "Advanced Requests" permission but not the global "Manage Requests" permission because the RequestModal was always sending an userId to the Seerr API. This PR fixes this by:
- Removing the select user dropdown if the user does not have the "Manage Requests" permission
- Removing the userId parameter from the API request when no permission to avoid the error

## 🏷️ Ticket / Issue
Fixes #1426 

### 🖼️ Screenshots / GIFs (if UI)
<img width="435" height="767" alt="Before" src="https://github.com/user-attachments/assets/3f55b7ca-a6df-4b09-a139-79ded7e6c4ad" />
<img width="435" height="767" alt="After" src="https://github.com/user-attachments/assets/21eec3df-1abd-438d-a52f-7a35155a44a8" />

## ✅ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms => Can't test on iOS but android & androidTV were tested and OK.
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions
1. Link to a Seerr instance with a user having the "Advanced Requests" permission but not the "Manage Requests" permission
2. Try to make a request in Streamyfin
3. It should display the form without the "Request as" dropdown and the request should now work as expected

Also testing that when the user have both permissions, it works fine as well:
1. Link to a Seerr instance with a user having the "Manage Requests" global permission
2. Try to make a request in Streamyfin
3. It should display the form with the "Request as" dropdown that you can change and the request should work as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request dialogs now respect user permissions more consistently.
  * Users without request-management access will see a simpler request flow without user-switching options.

* **Bug Fixes**
  * Improved request submission behavior so restricted users no longer send unsupported user-specific data.
  * Fixed loading and availability states so request options appear only when the app has the needed permission and data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->