### PR TITLE
fix: playback stopped reporting every 30 s

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -472,24 +472,42 @@ export default function DirectPlayerPage() {
     }
   };
 
+  // PlaySessionId of the last "stopped" report, to dedupe the double teardown.
+  const reportedStopSessionIdRef = useRef<string | null>(null);
+
   const reportPlaybackStopped = useCallback(async () => {
     if (!item?.Id || !stream?.sessionId || offline || !api) return;
+    // Leaving the player reports "stopped" twice: once from the beforeRemove
+    // listener (via stop()) and once from the unmount cleanup backstop. Dedupe
+    // per PlaySessionId — not a plain boolean, since the component survives
+    // in-place item switches and the next session must report again.
+    if (reportedStopSessionIdRef.current === stream.sessionId) return;
+    reportedStopSessionIdRef.current = stream.sessionId;
 
     const currentTimeInTicks = msToTicks(progress.get());
-    await getPlaystateApi(api).reportPlaybackStopped({
-      playbackStopInfo: {
-        ItemId: item.Id,
-        MediaSourceId: mediaSourceId,
-        PositionTicks: currentTimeInTicks,
-        PlaySessionId: stream.sessionId,
-        // Release the server-side live stream (and its tuner slot) on stop.
-        // Jellyfin only closes a live stream opened via autoOpenLiveStream when
-        // the stop report carries its LiveStreamId; without it the stream leaks
-        // and Live TV eventually fails for everyone with "M3U simultaneous
-        // stream limit has been reached". Undefined for non-live items (no-op).
-        LiveStreamId: stream.mediaSource?.LiveStreamId ?? undefined,
-      },
-    });
+    try {
+      await getPlaystateApi(api).reportPlaybackStopped({
+        playbackStopInfo: {
+          ItemId: item.Id,
+          MediaSourceId: mediaSourceId,
+          PositionTicks: currentTimeInTicks,
+          PlaySessionId: stream.sessionId,
+          // Release the server-side live stream (and its tuner slot) on stop.
+          // Jellyfin only closes a live stream opened via autoOpenLiveStream when
+          // the stop report carries its LiveStreamId; without it the stream leaks
+          // and Live TV eventually fails for everyone with "M3U simultaneous
+          // stream limit has been reached". Undefined for non-live items (no-op).
+          LiveStreamId: stream.mediaSource?.LiveStreamId ?? undefined,
+        },
+      });
+    } catch (error) {
+      // Un-mark the session so a later teardown path can retry: e.g. a failed
+      // report from a WebSocket remote-stop (player still mounted) must not
+      // suppress the report when the user then navigates away. Callers are
+      // fire-and-forget, so swallow instead of rethrowing unhandled.
+      reportedStopSessionIdRef.current = null;
+      writeToLog("ERROR", "reportPlaybackStopped failed", error);
+    }
   }, [api, item, mediaSourceId, stream, progress, offline]);
 
   const stop = useCallback(() => {
@@ -524,9 +542,12 @@ export default function DirectPlayerPage() {
   // the 30s router.setParams position write mutates navigation state) caused a
   // spurious PlaybackStopped every URL_UPDATE_INTERVAL.
   const stopRef = useRef(stop);
-  stopRef.current = stop;
   const reportPlaybackStoppedRef = useRef(reportPlaybackStopped);
-  reportPlaybackStoppedRef.current = reportPlaybackStopped;
+
+  useEffect(() => {
+    stopRef.current = stop;
+    reportPlaybackStoppedRef.current = reportPlaybackStopped;
+  }, [stop, reportPlaybackStopped]);
 
   // Report playback stopped only on a real unmount (leaving the player).
   useEffect(() => {

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -481,9 +481,9 @@ export default function DirectPlayerPage() {
     // listener (via stop()) and once from the unmount cleanup backstop. Dedupe
     // per PlaySessionId — not a plain boolean, since the component survives
     // in-place item switches and the next session must report again.
-    if (reportedStopSessionIdRef.current === stream.sessionId) return;
-    reportedStopSessionIdRef.current = stream.sessionId;
-
+    const sessionId = stream.sessionId;
+    if (reportedStopSessionIdRef.current === sessionId) return;
+    reportedStopSessionIdRef.current = sessionId;
     const currentTimeInTicks = msToTicks(progress.get());
     try {
       await getPlaystateApi(api).reportPlaybackStopped({
@@ -491,7 +491,7 @@ export default function DirectPlayerPage() {
           ItemId: item.Id,
           MediaSourceId: mediaSourceId,
           PositionTicks: currentTimeInTicks,
-          PlaySessionId: stream.sessionId,
+          PlaySessionId: sessionId,
           // Release the server-side live stream (and its tuner slot) on stop.
           // Jellyfin only closes a live stream opened via autoOpenLiveStream when
           // the stop report carries its LiveStreamId; without it the stream leaks
@@ -505,7 +505,9 @@ export default function DirectPlayerPage() {
       // report from a WebSocket remote-stop (player still mounted) must not
       // suppress the report when the user then navigates away. Callers are
       // fire-and-forget, so swallow instead of rethrowing unhandled.
-      reportedStopSessionIdRef.current = null;
+      if (reportedStopSessionIdRef.current === sessionId) {
+        reportedStopSessionIdRef.current = null;
+      }
       writeToLog(
         "ERROR",
         "reportPlaybackStopped failed",

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -555,12 +555,12 @@ export default function DirectPlayerPage() {
     reportPlaybackStoppedRef.current = reportPlaybackStopped;
   }, [stop, reportPlaybackStopped]);
 
-  // Report playback stopped only on a real unmount (leaving the player).
+  // Report playback stopped only on a real source switch or unmount.
   useEffect(() => {
     return () => {
       reportPlaybackStoppedRef.current();
     };
-  }, []);
+  }, [item?.Id, stream?.sessionId, mediaSourceId]);
 
   // Stop on navigation-away. Re-subscribing when the navigation object identity
   // changes (e.g. after a setParams) no longer reports anything on its own.

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -506,7 +506,11 @@ export default function DirectPlayerPage() {
       // suppress the report when the user then navigates away. Callers are
       // fire-and-forget, so swallow instead of rethrowing unhandled.
       reportedStopSessionIdRef.current = null;
-      writeToLog("ERROR", "reportPlaybackStopped failed", error);
+      writeToLog(
+        "ERROR",
+        "reportPlaybackStopped failed",
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }, [api, item, mediaSourceId, stream, progress, offline]);
 

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -518,13 +518,33 @@ export default function DirectPlayerPage() {
     deactivateKeepAwake();
   }, [videoRef, reportPlaybackStopped, progress, resumeInactivityTimer]);
 
+  // Keep refs to the latest stop / stopped-report so the effects below don't
+  // need these churning callbacks in their dependency arrays. Reporting
+  // "stopped" from an effect cleanup that re-runs during playback (e.g. when
+  // the 30s router.setParams position write mutates navigation state) caused a
+  // spurious PlaybackStopped every URL_UPDATE_INTERVAL.
+  const stopRef = useRef(stop);
+  stopRef.current = stop;
+  const reportPlaybackStoppedRef = useRef(reportPlaybackStopped);
+  reportPlaybackStoppedRef.current = reportPlaybackStopped;
+
+  // Report playback stopped only on a real unmount (leaving the player).
   useEffect(() => {
-    const beforeRemoveListener = navigation.addListener("beforeRemove", stop);
     return () => {
-      reportPlaybackStopped();
+      reportPlaybackStoppedRef.current();
+    };
+  }, []);
+
+  // Stop on navigation-away. Re-subscribing when the navigation object identity
+  // changes (e.g. after a setParams) no longer reports anything on its own.
+  useEffect(() => {
+    const beforeRemoveListener = navigation.addListener("beforeRemove", () =>
+      stopRef.current(),
+    );
+    return () => {
       beforeRemoveListener();
     };
-  }, [navigation, stop, reportPlaybackStopped]);
+  }, [navigation]);
 
   const currentPlayStateInfo = useCallback(():
     | PlaybackProgressInfo

--- a/utils/atoms/filters.ts
+++ b/utils/atoms/filters.ts
@@ -82,8 +82,6 @@ export const useFilterOptions = () => {
         { key: FilterByOption.IsFavorite, value: "Is Favorite" },
         { key: FilterByOption.IsResumable, value: "Is Resumable" },
       ];
-  console.log("filterOptions");
-  console.log(filterOptions);
   return filterOptions;
 };
 


### PR DESCRIPTION
<!-- 
Use a conventional commit title for the PR title, 
for example `feat(auth): add MFA`
All sections below are required. Write N/A if a section is not applicable.
If you use AI to help implement this PR, you must declare it below. It's very important that the feature or fix implemented has been tested thoroughly by you personally on all target platforms. Only adding AI generated code without proper testing is not allowed and this PR will be closed immediately.
-->

# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)
used for finding the cause and suggesting a quick fix.
## 📝 Description
fixes the playbackreporting stopped behaviour so it only happens once playback ends (and player exits) instead of once every 30 seconds.

## 🏷️ Ticket / Issue
N/A, I found it myself

### 🖼️ Screenshots / GIFs (if UI)
<!-- 
Include screenshots of relevant UI changes for both Android and iOS.
Before/After, responsive states (if relevant). 
-->
N/A it's just a logs thing

## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions
<!--
Describe how reviewers can test your changes. This will help the PR get merged faster.
Example:
1. Open the settings page and scroll to the bottom
2. Verify that the clear data button is visible and pressable
3. Verify that when you click the clear data button, a dialog appears prompting you to confirm
4. Verify that when you click the confirm button, the data is cleared and a toast message is displayed
-->
before installing this version:
1. open jellyfin logs (ex. docker logs jellyfin -f)
2. start playback on something in streamyfin (develop)
3. see that every 30 seconds, playback reports an end

after installing this version:
repeat same steps except no playback end reports while playback is ongoing



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate “playback stopped” reports when leaving the player by deduplicating per stream session.
  * Improved teardown behavior so reporting happens only on real unmount, while navigation changes no longer trigger the same report.
  * Added safer error handling for playback-stop reporting (errors are logged and cleanup continues).
* **Chores**
  * Removed debug console logging related to filter options computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->