### PR TITLE
fix(tv): "See All" opens library and Back returns to library list

### DIFF
--- a/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
+++ b/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
@@ -12,11 +12,16 @@ import {
 import { FlashList } from "@shopify/flash-list";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Image } from "expo-image";
-import { useLocalSearchParams, useNavigation } from "expo-router";
+import {
+  useFocusEffect,
+  useLocalSearchParams,
+  useNavigation,
+} from "expo-router";
 import { useAtom } from "jotai";
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  BackHandler,
   FlatList,
   Platform,
   ScrollView,
@@ -80,8 +85,9 @@ const Page = () => {
     sortBy?: string;
     sortOrder?: string;
     filterBy?: string;
+    fromSeeAll?: string;
   };
-  const { libraryId } = searchParams;
+  const { libraryId, fromSeeAll } = searchParams;
 
   const typography = useScaledTVTypography();
   const posterSizes = useScaledTVPosterSizes();
@@ -112,6 +118,22 @@ const Page = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const { showOptions } = useTVOptionModal();
+
+  // When this library detail was opened from the home "See All" button, its
+  // libraries stack is just [detail], so the default TV Back would exit to home.
+  // Intercept Back (scoped to while this screen is focused via useFocusEffect) and
+  // route to the library list instead, so the user can switch libraries. Normal
+  // entries from the list keep their native pop-to-list behavior.
+  useFocusEffect(
+    useCallback(() => {
+      if (!Platform.isTV || fromSeeAll !== "true") return;
+      const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+        router.replace("/(auth)/(tabs)/(libraries)");
+        return true;
+      });
+      return () => sub.remove();
+    }, [fromSeeAll, router]),
+  );
   const { showItemActions } = useTVItemActionModal();
 
   // TV Filter queries
@@ -268,6 +290,23 @@ const Page = () => {
       title: library?.Name || "",
     });
   }, [library]);
