### PR TITLE
chore(renovate): group compat pairs, gate native majors, cut dashboard noise

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,9 @@
   "commitMessagePrefix": "chore(deps):",
   "osvVulnerabilityAlerts": true,
   "configMigration": true,
-  "separateMinorPatch": true,
+  "separateMinorPatch": false,
+  "prConcurrentLimit": 8,
+  "prHourlyLimit": 4,
   "customManagers": [
     {
       "customType": "regex",
@@ -60,18 +62,70 @@
   },
   "packageRules": [
     {
-      "description": "Expo SDK coherence: expo, react, react-native and Expo-managed modules are pinned by the Expo SDK and must move together (via `expo install --fix`), so do not raise individual update PRs — group them and require manual approval from the Dependency Dashboard",
+      "description": "Expo SDK coherence: expo, react, react-native (the react-native-tvos fork and its config plugin included) and Expo-managed modules are pinned by the Expo SDK and must move together (via `expo install --fix`), so do not raise individual update PRs — group them and require manual approval from the Dependency Dashboard",
       "matchPackageNames": [
         "expo",
         "react",
         "react-dom",
         "react-native",
+        "react-native-tvos",
         "react-native-web",
         "expo-*",
-        "@expo/*"
+        "@expo/*",
+        "@react-native-tvos/*"
       ],
       "groupName": "Expo SDK",
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "react-native-reanimated and react-native-worklets follow a strict compatibility matrix (see reanimated docs) — bumping one without the other breaks every native build, so they always move in a single PR",
+      "matchPackageNames": ["react-native-reanimated", "react-native-worklets"],
+      "groupName": "reanimated + worklets"
+    },
+    {
+      "description": "react-native-mmkv >=4.2.0 hard-requires react-native-nitro-modules >=0.35.0 — bumping one without the other breaks the build, so they always move in a single PR",
+      "matchPackageNames": ["react-native-mmkv", "react-native-nitro-modules"],
+      "groupName": "mmkv + nitro-modules"
+    },
+    {
+      "description": "Major updates of native modules routinely break builds or need real migration work (e.g. gesture-handler v3 hook API) — hold them for manual approval from the Dependency Dashboard instead of leaving broken PRs open",
+      "matchUpdateTypes": ["major"],
+      "matchPackageNames": [
+        "react-native-gesture-handler",
+        "react-native-screens",
+        "react-native-safe-area-context",
+        "react-native-pager-view",
+        "react-native-svg",
+        "react-native-edge-to-edge",
+        "react-native-mmkv",
+        "react-native-nitro-modules",
+        "react-native-reanimated",
+        "react-native-worklets",
+        "react-native-udp",
+        "react-native-volume-manager",
+        "react-native-track-player",
+        "react-native-google-cast",
+        "react-native-bottom-tabs",
+        "react-native-device-info",
+        "@bottom-tabs/react-navigation",
+        "@gorhom/bottom-sheet",
+        "@shopify/flash-list",
+        "@react-native-community/netinfo",
+        "@react-navigation/*",
+        "sonner-native"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "nativewind 2.x / tailwindcss 3.x are frozen on purpose — v4 requires a full styling refactor and is explicitly out of scope (see issue #1831)",
+      "matchPackageNames": ["nativewind", "tailwindcss"],
+      "enabled": false
+    },
+    {
+      "description": "Low-risk dev tooling and type packages: automerge non-major updates once all status checks are green",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     },
     {
       "description": "Group minor and patch GitHub Action updates into a single PR",


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Rework of the Renovate configuration so the Dependency Dashboard (#724) becomes a reliable tracking base instead of a backlog of broken/rate-limited PRs. This is PR 1 of the SDK 57 / dependency-overhaul initiative (#1831).

What changes and why:

- **Group compatibility pairs into single PRs** — `react-native-reanimated` + `react-native-worklets` (strict compat matrix) and `react-native-mmkv` + `react-native-nitro-modules` (mmkv ≥4.2 hard-requires nitro ≥0.35). Bumping these separately is why #1381/#1419 failed every native build for ~6 months and why the mmkv/nitro updates ended up in the dead "PR Closed (Blocked)" state.
- **Add `react-native-tvos` and `@react-native-tvos/*` to the gated "Expo SDK" group** — the fork was escaping the group and raising standalone `react-native` PRs outside the SDK-coherence rule.
- **Require Dashboard approval for major updates of native modules** (gesture-handler, screens, flash-list, mmkv/nitro, navigation, etc.) — majors like gesture-handler v3 (#1610) need real migration work and otherwise sit open with red CI for weeks.
- **Disable `nativewind` / `tailwindcss` updates with an explanatory rule** — v4 requires a full styling refactor, explicitly out of scope (#1831). Replaces the silent closed-blocked entries.
- **`separateMinorPatch: false`** — stops doubling PR volume with separate patch-only PRs.
- **`prConcurrentLimit: 8` / `prHourlyLimit: 4`** — drains the 24-entry rate-limited backlog within the weekly schedule window instead of letting it grow.
- **Automerge green non-major devDependencies** — low-risk tooling/types PRs no longer need manual attention (`:automergeRequireAllStatusChecks` still applies).

Everything else (custom managers for CI YAML pins / eas.json bun version, xcode datasource, vulnerability alerts, weekly schedule, 3-day minimum release age) is unchanged.

## 🏷️ Ticket / Issue

Part of #1831 · Fixes the dashboard noise described in #724

### 🖼️ Screenshots / GIFs (if UI)

N/A (config only)

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms (config-only; no app code touched)
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`) — JSON strict-parsed + `biome format` clean
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (badge above)

## 🔍 Testing Instructions

1. Config is standard-options only; it strict-parses and is formatted with Biome. Mend/Renovate validates the config on its next scheduled run and would surface a config-error banner in the Dependency Dashboard (#724) if anything were invalid.
2. After merge, on the next Renovate run, verify in #724 that: reanimated+worklets and mmkv+nitro appear as grouped entries, native majors moved to "Pending Approval", and nativewind/tailwindcss entries disappeared.
3. Open Renovate PRs superseded by the upcoming dependency PRs (#1729, #1828, #1630, #1747, #1433, #1381, #1419) will auto-close as those land — no manual cleanup needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update management to reduce unnecessary pull requests and control update frequency.
  * Related React Native and Expo packages will now be updated together for better compatibility.
  * Major native dependency updates require manual review.
  * Low-risk development dependency updates may be merged automatically after checks pass.
  * Updates for selected styling packages are now paused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->