### PR TITLE
chore(deps): drop unused androidx.core:core-ktx from tv-recommendations

### DIFF
--- a/modules/tv-recommendations/android/build.gradle
+++ b/modules/tv-recommendations/android/build.gradle
@@ -36,7 +36,6 @@ android {
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
   implementation "androidx.tvprovider:tvprovider:1.1.0"
-  implementation "androidx.core:core-ktx:1.13.1"
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {


### PR DESCRIPTION
# 📦 Pull Request

## 📝 Description

Removes the explicit `androidx.core:core-ktx:1.13.1` dependency from the tv-recommendations module. It is a dead declaration:

- The module's Kotlin sources import nothing from `androidx.core` (only `androidx.tvprovider`, `android.*`, `expo.modules.kotlin` and `org.json`).
- `expo-modules-core` already exposes `api "androidx.core:core-ktx:1.17.0"` (SDK 57), which the module receives through `useCoreDependencies()`. Gradle resolves to the highest version, so the app already ships 1.17.0 and the 1.13.1 pin is a no-op.
- `androidx.tvprovider` pulls `androidx.core:core` transitively for its own needs.

This also stops Renovate from proposing core-ktx bumps that cannot build here: 1.19.0 (see #1710) requires compileSdk 37 and AGP 9.1.0, while Expo SDK 57 / RN 0.86 pin compileSdk 36 and AGP 8.12.0, so its CI fails on `:app:checkReleaseAarMetadata`. With the dependency gone, Renovate will detect it is no longer referenced and close #1710 on its own. The version now follows expo-modules-core, which is upgraded together with the SDK.

An audit of the other native module dependencies (all `build.gradle` and `.podspec` files under `modules/`) found no other dead declarations: okhttp (background-downloader), media3 artifacts including the reflection-loaded HLS and FFmpeg decoder (exoplayer-player), libmpv (mpv-player), tvprovider (tv-recommendations) and MPVKit (mpv-player iOS) are all used.

## 🏷️ Ticket / Issue

Supersedes #1710

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. CI: Android Phone and TV APK builds must pass (the removed line only affects the Android classpath).
2. Optional runtime check on Android TV: play some items, then verify the Streamyfin channel on the TV launcher still publishes recommendation cards (tv-recommendations module untouched apart from the dependency list).
3. `./gradlew :tv-recommendations:dependencies` in a prebuilt android folder still shows `androidx.core:core-ktx:1.17.0` provided by expo-modules-core.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android TV integration dependency to improve compatibility with TV provider features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->