+
+  // If this See-All detail was deep-linked on top of the libraries index, collapse
+  // the libraries stack to just this screen. Otherwise the stack is [index, detail],
+  // which the native bottom tab reliably auto-pops back to the index (the detail
+  // "bounces" to the library list ~0.5s after opening). With [detail] alone it stays
+  // put, and Back is handled explicitly by the fromSeeAll interceptor above.
+  const didCollapseRef = useRef(false);
+  useEffect(() => {
+    if (!Platform.isTV || fromSeeAll !== "true" || didCollapseRef.current)
+      return;
+    const state = navigation.getState();
+    if (state?.routes && state.routes.length > 1) {
+      didCollapseRef.current = true;
+      const top = state.routes[state.routes.length - 1];
+      navigation.reset({ index: 0, routes: [top] } as any);
+    }
+  }, [navigation, fromSeeAll]);
 
   const fetchItems = useCallback(
     async ({

--- a/components/home/InfiniteScrollingCollectionList.tv.tsx
+++ b/components/home/InfiniteScrollingCollectionList.tv.tsx
@@ -201,16 +201,18 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
 
   const handleSeeAllPress = useCallback(() => {
     if (!parentId) return;
-    // Use the relative "/[libraryId]" pathname (same as getItemNavigation) so the
-    // library detail is pushed within the current tab's stack. The fully-qualified
-    // "/(auth)/(tabs)/(libraries)/[libraryId]" path is a cross-tab navigation that
-    // only switches to the libraries tab and drops the nested screen push.
+    // Navigate into the library detail (lives in the libraries tab) sorted by most
+    // recently added. The `fromSeeAll` flag tells the detail page to (a) collapse
+    // the libraries stack so the native tab can't auto-pop it back to the list, and
+    // (b) intercept Back to route to the library list so the user can switch
+    // libraries. See app/(auth)/(tabs)/(libraries)/[libraryId].tsx.
     router.push({
       pathname: "/[libraryId]",
       params: {
         libraryId: parentId,
         sortBy: SortByOption.DateCreated,
         sortOrder: SortOrderOption.Descending,
+        fromSeeAll: "true",
       },
     } as any);
   }, [router, parentId]);

--- a/components/home/InfiniteScrollingCollectionList.tv.tsx
+++ b/components/home/InfiniteScrollingCollectionList.tv.tsx
@@ -201,8 +201,12 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
 
   const handleSeeAllPress = useCallback(() => {
     if (!parentId) return;
+    // Use the relative "/[libraryId]" pathname (same as getItemNavigation) so the
+    // library detail is pushed within the current tab's stack. The fully-qualified
+    // "/(auth)/(tabs)/(libraries)/[libraryId]" path is a cross-tab navigation that
+    // only switches to the libraries tab and drops the nested screen push.
     router.push({
-      pathname: "/(auth)/(tabs)/(libraries)/[libraryId]",
+      pathname: "/[libraryId]",
       params: {
         libraryId: parentId,
         sortBy: SortByOption.DateCreated,

--- a/components/home/InfiniteScrollingCollectionList.tv.tsx
+++ b/components/home/InfiniteScrollingCollectionList.tv.tsx
@@ -354,11 +354,14 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
           // contentOffset={{ x: -sizes.padding.horizontal, y: 0 }}
           // contentContainerStyle={{ paddingVertical: SCALE_PADDING }}
           ListFooterComponent={
+            // No fixed width: the footer must size to the "See All" card so the
+            // FlatList's scrollable content extends to fully reveal it. A fixed
+            // (narrow) width clipped the card at the right edge. Trailing space is
+            // provided by contentContainerStyle.paddingRight.
             <View
               style={{
                 flexDirection: "row",
                 alignItems: "center",
-                width: sizes.padding.horizontal,
               }}
             >
               {isFetchingNextPage && (


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

On Apple TV, the home-screen "See All" card at the end of horizontal rows (e.g. "Recently Added in Movies") now reliably opens the target library — sorted by most recently added — and pressing **Back** returns to the **library list** so the user can switch libraries.

The detail page lives in the libraries tab, which caused two problems:
1. **Wrong Back target** — deep-linking straight into `[libraryId]` made the libraries stack `[detail]` only, so Back exited the tab to Home instead of the library list.
2. **Auto-bounce** — once the libraries tab already had its `index` in the stack (after a previous See All + Back), navigating produced `[index, detail]`, which the native bottom tab (`@bottom-tabs/react-navigation`) reliably auto-popped back to `index` ~0.5s later — the detail "bounced" to the list on its own.

Fix:
- The See All button passes a `fromSeeAll` flag into the detail route.
- The detail page collapses the libraries stack to `[detail]` when deep-linked on top of the `index`, so the native tab has nothing to auto-pop to.
- TV Back is intercepted (only while the See-All detail is focused) and routed to the library list. Normal entries from the list keep their native pop-to-list behavior.
- `useIsFocused` from `@react-navigation/native` was avoided (banned by the expo-router SDK 56 compatibility check); focus scoping uses expo-router's `useFocusEffect` + `BackHandler`.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A — navigation/back-stack behavior; no visual change to the screens themselves.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms (TV-only change; verified on tvOS simulator. Mobile is unaffected.)
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

On Apple TV:
1. Open the Home tab and scroll a horizontal row (e.g. "Recently Added in Movies") all the way to the right to reveal the **See All** card.
2. Press **See All** → verify it opens that library, sorted by most recently added, and **stays** on the library (no auto-bounce back to the list).
3. Press **Back** → verify it lands on the **library list** (not Home), where you can select a different library.
4. Return to Home and press **See All again** (this is the case that previously bounced) → verify the detail still opens and stays put.

https://claude.ai/code/session_016Hhu5DruGLPhdP4LAoy1Xd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TV “See All” navigation to open library details with the correct deep-link behavior.
  * Added handling for returning from “See All” on TV so back navigation goes to the libraries list more reliably.

* **Bug Fixes**
  * Prevented a tab auto-pop bounce when opening deeply linked library detail pages.
  * Updated the “See All” card layout so it displays correctly in the footer area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->