### PR TITLE
refactor(player): name the stop dedupe ref after the key it holds

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -480,8 +480,9 @@ export default function DirectPlayerPage() {
     }
   };
 
-  // PlaySessionId of the last "stopped" report, to dedupe the double teardown.
-  const reportedStopSessionIdRef = useRef<string | null>(null);
+  // Key of the last "stopped" report, to dedupe the double teardown. The
+  // PlaySessionId when there is one, the item id otherwise (see stopKey below).
+  const reportedStopKeyRef = useRef<string | null>(null);
 
   const reportPlaybackStopped = useCallback(async () => {
     if (!item?.Id || !stream || !api || !isConnected) return;
@@ -491,8 +492,8 @@ export default function DirectPlayerPage() {
     // item switches and the next session must report again. Downloaded items
     // have no PlaySessionId, so fall back to the item id.
     const stopKey = stream.sessionId || item.Id;
-    if (reportedStopSessionIdRef.current === stopKey) return;
-    reportedStopSessionIdRef.current = stopKey;
+    if (reportedStopKeyRef.current === stopKey) return;
+    reportedStopKeyRef.current = stopKey;
     const currentTimeInTicks = msToTicks(progress.get());
     try {
       await getPlaystateApi(api).reportPlaybackStopped({
@@ -514,8 +515,8 @@ export default function DirectPlayerPage() {
       // report from a WebSocket remote-stop (player still mounted) must not
       // suppress the report when the user then navigates away. Callers are
       // fire-and-forget, so swallow instead of rethrowing unhandled.
-      if (reportedStopSessionIdRef.current === stopKey) {
-        reportedStopSessionIdRef.current = null;
+      if (reportedStopKeyRef.current === stopKey) {
+        reportedStopKeyRef.current = null;
       }
       writeToLog(
         "ERROR",


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Follow-up on #1873, opened against its branch so it can be folded in before that PR merges. Naming only, no behaviour change.

#1873 made the teardown dedupe fall back to the item id when a downloaded item has no PlaySessionId. The inner comment was updated for it, but the declaration was not:

```tsx
// PlaySessionId of the last "stopped" report, to dedupe the double teardown.
const reportedStopSessionIdRef = useRef<string | null>(null);
```

The ref no longer holds a PlaySessionId in the case the PR was written for, and the next person to touch this will read the declaration first. Renamed to `reportedStopKeyRef` and reworded so the two comments agree with the code and with each other.

This is the point Copilot raised on #1873.

## 🏷️ Ticket / Issue

Follow-up on #1873.

### 🖼️ Screenshots / GIFs (if UI)

N/A, no UI changes.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Rename plus comments, no runtime change. `bun run typecheck` and `biome check` pass.

The behaviour to confirm is #1873's own, unchanged by this PR: play a downloaded item with the network on, exit the player, and confirm the session disappears from Dashboard → Active Devices.
