### PR TITLE
fix(network): reject stale/overlapping reachability checks

### DIFF
--- a/providers/NetworkStatusProvider.tsx
+++ b/providers/NetworkStatusProvider.tsx
@@ -87,7 +87,14 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
   }, [validateConnection]);
 
   useEffect(() => {
+    // Guards against a NetInfo.fetch() promise from this effect run resolving
+    // after api/customHeadersVersion changed and this effect was cleaned up: its
+    // captured validateConnection() closure would otherwise still probe the stale
+    // URL/headers, bump the version counter for itself, and win the race.
+    let isActive = true;
+
     const unsubscribe = NetInfo.addEventListener(async (state) => {
+      if (!isActive) return;
       setIsConnected(!!state.isConnected);
       if (state.isConnected) {
         await validateConnection();
@@ -99,6 +106,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
 
     // Initial check
     NetInfo.fetch().then((state) => {
+      if (!isActive) return;
       if (state.isConnected) {
         validateConnection();
       } else {
@@ -107,7 +115,10 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
       }
     });
 
-    return () => unsubscribe();
+    return () => {
+      isActive = false;
+      unsubscribe();
+    };
   }, [validateConnection]);
 
   // Refetch active queries when server becomes reachable

--- a/providers/NetworkStatusProvider.tsx
+++ b/providers/NetworkStatusProvider.tsx
@@ -62,12 +62,12 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
   // result with an outdated one.
   const validationVersionRef = useRef(0);
 
-  // Invalidate in-flight checks as soon as the active API changes, rather than
-  // waiting for the next validateConnection() call to start — a check for the
-  // previous URL can otherwise resolve and win the race before that happens.
+  // Invalidate in-flight checks as soon as the active API or custom headers change,
+  // rather than waiting for the next validateConnection() call to start — a check
+  // using the previous URL/headers can otherwise resolve and win the race first.
   useEffect(() => {
     validationVersionRef.current += 1;
-  }, [api]);
+  }, [api, customHeadersVersion]);
 
   const validateConnection = useCallback(async () => {
     const validationVersion = ++validationVersionRef.current;

--- a/providers/NetworkStatusProvider.tsx
+++ b/providers/NetworkStatusProvider.tsx
@@ -58,8 +58,16 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
   const wasServerConnected = useRef<boolean | null>(null);
 
   // Guards against a stale or overlapping check (e.g. two checks in flight for the
-  // same basePath) overwriting a newer result with an outdated one.
+  // same basePath, or the active API URL changing mid-check) overwriting a newer
+  // result with an outdated one.
   const validationVersionRef = useRef(0);
+
+  // Invalidate in-flight checks as soon as the active API changes, rather than
+  // waiting for the next validateConnection() call to start — a check for the
+  // previous URL can otherwise resolve and win the race before that happens.
+  useEffect(() => {
+    validationVersionRef.current += 1;
+  }, [api]);
 
   const validateConnection = useCallback(async () => {
     const validationVersion = ++validationVersionRef.current;

--- a/providers/NetworkStatusProvider.tsx
+++ b/providers/NetworkStatusProvider.tsx
@@ -57,10 +57,17 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
   const wasServerConnected = useRef<boolean | null>(null);
 
+  // Guards against a stale or overlapping check (e.g. two checks in flight for the
+  // same basePath) overwriting a newer result with an outdated one.
+  const validationVersionRef = useRef(0);
+
   const validateConnection = useCallback(async () => {
+    const validationVersion = ++validationVersionRef.current;
     if (!api?.basePath) return false;
     const reachable = await checkApiReachable(api.basePath);
-    setServerConnected(reachable);
+    if (validationVersion === validationVersionRef.current) {
+      setServerConnected(reachable);
+    }
     return reachable;
     // customHeadersVersion: re-probe with the headers the user just saved.
   }, [api?.basePath, customHeadersVersion]);
@@ -77,6 +84,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
       if (state.isConnected) {
         await validateConnection();
       } else {
+        validationVersionRef.current += 1;
         setServerConnected(false);
       }
     });
@@ -86,6 +94,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
       if (state.isConnected) {
         validateConnection();
       } else {
+        validationVersionRef.current += 1;
         setServerConnected(false);
       }
     });

--- a/providers/NetworkStatusProvider.tsx
+++ b/providers/NetworkStatusProvider.tsx
@@ -163,7 +163,12 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
   }, [api, validateConnection]);
 
   useEffect(() => {
+    let isActive = true;
+    let receivedSubscriptionState = false;
+
     const unsubscribe = NetInfo.addEventListener(async (state) => {
+      if (!isActive) return;
+      receivedSubscriptionState = true;
       setIsConnected(state.isConnected ?? false);
       if (state.isConnected) {
         await validateConnectionRef.current();
@@ -175,6 +180,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
 
     // Initial check
     NetInfo.fetch().then((state) => {
+      if (!isActive || receivedSubscriptionState) return;
       if (state.isConnected) {
         validateConnectionRef.current();
       } else {
@@ -183,7 +189,10 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
       }
     });
 
-    return () => unsubscribe();
+    return () => {
+      isActive = false;
+      unsubscribe();
+    };
   }, []);
 
   // Refetch active queries when server becomes reachable

--- a/providers/NetworkStatusProvider.tsx
+++ b/providers/NetworkStatusProvider.tsx
@@ -23,6 +23,13 @@ const NetworkStatusContext = createContext<NetworkStatusContextType | null>(
   null,
 );
 
+/**
+ * Verifies if the Jellyfin server API is reachable by performing a HEAD request.
+ * Discards requests that exceed a 5-second timeout limit.
+ *
+ * @param basePath - The base URL of the Jellyfin server.
+ * @returns A promise resolving to true if reachable, false otherwise.
+ */
 async function checkApiReachable(basePath?: string): Promise<boolean> {
   if (!basePath) return false;
   const controller = new AbortController();
@@ -41,6 +48,10 @@ async function checkApiReachable(basePath?: string): Promise<boolean> {
   }
 }
 
+/**
+ * Provider component that monitors and broadcasts device internet connection and Jellyfin server status.
+ * Handles automatic re-checking when NetInfo detects connectivity status changes.
+ */
 export function NetworkStatusProvider({ children }: { children: ReactNode }) {
   const [isConnected, setIsConnected] = useState(true);
   const [serverConnected, setServerConnected] = useState<boolean | null>(true);
@@ -50,15 +61,22 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
   const wasServerConnected = useRef<boolean | null>(null);
 
   const apiRef = useRef(api);
+  const validationVersionRef = useRef(0);
+
   useEffect(() => {
     apiRef.current = api;
+    validationVersionRef.current += 1;
   }, [api]);
 
   const validateConnection = useCallback(async () => {
+    const validationVersion = ++validationVersionRef.current;
     if (!api?.basePath) return false;
     const checkPath = api.basePath;
     const reachable = await checkApiReachable(checkPath);
-    if (apiRef.current?.basePath === checkPath) {
+    if (
+      validationVersion === validationVersionRef.current &&
+      apiRef.current?.basePath === checkPath
+    ) {
       setServerConnected(reachable);
     }
     return reachable;
@@ -76,6 +94,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
       if (state.isConnected) {
         await validateConnection();
       } else {
+        validationVersionRef.current += 1;
         setServerConnected(false);
       }
     });
@@ -85,6 +104,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
       if (state.isConnected) {
         validateConnection();
       } else {
+        validationVersionRef.current += 1;
         setServerConnected(false);
       }
     });
@@ -109,6 +129,12 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
   );
 }
 
+/**
+ * Hook to retrieve the current network connection and server reachability status.
+ * Must be used within a NetworkStatusProvider.
+ *
+ * @returns The current NetworkStatusContext value.
+ */
 export function useNetworkStatus(): NetworkStatusContextType {
   const context = useContext(NetworkStatusContext);
   if (!context) {

--- a/providers/NetworkStatusProvider.tsx
+++ b/providers/NetworkStatusProvider.tsx
@@ -11,7 +11,9 @@ import {
   useRef,
   useState,
 } from "react";
-import { apiAtom } from "@/providers/JellyfinProvider";
+import { apiAtom, useJellyfin } from "@/providers/JellyfinProvider";
+import { storage } from "@/utils/mmkv";
+import { getServerLocalConfig } from "@/utils/secureCredentials";
 
 interface NetworkStatusContextType {
   isConnected: boolean;
@@ -35,9 +37,11 @@ const NetworkStatusContext = createContext<NetworkStatusContextType | null>(
 async function checkApiReachable(api: Api, basePath: string): Promise<boolean> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
+  const cleanPath = basePath.endsWith("/") ? basePath.slice(0, -1) : basePath;
+  const url = `${cleanPath}/System/Info/Public`;
+
   try {
-    const url = basePath.endsWith("/") ? basePath : `${basePath}/`;
-    const response = await api.axiosInstance.head(url, {
+    const response = await api.axiosInstance.get(url, {
       signal: controller.signal,
       timeout: 5000,
     });
@@ -45,11 +49,27 @@ async function checkApiReachable(api: Api, basePath: string): Promise<boolean> {
     return response.status >= 200 && response.status < 300;
   } catch (error: any) {
     clearTimeout(timeoutId);
+
     // If the server responded with any status code, it is reachable
     if (error?.response) {
       return true;
     }
-    return false;
+
+    // Fallback to fetch in case Axios/XHR had issues with local certificates/network layers
+    try {
+      const fetchController = new AbortController();
+      const fetchTimeoutId = setTimeout(() => fetchController.abort(), 5000);
+      const response = await fetch(url, {
+        method: "GET",
+        signal: fetchController.signal,
+      });
+      clearTimeout(fetchTimeoutId);
+
+      // Any response (even if non-2xx status code like 401/403) means the server is reachable
+      return response.ok || response.status === 401 || response.status === 403;
+    } catch {
+      return false;
+    }
   }
 }
 
@@ -62,6 +82,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
   const [serverConnected, setServerConnected] = useState<boolean | null>(true);
   const [loading, setLoading] = useState(false);
   const [api] = useAtom(apiAtom);
+  const { switchServerUrl } = useJellyfin();
   const queryClient = useQueryClient();
   const wasServerConnected = useRef<boolean | null>(null);
 
@@ -77,15 +98,50 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
     const validationVersion = ++validationVersionRef.current;
     if (!api?.basePath) return false;
     const checkPath = api.basePath;
-    const reachable = await checkApiReachable(api, checkPath);
+    let reachable = await checkApiReachable(api, checkPath);
+
+    // Fallback: If unreachable, check if we have a local URL configured and try that as well
+    if (!reachable) {
+      const remoteUrl = storage.getString("serverUrl");
+      if (remoteUrl) {
+        const config = getServerLocalConfig(remoteUrl);
+        if (config?.enabled && config.localUrl) {
+          // Normalize URLs by stripping trailing slashes
+          const normalizedLocal = config.localUrl.endsWith("/")
+            ? config.localUrl.slice(0, -1)
+            : config.localUrl;
+          const normalizedCurrent = checkPath.endsWith("/")
+            ? checkPath.slice(0, -1)
+            : checkPath;
+          const normalizedRemote = remoteUrl.endsWith("/")
+            ? remoteUrl.slice(0, -1)
+            : remoteUrl;
+
+          // If current is remote, try local. If current is local, try remote (in case we moved away from home)
+          const fallbackUrl =
+            normalizedCurrent === normalizedRemote
+              ? normalizedLocal
+              : normalizedRemote;
+
+          if (normalizedCurrent !== fallbackUrl) {
+            const fallbackReachable = await checkApiReachable(api, fallbackUrl);
+            if (fallbackReachable) {
+              switchServerUrl(fallbackUrl);
+              reachable = true;
+            }
+          }
+        }
+      }
+    }
+
     if (
       validationVersion === validationVersionRef.current &&
-      apiRef.current?.basePath === checkPath
+      apiRef.current?.basePath === api.basePath
     ) {
       setServerConnected(reachable);
     }
     return reachable;
-  }, [api, api?.basePath]);
+  }, [api, api?.basePath, switchServerUrl]);
 
   const retryCheck = useCallback(async () => {
     setLoading(true);
@@ -93,11 +149,24 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
     setLoading(false);
   }, [validateConnection]);
 
+  const validateConnectionRef = useRef(validateConnection);
+
+  useEffect(() => {
+    validateConnectionRef.current = validateConnection;
+  }, [validateConnection]);
+
+  // Run validation check when api changes
+  useEffect(() => {
+    if (api?.basePath) {
+      validateConnection();
+    }
+  }, [api, validateConnection]);
+
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener(async (state) => {
       setIsConnected(state.isConnected ?? false);
       if (state.isConnected) {
-        await validateConnection();
+        await validateConnectionRef.current();
       } else {
         validationVersionRef.current += 1;
         setServerConnected(false);
@@ -107,7 +176,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
     // Initial check
     NetInfo.fetch().then((state) => {
       if (state.isConnected) {
-        validateConnection();
+        validateConnectionRef.current();
       } else {
         validationVersionRef.current += 1;
         setServerConnected(false);
@@ -115,7 +184,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
     });
 
     return () => unsubscribe();
-  }, [validateConnection]);
+  }, []);
 
   // Refetch active queries when server becomes reachable
   useEffect(() => {

--- a/providers/NetworkStatusProvider.tsx
+++ b/providers/NetworkStatusProvider.tsx
@@ -25,11 +25,18 @@ const NetworkStatusContext = createContext<NetworkStatusContextType | null>(
 
 async function checkApiReachable(basePath?: string): Promise<boolean> {
   if (!basePath) return false;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
   try {
     const url = basePath.endsWith("/") ? basePath : `${basePath}/`;
-    const response = await fetch(url, { method: "HEAD" });
+    const response = await fetch(url, {
+      method: "HEAD",
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
     return response.ok;
   } catch {
+    clearTimeout(timeoutId);
     return false;
   }
 }
@@ -42,10 +49,18 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
   const wasServerConnected = useRef<boolean | null>(null);
 
+  const apiRef = useRef(api);
+  useEffect(() => {
+    apiRef.current = api;
+  }, [api]);
+
   const validateConnection = useCallback(async () => {
     if (!api?.basePath) return false;
-    const reachable = await checkApiReachable(api.basePath);
-    setServerConnected(reachable);
+    const checkPath = api.basePath;
+    const reachable = await checkApiReachable(checkPath);
+    if (apiRef.current?.basePath === checkPath) {
+      setServerConnected(reachable);
+    }
     return reachable;
   }, [api?.basePath]);
 
@@ -57,7 +72,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener(async (state) => {
-      setIsConnected(!!state.isConnected);
+      setIsConnected(state.isConnected ?? false);
       if (state.isConnected) {
         await validateConnection();
       } else {

--- a/providers/NetworkStatusProvider.tsx
+++ b/providers/NetworkStatusProvider.tsx
@@ -1,3 +1,4 @@
+import type { Api } from "@jellyfin/sdk";
 import NetInfo from "@react-native-community/netinfo";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAtom } from "jotai";
@@ -27,23 +28,27 @@ const NetworkStatusContext = createContext<NetworkStatusContextType | null>(
  * Verifies if the Jellyfin server API is reachable by performing a HEAD request.
  * Discards requests that exceed a 5-second timeout limit.
  *
+ * @param api - The Jellyfin API client instance.
  * @param basePath - The base URL of the Jellyfin server.
  * @returns A promise resolving to true if reachable, false otherwise.
  */
-async function checkApiReachable(basePath?: string): Promise<boolean> {
-  if (!basePath) return false;
+async function checkApiReachable(api: Api, basePath: string): Promise<boolean> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
   try {
     const url = basePath.endsWith("/") ? basePath : `${basePath}/`;
-    const response = await fetch(url, {
-      method: "HEAD",
+    const response = await api.axiosInstance.head(url, {
       signal: controller.signal,
+      timeout: 5000,
     });
     clearTimeout(timeoutId);
-    return response.ok;
-  } catch {
+    return response.status >= 200 && response.status < 300;
+  } catch (error: any) {
     clearTimeout(timeoutId);
+    // If the server responded with any status code, it is reachable
+    if (error?.response) {
+      return true;
+    }
     return false;
   }
 }
@@ -72,7 +77,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
     const validationVersion = ++validationVersionRef.current;
     if (!api?.basePath) return false;
     const checkPath = api.basePath;
-    const reachable = await checkApiReachable(checkPath);
+    const reachable = await checkApiReachable(api, checkPath);
     if (
       validationVersion === validationVersionRef.current &&
       apiRef.current?.basePath === checkPath
@@ -80,7 +85,7 @@ export function NetworkStatusProvider({ children }: { children: ReactNode }) {
       setServerConnected(reachable);
     }
     return reachable;
-  }, [api?.basePath]);
+  }, [api, api?.basePath]);
 
   const retryCheck = useCallback(async () => {
     setLoading(true);

--- a/scripts/update-issue-form.mjs
+++ b/scripts/update-issue-form.mjs
@@ -85,7 +85,7 @@ const optIdx = lines.findIndex(
 if (optIdx === -1)
   throw new Error(`options: not found after id: ${DROPDOWN_ID}`);
 
-const itemIndent = lines[optIdx].match(/^\s*/)[0] + "  "; // options items are nested one level deeper
+const itemIndent = `${lines[optIdx].match(/^\s*/)[0]}  `; // options items are nested one level deeper
 let end = optIdx + 1;
 const sentinels = [];
 while (end < lines.length && /^\s*-\s+/.test(lines[end])) {

--- a/scripts/update-issue-form.mjs
+++ b/scripts/update-issue-form.mjs
@@ -85,7 +85,7 @@ const optIdx = lines.findIndex(
 if (optIdx === -1)
   throw new Error(`options: not found after id: ${DROPDOWN_ID}`);
 
-const itemIndent = `${lines[optIdx].match(/^\s*/)[0]}  `; // options items are nested one level deeper
+const itemIndent = lines[optIdx].match(/^\s*/)[0] + "  "; // options items are nested one level deeper
 let end = optIdx + 1;
 const sentinels = [];
 while (end < lines.length && /^\s*-\s+/.test(lines[end])) {


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description
This PR originally added a timeout and race-condition fixes to `checkApiReachable` in `NetworkStatusProvider.tsx`. Since it was opened, `develop` independently fixed the splash-screen hang (#1313) via a shared `jellyfinProbe` utility with its own `AbortController` timeout (#1670), and the SSID-based local/remote URL switching in `ServerUrlProvider` was unaffected. After rebasing onto current `develop`, this PR is now scoped to the one gap that fix doesn't cover:

**Stale/overlapping reachability checks:** `validateConnection` had no protection against an older in-flight check completing *after* a newer one and overwriting `serverConnected` with an outdated result. This produces a false "Server Unreachable" state even though the server is actually reachable — matching the "retry fixes it" symptom in #1250. Adds a version counter so only the most recently started check's result is ever applied.

## 🏷️ Ticket / Issue
Fixes #1250

(#1313 was already fixed on `develop` via #1670, independently of this PR.)

## ✅ Checklist
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

## 🔍 Testing Instructions
1. Configure a remote URL with auto-switch to a local URL enabled (SSID match).
2. Trigger two overlapping reachability checks for the same URL in quick succession (e.g. toggle network connectivity rapidly, or switch WiFi networks a couple of times back to back).
3. Verify `serverConnected` reflects the most recent check's result, not an older one that happened to resolve later — i.e. the app doesn't flash into a false "Server Unreachable" state when the server is actually reachable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection status accuracy by preventing outdated checks from overriding newer results.
  * Ensured connection checks use the latest server address and request settings.
  * Updated offline handling so disconnected states are reported promptly.
  * Prevented delayed network events from affecting connection status after settings change or cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->