### PR TITLE
ci: run independent workflow steps in parallel

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -255,7 +255,7 @@ jobs:
               xcode-version: "26.5"
 
           - name: 🏗️ Setup EAS
-            uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9.0.0
+            uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # main
             with:
               eas-version: latest
               token: ${{ secrets.EXPO_TOKEN }}
@@ -396,7 +396,7 @@ jobs:
               xcode-version: "26.5"
 
           - name: 🏗️ Setup EAS
-            uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9.0.0
+            uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # main
             with:
               eas-version: latest
               token: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -30,63 +30,65 @@ jobs:
       actions: write # dispatch artifact-comment.yml to refresh the PR comment
 
     steps:
-      - name: 🗑️ Free Disk Space
-        uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
-        with:
-          tool-cache: false
-          mandb: true
-          android: false
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+      - parallel:
+          - name: 🗑️ Free Disk Space
+            uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
+            with:
+              tool-cache: false
+              mandb: true
+              android: false
+              dotnet: true
+              haskell: true
+              large-packages: false
+              docker-images: true
+              swap-storage: false
 
-      - name: 📥 Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
-          submodules: recursive
-          show-progress: false
+          - name: 📥 Checkout code
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              ref: ${{ github.event.pull_request.head.sha || github.sha }}
+              fetch-depth: 0
+              submodules: recursive
+              show-progress: false
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
 
-      - name: 💾 Cache Bun dependencies
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-bun-
+          - name: ☕ Set up JDK 17
+            # ubuntu-26.04 defaults to JDK 25, which breaks the RN/AGP native build
+            # (Kotlin falls back to JVM_23, the foojay toolchain + CMake configure
+            # fail). Pin Temurin 17 for a deterministic Android build.
+            uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+            with:
+              distribution: temurin
+              java-version: "17"
+
+      - parallel:
+          - name: 💾 Cache Bun dependencies
+            uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+            with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
+              restore-keys: |
+                ${{ runner.os }}-${{ runner.arch }}-bun-
+
+          - name: 💾 Cache Gradle global
+            uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+            with:
+              path: |
+                ~/.gradle/caches/modules-2
+                ~/.gradle/wrapper
+              key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+              restore-keys: |
+                ${{ runner.os }}-${{ runner.arch }}-gradle-
 
       - name: 📦 Install dependencies and reload submodules
         run: |
           bun install --frozen-lockfile
           bun run submodule-reload
-
-      - name: ☕ Set up JDK 17
-        # ubuntu-26.04 defaults to JDK 25, which breaks the RN/AGP native build
-        # (Kotlin falls back to JVM_23, the foojay toolchain + CMake configure
-        # fail). Pin Temurin 17 for a deterministic Android build.
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: 💾 Cache Gradle global
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        with:
-          path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-gradle-
 
       - name: 🛠️ Generate project files
         run: bun run prebuild
@@ -130,63 +132,65 @@ jobs:
       actions: write # dispatch artifact-comment.yml to refresh the PR comment
 
     steps:
-      - name: 🗑️ Free Disk Space
-        uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
-        with:
-          tool-cache: false
-          mandb: true
-          android: false
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: false
+      - parallel:
+          - name: 🗑️ Free Disk Space
+            uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3
+            with:
+              tool-cache: false
+              mandb: true
+              android: false
+              dotnet: true
+              haskell: true
+              large-packages: false
+              docker-images: true
+              swap-storage: false
 
-      - name: 📥 Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
-          submodules: recursive
-          show-progress: false
+          - name: 📥 Checkout code
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              ref: ${{ github.event.pull_request.head.sha || github.sha }}
+              fetch-depth: 0
+              submodules: recursive
+              show-progress: false
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
 
