### PR TITLE
fix(player): report playback stopped when exiting a downloaded item

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -37,6 +37,7 @@ import {
 import { VideoPlayerView } from "@/components/video-player/VideoPlayerView";
 import useRouter from "@/hooks/useAppRouter";
 import { useHaptic } from "@/hooks/useHaptic";
+import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import { useOrientation } from "@/hooks/useOrientation";
 import { usePlaybackManager } from "@/hooks/usePlaybackManager";
 import usePlaybackSpeed from "@/hooks/usePlaybackSpeed";
@@ -179,6 +180,7 @@ export default function DirectPlayerPage() {
   // Playback manager for progress reporting and adjacent items
   const playbackManager = usePlaybackManager({ item, isOffline: offline });
   const { nextItem, previousItem } = playbackManager;
+  const { isConnected } = useNetworkStatus();
 
   // Resolve audio index: use URL param if provided, otherwise use stored index for offline playback
   const audioIndex = useMemo(() => {
@@ -482,14 +484,15 @@ export default function DirectPlayerPage() {
   const reportedStopSessionIdRef = useRef<string | null>(null);
 
   const reportPlaybackStopped = useCallback(async () => {
-    if (!item?.Id || !stream?.sessionId || offline || !api) return;
+    if (!item?.Id || !stream || !api || !isConnected) return;
     // Leaving the player reports "stopped" twice: once from the beforeRemove
     // listener (via stop()) and once from the unmount cleanup backstop. Dedupe
-    // per PlaySessionId — not a plain boolean, since the component survives
-    // in-place item switches and the next session must report again.
-    const sessionId = stream.sessionId;
-    if (reportedStopSessionIdRef.current === sessionId) return;
-    reportedStopSessionIdRef.current = sessionId;
+    // per session — not a plain boolean, since the component survives in-place
+    // item switches and the next session must report again. Downloaded items
+    // have no PlaySessionId, so fall back to the item id.
+    const stopKey = stream.sessionId || item.Id;
+    if (reportedStopSessionIdRef.current === stopKey) return;
+    reportedStopSessionIdRef.current = stopKey;
     const currentTimeInTicks = msToTicks(progress.get());
     try {
       await getPlaystateApi(api).reportPlaybackStopped({
@@ -497,7 +500,7 @@ export default function DirectPlayerPage() {
           ItemId: item.Id,
           MediaSourceId: mediaSourceId,
           PositionTicks: currentTimeInTicks,
-          PlaySessionId: sessionId,
+          PlaySessionId: stream.sessionId || undefined,
           // Release the server-side live stream (and its tuner slot) on stop.
           // Jellyfin only closes a live stream opened via autoOpenLiveStream when
           // the stop report carries its LiveStreamId; without it the stream leaks
@@ -511,7 +514,7 @@ export default function DirectPlayerPage() {
       // report from a WebSocket remote-stop (player still mounted) must not
       // suppress the report when the user then navigates away. Callers are
       // fire-and-forget, so swallow instead of rethrowing unhandled.
-      if (reportedStopSessionIdRef.current === sessionId) {
+      if (reportedStopSessionIdRef.current === stopKey) {
         reportedStopSessionIdRef.current = null;
       }
       writeToLog(
@@ -520,7 +523,7 @@ export default function DirectPlayerPage() {
         error instanceof Error ? error.message : String(error),
       );
     }
-  }, [api, item, mediaSourceId, stream, progress, offline]);
+  }, [api, item, mediaSourceId, stream, progress, isConnected]);
 
   const stop = useCallback(() => {
     // Update URL with final playback position before stopping

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -480,8 +480,9 @@ export default function DirectPlayerPage() {
     }
   };
 
-  // PlaySessionId of the last "stopped" report, to dedupe the double teardown.
-  const reportedStopSessionIdRef = useRef<string | null>(null);
+  // Key of the last "stopped" report, to dedupe the double teardown. The
+  // PlaySessionId when there is one, the item id otherwise (see stopKey below).
+  const reportedStopKeyRef = useRef<string | null>(null);
 
   const reportPlaybackStopped = useCallback(async () => {
     if (!item?.Id || !stream || !api || !isConnected) return;
@@ -491,8 +492,8 @@ export default function DirectPlayerPage() {
     // item switches and the next session must report again. Downloaded items
     // have no PlaySessionId, so fall back to the item id.
     const stopKey = stream.sessionId || item.Id;
-    if (reportedStopSessionIdRef.current === stopKey) return;
-    reportedStopSessionIdRef.current = stopKey;
+    if (reportedStopKeyRef.current === stopKey) return;
+    reportedStopKeyRef.current = stopKey;
     const currentTimeInTicks = msToTicks(progress.get());
     try {
       await getPlaystateApi(api).reportPlaybackStopped({
@@ -514,8 +515,8 @@ export default function DirectPlayerPage() {
       // report from a WebSocket remote-stop (player still mounted) must not
       // suppress the report when the user then navigates away. Callers are
       // fire-and-forget, so swallow instead of rethrowing unhandled.
-      if (reportedStopSessionIdRef.current === stopKey) {
-        reportedStopSessionIdRef.current = null;
+      if (reportedStopKeyRef.current === stopKey) {
+        reportedStopKeyRef.current = null;
       }
       writeToLog(
         "ERROR",


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Exiting a downloaded item never closed its server-side session, so it stayed listed as active on the Jellyfin dashboard.

`reportPlaybackStopped` returned early whenever `offline` was set, but that flag only means the source is a local file — it says nothing about whether the device has a network connection. Progress *is* still sent to the server in that state, because `usePlaybackManager.reportPlaybackProgress` posts whenever it has a connection. So Jellyfin opened a session, received progress, and then never got a stop.

Now gated on the actual connection instead. Two smaller things had to change with it:

- Downloaded streams are constructed with `sessionId: ""`, which also tripped the `!stream?.sessionId` guard. The dedupe key falls back to the item id when there's no PlaySessionId.
- `PlaySessionId` is omitted from the payload rather than sent as an empty string.

Genuinely disconnected playback is unchanged: `isConnected` is false, so it returns early exactly as before.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A — no UI changes. Visible in the Jellyfin dashboard's active session list.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Open **Dashboard → Active Devices** in the Jellyfin web UI alongside the app.

**Downloaded item, with network**
1. Download an item, then play it from the downloads screen with wifi on
2. Confirm the session appears in Active Devices
3. Exit the player
4. Confirm the session disappears, and the resume position on the server matches where you stopped

**Downloaded item, no network**
1. Enable airplane mode and play a downloaded item
2. Exit the player
3. Confirm no crash, no error toast, and the local resume position is still saved

**Streamed item (regression)**
1. Play a normal streamed item and exit
2. Confirm the session still closes as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback “stopped” updates to the playstate service so they only occur when network connectivity is available.
  - Avoided sending unnecessary stop notifications while offline.
  - Reduced duplicate “stopped” notifications by using a more reliable deduping key for both session-based and session-less playback.
  - Updated stop reporting so the play session identifier is sent when available, and cleared appropriately on matching failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->