### PR TITLE
fix(mpv-ios): restore auto-PiP on later videos and Now Playing state

### DIFF
--- a/modules/mpv-player/ios/MpvPlayerView.swift
+++ b/modules/mpv-player/ios/MpvPlayerView.swift
@@ -237,6 +237,9 @@ class MpvPlayerView: ExpoView {
 			return
 		}
 		currentURL = config.url
+		// Paired with the disarm in destroy(), which the reused view would
+		// otherwise never undo.
+		pipController?.setAutoStartEnabled(true)
 
 		let preset = PlayerPreset(
 			id: .sdrRec709,
@@ -297,6 +300,9 @@ class MpvPlayerView: ExpoView {
 	 * Cross-platform counterpart of MpvPlayerView.destroy() on Android.
 	 */
 	func destroy() {
+		// Release the system's single inline auto-PiP slot now; deinit is deferred
+		// and would otherwise keep it claimed, blocking PiP for the next video.
+		pipController?.setAutoStartEnabled(false)
 		renderer?.stop()
 
 		// Reset view state and re-create the mpv handle so a subsequent
@@ -570,7 +576,11 @@ extension MpvPlayerView: MPVLayerRendererDelegate {
 
 	func renderer(_: MPVLayerRenderer, didSelectAudioOutput audioOutput: String) {
 		print("[MPV] Audio output ready (\(audioOutput)), syncing Now Playing")
-		syncNowPlaying(isPlaying: !isPaused())
+		// mpv reconfigures the shared AVAudioSession when its audio unit spins up,
+		// overriding what play() set. Until ours is re-applied the system doesn't
+		// treat us as the Now Playing app and drops every info update.
+		configureAudioSession()
+		syncNowPlaying(isPlaying: intendedPlayState)
 	}
 }
 

--- a/modules/mpv-player/ios/PiPController.swift
+++ b/modules/mpv-player/ios/PiPController.swift
@@ -80,11 +80,20 @@ final class PiPController: NSObject {
         pipController = AVPictureInPictureController(contentSource: contentSource)
         pipController?.delegate = self
         pipController?.requiresLinearPlayback = false
+    }
+
+    /// Enable/disable auto-PiP ("swipe up while playing").
+    ///
+    /// Armed per loaded video rather than once at init: leaving it enabled on an
+    /// outgoing player stopped the *next* video from entering PiP, and the view
+    /// is reused across videos so init doesn't run again. Set in `loadVideo()`,
+    /// cleared in `destroy()`.
+    func setAutoStartEnabled(_ enabled: Bool) {
         #if !os(tvOS)
-        pipController?.canStartPictureInPictureAutomaticallyFromInline = true
+        pipController?.canStartPictureInPictureAutomaticallyFromInline = enabled
         #endif
     }
-    
+
     func startPictureInPicture() {
         guard let pipController = pipController,
               pipController.isPictureInPicturePossible else {


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Fixes two iOS mpv player bugs with separate causes.

**Auto-PiP stopped working for every video after the first.** The outgoing player kept `canStartPictureInPictureAutomaticallyFromInline` enabled, so the next video never entered PiP on swipe up. The flag was set once at controller init, meaning it could only ever be turned on — nothing released it when a video ended. It's now armed in `loadVideo()` and cleared in `destroy()`. It can't live in `init` alone because `destroy()` deliberately keeps the view alive for reuse (Expo Router reuses the same `MpvPlayerView` on `router.replace` to the same route), so `init` never runs again for the next episode.

**Now Playing stayed empty until the user manually paused and unpaused.** mpv reconfigures the shared `AVAudioSession` when its audio unit spins up, overriding what `play()` set, so the system stopped treating the app as the Now Playing app and dropped every info update. Reapplying our session in `didSelectAudioOutput` restores it — this is what `1cabf757` removed.

Also syncs using `intendedPlayState` instead of `isPaused()`: the renderer's cached pause flag starts as `true` and is only corrected asynchronously, so it reads stale during startup and would publish a paused state.

iOS only — 2 files, +22/−3. Android and tvOS are untouched (the PiP flag is behind `#if !os(tvOS)`).

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A — no UI changes.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

**Auto-PiP on subsequent videos**
1. Play any video, then exit back to the detail screen
2. Play a different video and swipe up to the home screen
3. Verify it enters Picture in Picture (before this fix, only the first video of a session would)
4. Let a video roll into the next episode, swipe up, and verify PiP still works

**Now Playing**
1. Start a video from a cold app launch
2. Lock the phone (or open Control Center) *without* pressing pause first
3. Verify the title, artwork and a **playing** state appear immediately
4. Verify play/pause, seek and 15s skip from the lock screen still control playback

**Audio session regression check**
1. Start a video, then trigger an interruption (incoming call or Siri)
2. Dismiss the interruption and press play
3. Verify audio resumes