### PR TITLE
ci: skip PR title comment when the lint run was cancelled

### DIFF
--- a/.github/workflows/pr-title-comment.yml
+++ b/.github/workflows/pr-title-comment.yml
@@ -20,7 +20,12 @@ concurrency:
 
 jobs:
   comment:
-    if: github.event.workflow_run.event == 'pull_request'
+    # Only run when the lint run actually produced a result artifact: a run
+    # cancelled by concurrency (rapid pushes to the same PR) completes with
+    # conclusion "cancelled" before uploading it, and would fail the download.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)
     runs-on: ubuntu-26.04
     steps:
       - name: ⬇️ Download lint result


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

`📝 PR Title Comment` (workflow_run) fails with `no valid artifacts found to download` whenever the triggering `📝 PR Title` run was **cancelled** by its concurrency group (two rapid pushes to the same PR): the cancelled run still counts as `completed`, so the comment workflow fires, but the run never reached the artifact upload step. The red run then spams failure webhooks (e.g. Discord) even though nothing is actually wrong.

Example: https://github.com/streamyfin/streamyfin/actions/runs/29350639981 (parent run `29350634221`, conclusion `cancelled`, 0 artifacts).

Fix: gate the `comment` job on the parent run conclusion — only `success` (sticky comment cleanup) and `failure` (post the lint error) produce the `pr-title-result` artifact. Cancelled/skipped parents now skip the job instead of failing it.

## 🏷️ Ticket / Issue

N/A (follow-up to #1788)

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Push twice in quick succession to any open PR branch: the first `📝 PR Title` run gets cancelled by `cancel-in-progress`
2. Verify the `📝 PR Title Comment` run triggered by the cancelled run is **skipped** (previously: red `no valid artifacts found to download`)
3. Verify normal behavior is unchanged: an invalid PR title still gets the sticky comment, fixing the title still removes it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pull request status comments to appear only after workflows complete successfully or with a failure.
  * Prevented comments from being posted for cancelled or otherwise incomplete workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->