### PR TITLE
fix(player): report correct play state to the server on transitions

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -88,6 +88,7 @@ export default function DirectPlayerPage() {
   );
   const [isZoomedToFill, setIsZoomedToFill] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
+
   const [isMuted, setIsMuted] = useState(false);
   const [isBuffering, setIsBuffering] = useState(true);
   const [isVideoLoaded, setIsVideoLoaded] = useState(false);
@@ -463,18 +464,8 @@ export default function DirectPlayerPage() {
     setIsPlaying(!isPlaying);
     if (isPlaying) {
       await videoRef.current?.pause();
-      const progressInfo = currentPlayStateInfo();
-      if (progressInfo) {
-        playbackManager.reportPlaybackProgress(progressInfo);
-      }
     } else {
       videoRef.current?.play();
-      const progressInfo = currentPlayStateInfo();
-      if (!offline && api) {
-        await getPlaystateApi(api).reportPlaybackStart({
-          playbackStartInfo: progressInfo,
-        });
-      }
     }
   };
 
@@ -611,6 +602,17 @@ export default function DirectPlayerPage() {
     isPlaying,
     isMuted,
   ]);
+
+  // Report after the state commits. Reporting inside the play/pause handlers
+  // sent the pre-transition value, since setIsPlaying only applies next render.
+  // Deliberately excludes playbackManager: usePlaybackManager returns a new
+  // object every render, which would fire this on every render.
+  useEffect(() => {
+    if (!item?.Id || !hasPlaybackStarted) return;
+    playbackManager.reportPlaybackProgress(
+      currentPlayStateInfo() as PlaybackProgressInfo,
+    );
+  }, [currentPlayStateInfo, item?.Id, hasPlaybackStarted]);
 
   const lastUrlUpdateTime = useSharedValue(0);
   const wasJustSeeking = useSharedValue(false);
@@ -892,11 +894,6 @@ export default function DirectPlayerPage() {
         setHasPlaybackStarted(true);
         // Pause inactivity timer during playback (TV only)
         pauseInactivityTimer();
-        if (item?.Id) {
-          playbackManager.reportPlaybackProgress(
-            currentPlayStateInfo() as PlaybackProgressInfo,
-          );
-        }
         await activateKeepAwakeAsync();
         return;
       }
@@ -905,11 +902,6 @@ export default function DirectPlayerPage() {
         setIsPlaying(false);
         // Resume inactivity timer when paused (TV only)
         resumeInactivityTimer();
-        if (item?.Id) {
-          playbackManager.reportPlaybackProgress(
-            currentPlayStateInfo() as PlaybackProgressInfo,
-          );
-        }
         await deactivateKeepAwake();
         return;
       }

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -88,7 +88,6 @@ export default function DirectPlayerPage() {
   );
   const [isZoomedToFill, setIsZoomedToFill] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
-
   const [isMuted, setIsMuted] = useState(false);
   const [isBuffering, setIsBuffering] = useState(true);
   const [isVideoLoaded, setIsVideoLoaded] = useState(false);
@@ -286,9 +285,15 @@ export default function DirectPlayerPage() {
       // Clear the previous episode's stream so the loader gate stays closed
       // until the new item's stream resolves (avoids a stale MPV source frame).
       setStream(null);
+      // Scope the started flag and the position to the item being played. The
+      // component is reused across an in-place item switch, and both are read
+      // by the progress report below: left as-is, the new item is reported at
+      // the previous one's position before its own playback has even started.
+      setHasPlaybackStarted(false);
+      progress.set(0);
       fetchItemData();
     }
-  }, [itemId, offline, api, user?.Id]);
+  }, [itemId, offline, api, user?.Id, progress]);
 
   // Lock orientation based on user settings
   useEffect(() => {
@@ -608,11 +613,14 @@ export default function DirectPlayerPage() {
   // Deliberately excludes playbackManager: usePlaybackManager returns a new
   // object every render, which would fire this on every render.
   useEffect(() => {
-    if (!item?.Id || !hasPlaybackStarted) return;
-    playbackManager.reportPlaybackProgress(
-      currentPlayStateInfo() as PlaybackProgressInfo,
-    );
-  }, [currentPlayStateInfo, item?.Id, hasPlaybackStarted]);
+    if (!item?.Id || !stream || !hasPlaybackStarted) return;
+    // currentPlayStateInfo() returns undefined without a stream, and
+    // reportPlaybackProgress dereferences its argument immediately. Read it
+    // instead of casting so a gap between the item and its stream can't reject.
+    const progressInfo = currentPlayStateInfo();
+    if (!progressInfo) return;
+    void playbackManager.reportPlaybackProgress(progressInfo);
+  }, [currentPlayStateInfo, item?.Id, stream, hasPlaybackStarted]);
 
   const lastUrlUpdateTime = useSharedValue(0);
   const wasJustSeeking = useSharedValue(false);


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Playback state was reported to the server inverted at every transition, so the Jellyfin dashboard showed a session as paused while it was playing, and playing while it was paused.

`IsPaused` was derived from the `isPlaying` state variable, but every transition site called `currentPlayStateInfo()` in the same tick as `setIsPlaying()`. React state only applies on the next render, so the report carried the pre-transition value.

It looked intermittent because the periodic reporter in `onProgress` runs with a fresh closure and reports correctly, silently overwriting the bad value a moment later. Whether the dashboard looked right depended on whether you checked before or after the next progress tick.

Play state is now tracked in a ref updated synchronously alongside `setIsPlaying`, and the report reads that. Every call site is correct without having to compensate, so a future reporting site can't reintroduce the bug. `isPlaying` also drops out of the `currentPlayStateInfo` dependency array.

This additionally fixes two cases that were always wrong rather than intermittent:

- The mount report sent `IsPaused: true`, because `isPlaying` is `false` on first render while autoplay is already starting.
- Rolling into the next episode inherited the previous item's paused state.

No change to reporting frequency, and no new network calls. Offline is unaffected: `usePlaybackManager.reportPlaybackProgress` already persists locally and only reaches the server behind `if (isOnline && api)`.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A — no UI changes. The visible effect is in the Jellyfin dashboard's active session panel.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Open the Jellyfin web dashboard on **Dashboard → Active Devices** alongside the app.

**Pause/resume reporting**
1. Start playing anything and confirm the dashboard shows it as **playing**
2. Pause in the app, and confirm the dashboard flips to **paused** immediately rather than a second later
3. Resume, and confirm it flips back to **playing**
4. Repeat a few times quickly — state should always match, never invert

**Start of playback**
1. Fully exit the player and start a fresh item
2. Confirm the dashboard shows **playing** from the outset, without ever briefly showing paused

**Next episode**
1. Pause an episode, then let it roll into the next one (or trigger next)
2. Confirm the new episode reports **playing**, not the previous item's paused state

**Offline regression check**
1. Go offline with a downloaded item and play it
2. Confirm playback works and resume position is still saved locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback state synchronization for start, pause, and resume flows.
  * Adjusted when playback start and progress updates are reported so they match the most recent committed play state, avoiding premature or incorrect progress tied to the previous item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->