-      - name: 💾 Cache Bun dependencies
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-bun-
+          - name: ☕ Set up JDK 17
+            # ubuntu-26.04 defaults to JDK 25, which breaks the RN/AGP native build
+            # (Kotlin falls back to JVM_23, the foojay toolchain + CMake configure
+            # fail). Pin Temurin 17 for a deterministic Android build.
+            uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+            with:
+              distribution: temurin
+              java-version: "17"
+
+      - parallel:
+          - name: 💾 Cache Bun dependencies
+            uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+            with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
+              restore-keys: |
+                ${{ runner.os }}-${{ runner.arch }}-bun-
+
+          - name: 💾 Cache Gradle global
+            uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+            with:
+              path: |
+                ~/.gradle/caches/modules-2
+                ~/.gradle/wrapper
+              key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+              restore-keys: |
+                ${{ runner.os }}-${{ runner.arch }}-gradle-
 
       - name: 📦 Install dependencies and reload submodules
         run: |
           bun install --frozen-lockfile
           bun run submodule-reload
-
-      - name: ☕ Set up JDK 17
-        # ubuntu-26.04 defaults to JDK 25, which breaks the RN/AGP native build
-        # (Kotlin falls back to JVM_23, the foojay toolchain + CMake configure
-        # fail). Pin Temurin 17 for a deterministic Android build.
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
-        with:
-          distribution: temurin
-          java-version: "17"
-
-      - name: 💾 Cache Gradle global
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
-        with:
-          path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-${{ runner.arch }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-gradle-
 
       - name: 🛠️ Generate project files
         run: bun run prebuild:tv
@@ -229,19 +233,33 @@ jobs:
       actions: write # dispatch artifact-comment.yml to refresh the PR comment
 
     steps:
-      - name: 📥 Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
-          submodules: recursive
-          show-progress: false
+      - parallel:
+          - name: 📥 Checkout code
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              ref: ${{ github.event.pull_request.head.sha || github.sha }}
+              fetch-depth: 0
+              submodules: recursive
+              show-progress: false
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
+
+          - name: 🔧 Setup Xcode
+            uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+            with:
+              # renovate: datasource=custom.xcode depName=xcode versioning=loose
+              xcode-version: "26.5"
+
+          - name: 🏗️ Setup EAS
+            uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9.0.0
+            with:
+              eas-version: latest
+              token: ${{ secrets.EXPO_TOKEN }}
+              eas-cache: true
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
@@ -258,19 +276,6 @@ jobs:
 
       - name: 🛠️ Generate project files
         run: bun run prebuild
-
-      - name: 🔧 Setup Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
-        with:
-          # renovate: datasource=custom.xcode depName=xcode versioning=loose
-          xcode-version: "26.5"
-
-      - name: 🏗️ Setup EAS
-        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # main
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-          eas-cache: true
 
       - name: 🚀 Build iOS app
         env:
@@ -301,19 +306,26 @@ jobs:
       actions: write # dispatch artifact-comment.yml to refresh the PR comment
 
     steps:
-      - name: 📥 Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
-          submodules: recursive
-          show-progress: false
+      - parallel:
+          - name: 📥 Checkout code
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              ref: ${{ github.event.pull_request.head.sha || github.sha }}
+              fetch-depth: 0
+              submodules: recursive
+              show-progress: false
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
+
+          - name: 🔧 Setup Xcode
+            uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+            with:
+              # renovate: datasource=custom.xcode depName=xcode versioning=loose
+              xcode-version: "26.5"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
@@ -330,12 +342,6 @@ jobs:
 
       - name: 🛠️ Generate project files
         run: bun run prebuild
-
-      - name: 🔧 Setup Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
-        with:
-          # renovate: datasource=custom.xcode depName=xcode versioning=loose
-          xcode-version: "26.5"
 
       - name: 🚀 Build iOS app
         env:
@@ -368,19 +374,33 @@ jobs:
       actions: write # dispatch artifact-comment.yml to refresh the PR comment
 
     steps:
-      - name: 📥 Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
-          submodules: recursive
-          show-progress: false
+      - parallel:
+          - name: 📥 Checkout code
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              ref: ${{ github.event.pull_request.head.sha || github.sha }}
+              fetch-depth: 0
+              submodules: recursive
+              show-progress: false
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
+
+          - name: 🔧 Setup Xcode
+            uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+            with:
+              # renovate: datasource=custom.xcode depName=xcode versioning=loose
+              xcode-version: "26.5"
+
+          - name: 🏗️ Setup EAS
+            uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9.0.0
+            with:
+              eas-version: latest
+              token: ${{ secrets.EXPO_TOKEN }}
+              eas-cache: true
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
@@ -397,19 +417,6 @@ jobs:
 
       - name: 🛠️ Generate project files
         run: bun run prebuild:tv
-
-      - name: 🔧 Setup Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
-        with:
-          # renovate: datasource=custom.xcode depName=xcode versioning=loose
-          xcode-version: "26.5"
-
-      - name: 🏗️ Setup EAS
-        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # main
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-          eas-cache: true
 
       - name: 🚀 Build iOS app
         env:
@@ -438,19 +445,26 @@ jobs:
       actions: write # dispatch artifact-comment.yml to refresh the PR comment
 
     steps:
-      - name: 📥 Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
-          submodules: recursive
-          show-progress: false
+      - parallel:
+          - name: 📥 Checkout code
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              ref: ${{ github.event.pull_request.head.sha || github.sha }}
+              fetch-depth: 0
+              submodules: recursive
+              show-progress: false
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
+
+          - name: 🔧 Setup Xcode
+            uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+            with:
+              # renovate: datasource=custom.xcode depName=xcode versioning=loose
+              xcode-version: "26.5"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
@@ -467,12 +481,6 @@ jobs:
 
       - name: 🛠️ Generate project files
         run: bun run prebuild:tv
-
-      - name: 🔧 Setup Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
-        with:
-          # renovate: datasource=custom.xcode depName=xcode versioning=loose
-          xcode-version: "26.5"
 
       - name: 🚀 Build iOS app
         env:

--- a/.github/workflows/check-lockfile.yml
+++ b/.github/workflows/check-lockfile.yml
@@ -25,7 +25,6 @@ jobs:
               ref: ${{ github.event.pull_request.head.sha || github.sha }}
               show-progress: false
               submodules: recursive
-              fetch-depth: 0
 
           - name: 🍞 Setup Bun
             uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/check-lockfile.yml
+++ b/.github/workflows/check-lockfile.yml
@@ -18,19 +18,20 @@ jobs:
       contents: read
 
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          show-progress: false
-          submodules: recursive
-          fetch-depth: 0
+      - parallel:
+          - name: 📥 Checkout repository
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              ref: ${{ github.event.pull_request.head.sha || github.sha }}
+              show-progress: false
+              submodules: recursive
+              fetch-depth: 0
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0

--- a/.github/workflows/detect-duplicate.yml
+++ b/.github/workflows/detect-duplicate.yml
@@ -20,14 +20,15 @@ jobs:
       issues: write
       contents: read
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - parallel:
+          - name: 📥 Checkout repository
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
 
       - name: 🔍 Detect duplicate issues
         run: bun scripts/detect-duplicate-issue.ts

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,7 +2,7 @@ name: 🚦 Security & Quality Gate
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
     branches: [develop, master]
   workflow_dispatch:
   push:
@@ -16,42 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate_pr_title:
-    name: "📝 Validate PR Title"
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-26.04
-    permissions:
-      pull-requests: write
-      contents: read
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        id: lint_pr_title
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
-        if: always() && (steps.lint_pr_title.outputs.error_message != null)
-        with:
-          header: pr-title-lint-error
-          message: |
-            Hey there and thank you for opening this pull request! 👋🏼
-            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
-
-            **Error details:**
-            ```
-            ${{ steps.lint_pr_title.outputs.error_message }}
-            ```
-
-      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
-        with:
-          header: pr-title-lint-error
-          delete: true
-
   dependency-review:
     name: 🔍 Vulnerable Dependencies
-    # PR title/body edits can't change the dependency graph — only re-run on code events.
-    if: github.event.action != 'edited'
     runs-on: ubuntu-26.04
     permissions:
       contents: read
@@ -71,8 +37,6 @@ jobs:
 
   expo-doctor:
     name: 🚑 Expo Doctor Check
-    # PR title/body edits can't change the project — only re-run on code events.
-    if: github.event.action != 'edited'
     runs-on: ubuntu-26.04
     steps:
       - parallel:
@@ -108,8 +72,6 @@ jobs:
 
   code_quality:
     name: "🔍 Lint & Test (${{ matrix.command }})"
-    # PR title/body edits can't change the code — only re-run on code events.
-    if: github.event.action != 'edited'
     runs-on: ubuntu-26.04
     strategy:
       fail-fast: false

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -45,7 +45,6 @@ jobs:
             with:
               ref: ${{ github.event.pull_request.head.sha || github.sha }}
               submodules: recursive
-              fetch-depth: 0
 
           - name: 🍞 Setup Bun
             uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -90,7 +89,6 @@ jobs:
             with:
               ref: ${{ github.event.pull_request.head.sha || github.sha }}
               submodules: recursive
-              fetch-depth: 0
 
           - name: "🍞 Setup Bun"
             uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate_pr_title:
     name: "📝 Validate PR Title"
@@ -46,6 +50,8 @@ jobs:
 
   dependency-review:
     name: 🔍 Vulnerable Dependencies
+    # PR title/body edits can't change the dependency graph — only re-run on code events.
+    if: github.event.action != 'edited'
     runs-on: ubuntu-26.04
     permissions:
       contents: read
@@ -65,20 +71,31 @@ jobs:
 
   expo-doctor:
     name: 🚑 Expo Doctor Check
+    # PR title/body edits can't change the project — only re-run on code events.
+    if: github.event.action != 'edited'
     runs-on: ubuntu-26.04
     steps:
-      - name: 🛒 Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          submodules: recursive
-          fetch-depth: 0
+      - parallel:
+          - name: 🛒 Checkout repository
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              ref: ${{ github.event.pull_request.head.sha || github.sha }}
+              submodules: recursive
+              fetch-depth: 0
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
+
+      - name: 💾 Cache Bun dependencies
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-bun-
 
       - name: 📦 Install dependencies (bun)
         run: bun install --frozen-lockfile
@@ -91,6 +108,8 @@ jobs:
 
   code_quality:
     name: "🔍 Lint & Test (${{ matrix.command }})"
+    # PR title/body edits can't change the code — only re-run on code events.
+    if: github.event.action != 'edited'
     runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
@@ -103,24 +122,27 @@ jobs:
           - "i18n:check"
 
     steps:
-      - name: "📥 Checkout PR code"
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          submodules: recursive
-          fetch-depth: 0
+      - parallel:
+          - name: "📥 Checkout PR code"
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              ref: ${{ github.event.pull_request.head.sha || github.sha }}
+              submodules: recursive
+              fetch-depth: 0
 
-      - name: "🟢 Setup Node.js"
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          # renovate: datasource=node-version depName=node versioning=node
-          node-version: "24.18.0"
+          - name: "🍞 Setup Bun"
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
 
-      - name: "🍞 Setup Bun"
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: 💾 Cache Bun dependencies
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-bun-
 
       - name: "📦 Install dependencies"
         run: bun install --frozen-lockfile

--- a/.github/workflows/pr-title-comment.yml
+++ b/.github/workflows/pr-title-comment.yml
@@ -1,0 +1,76 @@
+name: 📝 PR Title Comment
+
+# Posts / updates / deletes the PR-title lint sticky comment with a write token,
+# so it works on FORK PRs too (the pull_request-triggered pr-title.yml only has a
+# read-only token on forks). workflow_run runs from the base branch with the base
+# repo's token. This is comment-only — the required check stays pr-title.yml.
+on:
+  workflow_run:
+    workflows: ["📝 PR Title"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read # download the artifact from the triggering run
+  pull-requests: write # post/update/delete the sticky comment
+
+concurrency:
+  group: pr-title-comment-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-26.04
+    steps:
+      - name: ⬇️ Download lint result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download "${{ github.event.workflow_run.id }}" \
+            --repo "${{ github.repository }}" \
+            --name pr-title-result \
+            --dir result
+
+      - name: 🔎 Read result
+        id: result
+        run: |
+          echo "number=$(cat result/number)" >> "$GITHUB_OUTPUT"
+          if [ -s result/error ]; then
+            echo "has_error=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_error=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 📥 Load error message
+        if: steps.result.outputs.has_error == 'true'
+        run: |
+          {
+            echo "LINT_ERROR<<PR_TITLE_ERR_EOF"
+            cat result/error
+            echo
+            echo "PR_TITLE_ERR_EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: 💬 Post title error
+        if: steps.result.outputs.has_error == 'true'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          number: ${{ steps.result.outputs.number }}
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+
+            **Error details:**
+            ```
+            ${{ env.LINT_ERROR }}
+            ```
+
+      - name: 🧹 Clear title error
+        if: steps.result.outputs.has_error == 'false'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          number: ${{ steps.result.outputs.number }}
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,30 +16,27 @@ jobs:
   validate_pr_title:
     name: "📝 Validate PR Title"
     runs-on: ubuntu-26.04
-    permissions:
-      pull-requests: write
-      contents: read
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
-        if: always() && (steps.lint_pr_title.outputs.error_message != null)
-        with:
-          header: pr-title-lint-error
-          message: |
-            Hey there and thank you for opening this pull request! 👋🏼
-            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+      # Fork PRs only get a read-only GITHUB_TOKEN here, so the sticky comment
+      # is posted from the privileged pr-title-comment.yml (workflow_run). Hand
+      # off the result (PR number + lint error) as an artifact for it to read.
+      - if: always()
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LINT_ERROR: ${{ steps.lint_pr_title.outputs.error_message }}
+        run: |
+          mkdir -p pr-title-result
+          printf '%s' "$PR_NUMBER" > pr-title-result/number
+          printf '%s' "$LINT_ERROR" > pr-title-result/error
 
-            **Error details:**
-            ```
-            ${{ steps.lint_pr_title.outputs.error_message }}
-            ```
-
-      - if: ${{ success() && steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          header: pr-title-lint-error
-          delete: true
+          name: pr-title-result
+          path: pr-title-result/
+          retention-days: 1

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,45 @@
+name: 📝 PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [develop, master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate_pr_title:
+    name: "📝 Validate PR Title"
+    runs-on: ubuntu-26.04
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
+
+            **Error details:**
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,15 +1,21 @@
 name: 📝 PR Title
 
+# pull_request_target so fork PRs get a write token — this workflow only reads
+# the PR title and posts/updates a sticky comment; it never checks out or runs
+# PR code, so it is not exposed to the usual _target code-execution risk.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
     branches: [develop, master]
 
 permissions:
   contents: read
 
+# Key on the PR number, not github.ref: under pull_request_target github.ref is
+# the base branch (shared by every PR), which would collapse all PRs into one
+# group and cross-cancel their title checks.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -38,7 +44,7 @@ jobs:
             ${{ steps.lint_pr_title.outputs.error_message }}
             ```
 
-      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+      - if: ${{ success() && steps.lint_pr_title.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: pr-title-lint-error

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,19 +1,13 @@
 name: 📝 PR Title
 
-# pull_request_target so fork PRs get a write token — this workflow only reads
-# the PR title and posts/updates a sticky comment; it never checks out or runs
-# PR code, so it is not exposed to the usual _target code-execution risk.
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
     branches: [develop, master]
 
 permissions:
   contents: read
 
-# Key on the PR number, not github.ref: under pull_request_target github.ref is
-# the base branch (shared by every PR), which would collapse all PRs into one
-# group and cross-cancel their title checks.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
               bun-version: "1.3.14"
 
           - name: 🏗️ Setup EAS
-            uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9.0.0
+            uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # main
             with:
               eas-version: latest
               token: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ name: 🚀 Release (EAS build + submit)
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
+  # Queue successive releases in order instead of dropping the extra pending run.
+  queue: max
 
 on:
   push:
@@ -63,18 +65,26 @@ jobs:
             artifact_name: streamyfin-android-tv-apk
 
     steps:
-      - name: 📥 Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-          submodules: recursive
-          show-progress: false
+      - parallel:
+          - name: 📥 Checkout code
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              fetch-depth: 0
+              submodules: recursive
+              show-progress: false
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
+
+          - name: 🏗️ Setup EAS
+            uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9.0.0
+            with:
+              eas-version: latest
+              token: ${{ secrets.EXPO_TOKEN }}
+              eas-cache: true
 
       - name: 💾 Cache Bun dependencies
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
@@ -88,13 +98,6 @@ jobs:
         run: |
           bun install --frozen-lockfile
           bun run submodule-reload
-
-      - name: 🏗️ Setup EAS
-        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # main
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-          eas-cache: true
 
       # tvOS uses credentialsSource: local — restore the gitignored
       # credentials.json + cert + provisioning profiles from secrets.

--- a/.github/workflows/update-issue-form.yml
+++ b/.github/workflows/update-issue-form.yml
@@ -25,19 +25,20 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # On `release` events GITHUB_SHA is the tagged commit — without this the
-          # script would regenerate the form from the tag's (stale) copy and the bot
-          # PR would revert any form edits made on develop since that release.
-          ref: develop
+      - parallel:
+          - name: 📥 Checkout repository
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            with:
+              # On `release` events GITHUB_SHA is the tagged commit — without this the
+              # script would regenerate the form from the tag's (stale) copy and the bot
+              # PR would revert any form edits made on develop since that release.
+              ref: develop
 
-      - name: 🍞 Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          # renovate: datasource=npm depName=bun
-          bun-version: "1.3.14"
+          - name: 🍞 Setup Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+            with:
+              # renovate: datasource=npm depName=bun
+              bun-version: "1.3.14"
 
       - name: 🔢 Populate version dropdown from GitHub releases
         id: populate


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Adopt the new GitHub Actions **parallel steps** feature ([changelog, 2026-06-25](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/)) across our workflows, inspired by [seerr-team/seerr#3225](https://github.com/seerr-team/seerr/pull/3225): independent setup steps (checkout, Bun/JDK/Xcode toolchains, EAS CLI install, disk-space cleanup, cache restores) now run concurrently instead of sequentially. Only genuinely independent steps are grouped — anything that reads the workspace or consumes a previous step's output stays sequential.

On the iOS jobs this also fixes a real ordering issue: `Setup Xcode` and `Setup EAS` used to run **after** the ~2 min `prebuild` step despite not depending on it.

While auditing every workflow for this, three more observed issues are fixed:

- **`linting.yml` ran its full 8-job gate twice per commit** on Renovate PRs (no `concurrency` group — see runs [28706325660](https://github.com/streamyfin/streamyfin/actions/runs/28706325660) + [28706325098](https://github.com/streamyfin/streamyfin/actions/runs/28706325098)), and re-ran everything on PR **title/body edits** (the `edited` trigger is only needed by the PR-title check). A concurrency group now cancels superseded runs, the missing Bun cache is added (consistent with the other workflows), and the unused `setup-node` step is dropped (everything runs through Bun).
- **PR title validation moved to its own workflow (`pr-title.yml`)**, the only one listening to `edited`. Gating the heavy jobs with a job-level `if: action != 'edited'` (this PR's first iteration) had two side effects: skipped matrix jobs surfaced as a literal `${{ matrix.command }}` check name with required checks stuck in *Expected*, and a title edit could cancel an in-flight code run through the shared concurrency group (also flagged by Copilot's review). Filtering at the trigger level removes the phantom run entirely; the check names and the ruleset are unchanged.
- **`release.yml`**: successive releases now queue in order (`queue: max`, [changelog 2026-05-07](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/)) instead of dropping the extra pending run.

Also trimmed: lint/lockfile jobs no longer fetch the full git history (`fetch-depth: 0` → shallow clone). Biome, `tsc` and the i18n/lockfile scripts only read the working tree — verified: no `vcs` block in `biome.json`, no git usage in the scripts. `dependency-review` and the build jobs keep their full fetch.

### ⚠️ Note for reviewers: expected false positives

`actionlint` (≤ 1.7.12) and the CodeQL `actions` pack don't know the `parallel:` keyword yet and may flag it as a syntax error. These are **tooling false positives** — the exact same pattern runs green on seerr's CI and GitHub's runner accepts it natively (see their PR's checks). The real proof is this PR's own checks.

`release.yml`, `crowdin.yml`, `update-issue-form.yml` and `notification.yml` are **not exercised** by PR events — the `release.yml` changes were reviewed line-by-line but only run on the next release.

## 📊 Benchmark (before / after)

**Before** = median of recent successful runs on develop/PRs (evidence run IDs linked). **After** = this PR's runs (run 1 = [28725605278](https://github.com/streamyfin/streamyfin/actions/runs/28725605278), run 2 = [28741921414](https://github.com/streamyfin/streamyfin/actions/runs/28741921414); run 2 also includes the shallow-clone commit).

| Workflow · Job | Before (median) | After (run 1) | After (run 2) | Evidence (before) |
|---|---|---|---|---|
| build-apps · 🍎 iOS Phone (signed) | ~26 min | 21 min 11 s | 14 min 56 s | [28723942596](https://github.com/streamyfin/streamyfin/actions/runs/28723942596), [28704822082](https://github.com/streamyfin/streamyfin/actions/runs/28704822082) |
| build-apps · 🤖 Android TV | ~21 min 20 s | 21 min 31 s | 21 min 27 s | same runs |
| build-apps · 🍎 iOS Phone (unsigned) | ~17 min | 22 min 10 s | 12 min 49 s | same runs |
| build-apps · 🤖 Android Phone | ~15 min 40 s | 16 min 21 s | 15 min 26 s | same runs |
| build-apps · 🍎 tvOS (unsigned) | ~11 min 40 s | 13 min 38 s | 11 min 59 s | same runs |
| linting · wall clock | ~30-35 s (**×2 per commit** on Renovate PRs) | ~37 s (single run) | ~26 s (single run) | [28724632314](https://github.com/streamyfin/streamyfin/actions/runs/28724632314), [28706325660](https://github.com/streamyfin/streamyfin/actions/runs/28706325660) |
| check-lockfile | ~24 s | 15 s | 10 s | [28724632330](https://github.com/streamyfin/streamyfin/actions/runs/28724632330) |

Benchmark caveats, read before judging the numbers: (1) PR runs restore caches written by develop — a key miss makes a PR run slower than a warm develop run, so definitive numbers come from develop runs post-merge; (2) macOS runner variance dominates the build jobs (the setup phase this PR parallelizes is ~1-3 min of a 15-25 min job — iOS unsigned/tvOS being slower on run 1 is noise, not regression).

Honest expectations: the native compile steps dominate the build jobs (~87-93 % of job time), so parallel steps shave the setup phase (~5-40 s per job), not the build itself. The structural wins are the linting dedup (halves gate runs on Renovate PRs), the un-blocked iOS toolchain setup, and title edits no longer spawning (or cancelling!) full gate runs. Native build caching was evaluated and deliberately rejected: it doesn't fit the 10 GB repo cache budget.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms (CI-only change — this PR's own checks are the verification)
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Check this PR's own workflow runs: every job that runs on PRs (build-apps ×5, linting, check-lockfile, CodeQL, Trivy) must be green.
2. Open any build job → the grouped setup steps now show as parallel step groups in the log timeline.
3. Compare job durations with the "before" table above (the description will be updated with the measured "after" values).
4. Edit this PR's title → only the `📝 PR Title` workflow runs; the gate workflow is not triggered at all (no skipped jobs, no broken matrix check names, no cancelled in-flight runs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated PR title follow-up workflow that posts a sticky comment with any lint error, or clears it when the title is valid.
* **Bug Fixes**
  * Improved CI/release reliability with stricter concurrency (cancel overlapping runs; queue releases instead of dropping them).
  * Reordered mobile and release pipeline setup to run preparation steps more efficiently.
* **Chores**
  * Streamlined multiple automation workflows by running checkout and Bun setup in parallel, adding/refreshing Bun caching, and improving lockfile consistency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->