### PR TITLE
fix(tv): re-negotiate the stream when changing audio track while transcoding

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -893,6 +893,22 @@ export default function DirectPlayerPage() {
       // Check if we're transcoding
       const isTranscoding = Boolean(stream?.mediaSource?.TranscodingUrl);
 
+      // A transcoded stream only carries the audio track the server encoded
+      // into it — switching requires re-negotiating the stream with the new
+      // index (like the mobile menu's replacePlayer), not an mpv aid change.
+      if (isTranscoding) {
+        const queryParams = new URLSearchParams({
+          itemId: item?.Id ?? "",
+          audioIndex: String(index),
+          subtitleIndex: String(currentSubtitleIndex),
+          mediaSourceId: stream?.mediaSource?.Id ?? "",
+          bitrateValue: bitrateValue?.toString() ?? "",
+          playbackPosition: msToTicks(progress.get()).toString(),
+        }).toString();
+        router.replace(`player/direct-player?${queryParams}` as any);
+        return;
+      }
+
       // Convert Jellyfin index to MPV track ID
       const mpvTrackId = getMpvAudioId(
         stream?.mediaSource,
@@ -904,7 +920,14 @@ export default function DirectPlayerPage() {
         await videoRef.current?.setAudioTrack?.(mpvTrackId);
       }
     },
-    [stream?.mediaSource],
+    [
+      stream?.mediaSource,
+      item?.Id,
+      currentSubtitleIndex,
+      bitrateValue,
+      router,
+      progress,
+    ],
   );
 
   // TV subtitle track change handler

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -905,6 +905,11 @@ export default function DirectPlayerPage() {
           bitrateValue: bitrateValue?.toString() ?? "",
           playbackPosition: msToTicks(progress.get()).toString(),
         }).toString();
+        // Destroy the current mpv instance BEFORE navigating, same rationale as
+        // goToNextItem/goToPreviousItem: Expo Router briefly holds two players
+        // during the transition, and two simultaneous decoders OOM-kill low-RAM
+        // devices. Resume is preserved via the playbackPosition param.
+        videoRef.current?.destroy().catch(() => {});
         router.replace(`player/direct-player?${queryParams}` as any);
         return;
       }

--- a/app/(auth)/tv-option-modal.tsx
+++ b/app/(auth)/tv-option-modal.tsx
@@ -76,13 +76,23 @@ export default function TVOptionModal() {
   }, [isReady]);
 
   const handleSelect = (value: any) => {
-    // Close FIRST, run the callback after this modal route is dismissed: an
-    // onSelect that navigates (e.g. the transcode audio switch replacing the
-    // player) would otherwise target the MODAL route and be swallowed.
-    const onSelect = modalState?.onSelect;
+    if (modalState?.deferApplyUntilDismissed) {
+      // onSelect navigates (the transcode audio switch replacing the player);
+      // a router.replace fired while this modal is the active route would be
+      // swallowed. Close FIRST, apply after dismissal.
+      const onSelect = modalState.onSelect;
+      store.set(tvOptionModalAtom, null);
+      router.back();
+      InteractionManager.runAfterInteractions(() => onSelect?.(value));
+      return;
+    }
+    // State-only callers (detail page, library filters, settings): run before
+    // closing so the re-render happens while the modal is up. Deferring it until
+    // after dismissal re-renders the page after focus returns and yanks TV
+    // focus, leaving navigation stuck.
+    modalState?.onSelect(value);
     store.set(tvOptionModalAtom, null);
     router.back();
-    InteractionManager.runAfterInteractions(() => onSelect?.(value));
   };
 
   const handleClose = useCallback(() => {

--- a/app/(auth)/tv-option-modal.tsx
+++ b/app/(auth)/tv-option-modal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Animated,
   Easing,
+  InteractionManager,
   ScrollView,
   StyleSheet,
   TVFocusGuideView,
@@ -75,9 +76,13 @@ export default function TVOptionModal() {
   }, [isReady]);
 
   const handleSelect = (value: any) => {
-    modalState?.onSelect(value);
+    // Close FIRST, run the callback after this modal route is dismissed: an
+    // onSelect that navigates (e.g. the transcode audio switch replacing the
+    // player) would otherwise target the MODAL route and be swallowed.
+    const onSelect = modalState?.onSelect;
     store.set(tvOptionModalAtom, null);
     router.back();
+    InteractionManager.runAfterInteractions(() => onSelect?.(value));
   };
 
   const handleClose = useCallback(() => {

--- a/components/video-player/controls/Controls.tv.tsx
+++ b/components/video-player/controls/Controls.tv.tsx
@@ -564,6 +564,9 @@ export const Controls: FC<Props> = ({
       title: t("item_card.audio"),
       options: audioOptions,
       onSelect: handleAudioChange,
+      // In-player audio selection navigates (replacePlayer while transcoding);
+      // apply it after the modal is dismissed so it isn't swallowed.
+      deferApplyUntilDismissed: true,
     });
     controlsInteractionRef.current();
   }, [showOptions, t, audioOptions, handleAudioChange]);

--- a/hooks/useTVOptionModal.ts
+++ b/hooks/useTVOptionModal.ts
@@ -12,6 +12,7 @@ interface ShowOptionsParams<T> {
   onSelect: (value: T) => void;
   cardWidth?: number;
   cardHeight?: number;
+  deferApplyUntilDismissed?: boolean;
 }
 
 export const useTVOptionModal = () => {
@@ -26,6 +27,7 @@ export const useTVOptionModal = () => {
         onSelect: params.onSelect,
         cardWidth: params.cardWidth,
         cardHeight: params.cardHeight,
+        deferApplyUntilDismissed: params.deferApplyUntilDismissed,
       });
       router.push("/(auth)/tv-option-modal");
     },

