### PR TITLE
fix(android): detect wifi SSID via NetInfo for local network switching

### DIFF
--- a/modules/wifi-ssid/index.ts
+++ b/modules/wifi-ssid/index.ts
@@ -1,3 +1,4 @@
+import NetInfo from "@react-native-community/netinfo";
 import { Platform, requireNativeModule } from "expo-modules-core";
 
 // Only load the native module on iOS
@@ -5,15 +6,19 @@ const WifiSsidModule =
   Platform.OS === "ios" ? requireNativeModule("WifiSsid") : null;
 
 /**
- * Get the current WiFi SSID on iOS.
- * Returns null on Android or if not connected to WiFi.
+ * Get the current WiFi SSID.
+ * Returns null if not connected to WiFi.
  *
- * Requires:
- * - Location permission granted
- * - com.apple.developer.networking.wifi-info entitlement
- * - Access WiFi Information capability enabled in Apple Developer Portal
+ * Requires location permission granted on both platforms.
+ * iOS additionally requires the com.apple.developer.networking.wifi-info
+ * entitlement and Access WiFi Information capability.
  */
 export async function getSSID(): Promise<string | null> {
+  if (Platform.OS === "android") {
+    const state = await NetInfo.fetch("wifi");
+    return state.type === "wifi" ? (state.details.ssid ?? null) : null;
+  }
+
   if (!WifiSsidModule) {
     return null;
   }

--- a/modules/wifi-ssid/index.ts
+++ b/modules/wifi-ssid/index.ts
@@ -16,12 +16,18 @@ const WifiSsidModule =
  */
 export async function getSSID(): Promise<string | null> {
   if (Platform.OS === "android") {
-    const state = await NetInfo.fetch("wifi");
-    if (state.type !== "wifi") return null;
-    const ssid = state.details.ssid;
-    // Android reports this placeholder instead of null when it can't resolve
-    // the real SSID (e.g. missing location permission on some OS versions).
-    return ssid && ssid !== "<unknown ssid>" ? ssid : null;
+    try {
+      const state = await NetInfo.fetch("wifi");
+      if (state.type !== "wifi") return null;
+      const ssid = state.details.ssid;
+      // Android reports this placeholder instead of null when it can't
+      // resolve the real SSID (e.g. missing location permission on some
+      // OS versions).
+      return ssid && ssid !== "<unknown ssid>" ? ssid : null;
+    } catch (error) {
+      console.error("[WifiSsid] Error getting SSID:", error);
+      return null;
+    }
   }
 
   if (!WifiSsidModule) {

--- a/modules/wifi-ssid/index.ts
+++ b/modules/wifi-ssid/index.ts
@@ -9,14 +9,19 @@ const WifiSsidModule =
  * Get the current WiFi SSID.
  * Returns null if not connected to WiFi.
  *
- * Requires location permission granted on both platforms.
+ * Requires location permission granted on both platforms (Android also
+ * needs device-level location services turned on).
  * iOS additionally requires the com.apple.developer.networking.wifi-info
  * entitlement and Access WiFi Information capability.
  */
 export async function getSSID(): Promise<string | null> {
   if (Platform.OS === "android") {
     const state = await NetInfo.fetch("wifi");
-    return state.type === "wifi" ? (state.details.ssid ?? null) : null;
+    if (state.type !== "wifi") return null;
+    const ssid = state.details.ssid;
+    // Android reports this placeholder instead of null when it can't resolve
+    // the real SSID (e.g. missing location permission on some OS versions).
+    return ssid && ssid !== "<unknown ssid>" ? ssid : null;
   }
 
   if (!WifiSsidModule) {


### PR DESCRIPTION
closes #1440

## What
The `wifi-ssid` module only implemented SSID lookup on iOS
(`modules/wifi-ssid/ios/WifiSsidModule.swift`), so `getSSID()`
always returned `null` on Android. This silently broke the local
network auto-switch feature for every Android user — the Settings
screen always showed "Not connected to WiFi" regardless of actual
connection state.

## Why
Rather than adding a new native Android module, this uses
`@react-native-community/netinfo` (already a project dependency,
already used elsewhere for connectivity checks) to read
`state.details.ssid` from `NetInfo.fetch("wifi")` on Android.

## Testing
Verified on a physical Xiaomi Pad 8 (Android 16 / HyperOS): confirmed
via `adb` that location permission and Wi-Fi state permission were
already granted, and that the OS itself correctly reported the
connected SSID via `dumpsys wifi` — the app just wasn't reading it.
After this fix, the Local Network settings screen correctly displays
the current SSID and auto-switch works as intended.

## AI Assistance Disclosure
I did this with the help of Claude Code — it found the root cause by
reading the wifi-ssid module source, proposed this fix, and helped me
build and test it on my own Android tablet via EAS and adb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wi‑Fi SSID detection on Android by returning the current SSID only when connected via Wi‑Fi and a valid SSID is available; returns `null` otherwise.
* **Documentation**
  * Clarified platform-specific prerequisites and expected behavior for SSID access to improve predictability across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->