### PR TITLE
feat(tv): add quality selector to player controls

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -993,7 +993,11 @@ export default function DirectPlayerPage() {
   // e.g. to burn an image sub in or out). Same-item mirror of VideoContext's
   // replacePlayer, resuming at the live position.
   const replaceWithTrackSelection = useCallback(
-    (params: { subtitleIndex?: string; audioIndex?: string }) => {
+    (params: {
+      subtitleIndex?: string;
+      audioIndex?: string;
+      bitrateValue?: string;
+    }) => {
       const queryParams = new URLSearchParams({
         itemId: item?.Id ?? "",
         audioIndex: params.audioIndex ?? String(currentAudioIndex ?? ""),
@@ -1001,7 +1005,7 @@ export default function DirectPlayerPage() {
           params.subtitleIndex ??
           String(toServerSubtitleIndex(currentSubtitleIndex)),
         mediaSourceId: stream?.mediaSource?.Id ?? "",
-        bitrateValue: bitrateValue?.toString() ?? "",
+        bitrateValue: params.bitrateValue ?? bitrateValue?.toString() ?? "",
         playbackPosition: msToTicks(progress.get()).toString(),
       }).toString();
       // Destroy the current mpv instance before re-navigating, same rationale as
@@ -1019,6 +1023,16 @@ export default function DirectPlayerPage() {
       router,
       progress,
     ],
+  );
+
+  // TV quality (max bitrate) change handler. A bitrate change always requires
+  // re-negotiating the stream with the server, so it goes through the same
+  // player-replace path as track changes while transcoding.
+  const handleBitrateChange = useCallback(
+    (bitrate: number | undefined) => {
+      replaceWithTrackSelection({ bitrateValue: bitrate?.toString() ?? "" });
+    },
+    [replaceWithTrackSelection],
   );
 
   // TV/mobile subtitle track change handler
@@ -1492,6 +1506,7 @@ export default function DirectPlayerPage() {
                   subtitleIndex={currentSubtitleIndex}
                   onAudioIndexChange={handleAudioIndexChange}
                   onSubtitleIndexChange={handleSubtitleIndexChange}
+                  onBitrateChange={handleBitrateChange}
                   previousItem={previousItem}
                   nextItem={nextItem}
                   goToPreviousItem={goToPreviousItem}

--- a/components/video-player/controls/Controls.tv.tsx
+++ b/components/video-player/controls/Controls.tv.tsx
@@ -29,6 +29,7 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { BITRATES } from "@/components/BitrateSelector";
 import { Text } from "@/components/common/Text";
 import {
   TVControlButton,
@@ -81,6 +82,7 @@ interface Props {
   subtitleIndex?: number;
   onAudioIndexChange?: (index: number) => void;
   onSubtitleIndexChange?: (index: number) => void;
+  onBitrateChange?: (bitrate: number | undefined) => void;
   previousItem?: BaseItemDto | null;
   nextItem?: BaseItemDto | null;
   goToPreviousItem?: () => void;
@@ -207,6 +209,7 @@ export const Controls: FC<Props> = ({
   subtitleIndex,
   onAudioIndexChange,
   onSubtitleIndexChange,
+  onBitrateChange,
   previousItem,
   nextItem: nextItemProp,
   goToPreviousItem,
@@ -255,7 +258,7 @@ export const Controls: FC<Props> = ({
   const { subtitleTracks: videoContextSubtitleTracks } = useVideoContext();
 
   // Track which button should have preferred focus when controls show
-  type LastModalType = "audio" | "subtitle" | "techInfo" | null;
+  type LastModalType = "audio" | "subtitle" | "quality" | "techInfo" | null;
   const [lastOpenedModal, setLastOpenedModal] = useState<LastModalType>(null);
 
   // Track if play button should have focus (when showing controls via up/down D-pad)
@@ -302,6 +305,24 @@ export const Controls: FC<Props> = ({
       onAudioIndexChange?.(index);
     },
     [onAudioIndexChange],
+  );
+
+  // Quality options mirror the mobile menu: value is the max bitrate as a
+  // string, "" meaning Max (no limit) — same encoding as the bitrateValue
+  // route param, so selection matching is a plain string compare.
+  const bitrateOptions: TVOptionItem<string>[] = useMemo(() => {
+    return BITRATES.map((bitrate) => ({
+      label: bitrate.key,
+      value: bitrate.value?.toString() ?? "",
+      selected: (bitrateValue ?? "") === (bitrate.value?.toString() ?? ""),
+    }));
+  }, [bitrateValue]);
+
+  const handleBitrateChange = useCallback(
+    (value: string) => {
+      onBitrateChange?.(value ? Number.parseInt(value, 10) : undefined);
+    },
+    [onBitrateChange],
   );
 
   const _handleSubtitleChange = useCallback(
@@ -573,6 +594,19 @@ export const Controls: FC<Props> = ({
     });
     controlsInteractionRef.current();
   }, [showOptions, t, audioOptions, handleAudioChange]);
+
+  const handleOpenQualitySheet = useCallback(() => {
+    setLastOpenedModal("quality");
+    showOptions({
+      title: t("item_card.quality"),
+      options: bitrateOptions,
+      onSelect: handleBitrateChange,
+      // Changing quality replaces the player route (stream re-negotiation);
+      // apply it after the modal is dismissed so it isn't swallowed.
+      deferApplyUntilDismissed: true,
+    });
+    controlsInteractionRef.current();
+  }, [showOptions, t, bitrateOptions, handleBitrateChange]);
 
   const handleLocalSubtitleDownloaded = useCallback(
     (path: string) => {
@@ -1370,6 +1404,17 @@ export const Controls: FC<Props> = ({
             />
 
             <View style={styles.controlButtonsSpacer} />
+
+            {onBitrateChange && !offline && !isLiveTV && (
+              <TVControlButton
+                icon='speedometer'
+                onPress={handleOpenQualitySheet}
+                hasTVPreferredFocus={
+                  !isCountdownActive && lastOpenedModal === "quality"
+                }
+                size={24}
+              />
+            )}
 
             {audioOptions.length > 0 && (
               <TVControlButton


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Adds a quality (max bitrate) selector to the TV player controls, matching the option already available on mobile.

- New `speedometer` icon button in the TV controls row, next to the audio and subtitle buttons.
- Opens the same navigation-based bottom sheet (`useTVOptionModal` → `tv-option-modal` route) used by the audio/subtitle selectors, titled with the existing `item_card.quality` translation key.
- Options are built from the shared `BITRATES` constants (Max, 8 Mb/s … 250 Kb/s); the current selection is matched against the player's `bitrateValue` route param.
- Selecting a quality routes through the existing `replaceWithTrackSelection` path (extended with a `bitrateValue` override), re-negotiating the stream with the server while preserving the live playback position, audio, and subtitle selection. The new bitrate also carries over to next/previous episodes.
- Hidden in offline mode (quality doesn't apply to downloads) and for live TV.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. On a TV build, start playing a movie or episode.
2. Show the player controls and focus the new quality button (`speedometer` icon, next to the audio/subtitle buttons).
3. Press it and verify the bottom sheet opens with the bitrate options (Max, 8 Mb/s … 250 Kb/s) and the current quality marked as selected.
4. Select a different quality and verify playback resumes at the same position with the new max bitrate applied.
5. Verify audio/subtitle selection is preserved across the quality change.
6. Verify the button is hidden for live TV and in offline/downloaded playback.