--- a/utils/atoms/tvOptionModal.ts
+++ b/utils/atoms/tvOptionModal.ts
@@ -13,6 +13,15 @@ export type TVOptionModalState = {
   onSelect: (value: any) => void;
   cardWidth?: number;
   cardHeight?: number;
+  /**
+   * Run onSelect AFTER the modal route is dismissed. Needed only when onSelect
+   * navigates (the in-player audio switch replacing the player while
+   * transcoding), which the still-active modal route would otherwise swallow.
+   * Default (false) runs onSelect before closing, so state-only callers (detail
+   * page, library filters, settings) don't re-render after focus returns and
+   * lose TV focus.
+   */
+  deferApplyUntilDismissed?: boolean;
 } | null;
 
 export const tvOptionModalAtom = atom<TVOptionModalState>(null);


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

On TV, changing the audio track from the in-player menu **while transcoding** did nothing. Root cause + two follow-on fixes for the shared TV option modal:

1. **`handleAudioIndexChange` only set the mpv `aid`.** A transcoded stream carries only the audio track the server encoded into it, so there's nothing to switch to inside the player. It now **re-negotiates the stream** with the new `AudioStreamIndex` (resuming at the live position), exactly like the mobile in-player menu (`VideoContext.replacePlayer`) already does. Direct play keeps the instant `aid` switch.
2. **The re-navigation was swallowed by the modal route.** `tv-option-modal` is a separate route; running the selection callback *before* it closed meant the `router.replace` targeted the modal and was dropped. The navigating selection now runs **after** the modal is dismissed (`InteractionManager.runAfterInteractions`).
3. **…but that deferral must be opt-in.** `tv-option-modal` is shared by many callers whose selection only updates state — the **item-detail audio selector, library filters, and settings**. Deferring *those* until after dismissal re-renders the page after focus returns and leaves the TV remote stuck. The deferral is now gated behind `deferApplyUntilDismissed`, set **only** by the in-player audio caller; everyone else applies before closing, as on `develop`, preserving focus.

Also destroys the mpv instance before the re-negotiation `router.replace` (matching `goToNextItem`), so two decoders/surfaces don't overlap and OOM low-RAM devices.

Verified live on the Android TV emulator: before, switching FR → ENG while transcoding did nothing; after, the stream restarts with `AudioStreamIndex=2` (checked in the logs) and English audio plays; direct-play switching still works instantly without a reload; and detail-page / filter / settings option menus stay focus-responsive after a selection. tvOS shares this exact code path (no platform fork).

## 🏷️ Ticket / Issue

Fixes #1790

### 🖼️ Screenshots / GIFs (if UI)

N/A — behavior fix, no UI change.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms (Android TV emulator live; tvOS shares the same code path; mobile path untouched)
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (badge at the top)

## 🔍 Testing Instructions

**Audio switch while transcoding (the fix):**
1. On Android TV, play a media with at least two audio tracks.
2. Force a transcode: player quality menu → pick a low bitrate (below the source bitrate).
3. Open the audio menu with the remote and select the other track → the stream reloads and the audio switches (before this fix: nothing happened).
4. Non-regression: switch back to max quality (direct play) and change the audio track again → it switches instantly, without a reload.

**Focus (the option-modal guard):**
5. On the item detail page, open the **audio** selector and pick an option → the page stays navigable (focus not lost).
6. In a library, open a **filter** (genre / year / sort) and pick a value → focus stays responsive. Same for a **settings** option list.
</content>
