### PR TITLE
fix: address CodeQL findings (fs race in TV plugin, dead conditionals)

### DIFF
--- a/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/series/[id].tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/series/[id].tsx
@@ -141,7 +141,7 @@ const page: React.FC = () => {
               <DownloadItems
                 size='large'
                 title={t("item_card.download.download_series")}
-                items={allEpisodes || []}
+                items={allEpisodes}
                 MissingDownloadIconComponent={() => (
                   <Ionicons name='download' size={22} color='white' />
                 )}

--- a/components/RoundButton.tsx
+++ b/components/RoundButton.tsx
@@ -96,9 +96,7 @@ export const RoundButton: React.FC<PropsWithChildren<Props>> = ({
     return (
       <Pressable
         onPress={handlePress}
-        className={`rounded-full ${buttonSize} flex items-center justify-center ${
-          fillColor ? fillColorClass : "bg-transparent"
-        }`}
+        className={`rounded-full ${buttonSize} flex items-center justify-center bg-transparent`}
         {...(viewProps as any)}
       >
         {icon ? (

--- a/plugins/withTVXcodeEnv.ts
+++ b/plugins/withTVXcodeEnv.ts
@@ -25,12 +25,16 @@ const withTVXcodeEnv: ConfigPlugin = (config) => {
       const xcodeEnvLocalPath = path.join(iosPath, ".xcode.env.local");
 
       // Read existing content or start fresh — no exists-check first, so a
-      // concurrent create/delete can't race between check and read
+      // concurrent create/delete can't race between check and read. Only a
+      // missing file means "start fresh"; any other read error must not let
+      // the plugin silently rebuild the file from scratch.
       let content = "";
       try {
         content = fs.readFileSync(xcodeEnvLocalPath, "utf-8");
-      } catch {
-        // File doesn't exist yet
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
       }
 
       let modified = false;

--- a/plugins/withTVXcodeEnv.ts
+++ b/plugins/withTVXcodeEnv.ts
@@ -24,10 +24,13 @@ const withTVXcodeEnv: ConfigPlugin = (config) => {
       const iosPath = path.join(config.modRequest.projectRoot, "ios");
       const xcodeEnvLocalPath = path.join(iosPath, ".xcode.env.local");
 
-      // Read existing content or start fresh
+      // Read existing content or start fresh — no exists-check first, so a
+      // concurrent create/delete can't race between check and read
       let content = "";
-      if (fs.existsSync(xcodeEnvLocalPath)) {
+      try {
         content = fs.readFileSync(xcodeEnvLocalPath, "utf-8");
+      } catch {
+        // File doesn't exist yet
       }
 
       let modified = false;

--- a/utils/jellyfin/media/getPlaybackUrl.ts
+++ b/utils/jellyfin/media/getPlaybackUrl.ts
@@ -42,7 +42,7 @@ export const getPlaybackUrl = async (
     deviceId: api.deviceInfo?.id || "",
     ApiKey: api.accessToken || "",
     Tag: ETag || "",
-    MediaSourceId: Id || "",
+    MediaSourceId: Id,
   });
 
   return `/Videos/${Id}/stream?${queryParams}`;


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

PR 3 of #1831: resolves the open CodeQL code-scanning findings. All fixes are behavior-preserving.

- **`plugins/withTVXcodeEnv.ts` — `js/file-system-race` (High, alert #348):** replaced the `existsSync` → `readFileSync` check-then-act pattern with a direct `readFileSync` in `try/catch` — no window between check and read anymore.
- **`components/RoundButton.tsx` — trivial conditional (alert #241):** the Android branch is only reachable after `if (fillColor) return …`, so `fillColor ? fillColorClass : "bg-transparent"` always evaluated to `"bg-transparent"` — inlined.
- **`app/…/series/[id].tsx` — trivial conditional (alert #265):** `items={allEpisodes || []}` sits inside JSX already guarded by `allEpisodes && allEpisodes.length > 0` — the fallback is dead, removed.
- **`utils/jellyfin/media/getPlaybackUrl.ts` — trivial conditional (alert #5):** `MediaSourceId: Id || ""` comes after `if (!Id) throw` — fallback dead, removed.

**Dismissed as false positive (no code change): alert #268** (`js/unknown-directive`, `components/music/MiniPlayerBar.tsx:38`) — `"worklet"` is a Reanimated directive consumed by the worklets Babel plugin to mark `rubberBand()` for UI-thread execution; removing it would break the mini-player gesture.

## 🏷️ Ticket / Issue

Part of #1831

### 🖼️ Screenshots / GIFs (if UI)

N/A (no visual changes — all fixes are provably-dead branches or an equivalent read pattern)

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms (behavior-preserving by construction; CI builds confirm)
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (badge above)

## 🔍 Testing Instructions

1. `bun run typecheck` and `bun run check` on the touched files — green.
2. After merge, the CodeQL workflow should close alerts #348, #265, #241 and #5 automatically (#268 and #346 were dismissed with justification).
3. Optional behavior spot-checks: Android `RoundButton` without `fillColor` still renders transparent; series page header download button unchanged; TV prebuild still writes `ios/.xcode.env.local` correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback URL generation for more reliable media streaming.
  - Refined episode download behavior to rely on available episode data without redundant fallbacks.
  - Corrected Android round-button styling to avoid unintended fill colors.
- **Build & Stability**
  - Improved iOS TV environment configuration loading to handle missing local env files more gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->