### PR TITLE
fix(player): scope the new progress report to the active play session

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -88,7 +88,6 @@ export default function DirectPlayerPage() {
   );
   const [isZoomedToFill, setIsZoomedToFill] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
-
   const [isMuted, setIsMuted] = useState(false);
   const [isBuffering, setIsBuffering] = useState(true);
   const [isVideoLoaded, setIsVideoLoaded] = useState(false);
@@ -286,9 +285,15 @@ export default function DirectPlayerPage() {
       // Clear the previous episode's stream so the loader gate stays closed
       // until the new item's stream resolves (avoids a stale MPV source frame).
       setStream(null);
+      // Scope the started flag and the position to the item being played. The
+      // component is reused across an in-place item switch, and both are read
+      // by the progress report below: left as-is, the new item is reported at
+      // the previous one's position before its own playback has even started.
+      setHasPlaybackStarted(false);
+      progress.set(0);
       fetchItemData();
     }
-  }, [itemId, offline, api, user?.Id]);
+  }, [itemId, offline, api, user?.Id, progress]);
 
   // Lock orientation based on user settings
   useEffect(() => {
@@ -608,11 +613,14 @@ export default function DirectPlayerPage() {
   // Deliberately excludes playbackManager: usePlaybackManager returns a new
   // object every render, which would fire this on every render.
   useEffect(() => {
-    if (!item?.Id || !hasPlaybackStarted) return;
-    playbackManager.reportPlaybackProgress(
-      currentPlayStateInfo() as PlaybackProgressInfo,
-    );
-  }, [currentPlayStateInfo, item?.Id, hasPlaybackStarted]);
+    if (!item?.Id || !stream || !hasPlaybackStarted) return;
+    // currentPlayStateInfo() returns undefined without a stream, and
+    // reportPlaybackProgress dereferences its argument immediately. Read it
+    // instead of casting so a gap between the item and its stream can't reject.
+    const progressInfo = currentPlayStateInfo();
+    if (!progressInfo) return;
+    void playbackManager.reportPlaybackProgress(progressInfo);
+  }, [currentPlayStateInfo, item?.Id, stream, hasPlaybackStarted]);
 
   const lastUrlUpdateTime = useSharedValue(0);
   const wasJustSeeking = useSharedValue(false);


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Follow-up on #1872, opened against its branch so it can be folded in before that PR merges. The diagnosis in #1872 is right and the shape of the fix is right; this tightens two guards the new effect is missing, and drops a leftover blank line from the earlier revision.

### 1. The cast hides a reachable `undefined`

```tsx
useEffect(() => {
  if (!item?.Id || !hasPlaybackStarted) return;
  playbackManager.reportPlaybackProgress(
    currentPlayStateInfo() as PlaybackProgressInfo,
  );
}, [currentPlayStateInfo, item?.Id, hasPlaybackStarted]);
```

`currentPlayStateInfo()` returns `undefined` when there is no stream, and `reportPlaybackProgress` dereferences its argument on its first line (`playbackProgressInfo.PositionTicks`). The effect only guards on the item id, so the cast is load-bearing.

The window is the in-place item switch:

1. `itemId` changes, the item effect batches `setItem(null)` + `setStream(null)`, the effect bails on `!item?.Id`.
2. `fetchItemData()` is async, so `setItem(fetchedItem)` lands in a later commit. The item id is set, the stream is still `null`, and `hasPlaybackStarted` is still `true` from the previous episode.
3. Both guards pass, `currentPlayStateInfo()` returns `undefined`, the call throws inside an async function nobody awaits, and it surfaces as an unhandled rejection.

The render-level `if (... || !item || !stream) return <Loader />` does not help, since hooks run before it.

Fixed by reading the value and bailing rather than asserting it. The `!stream` guard is there so the precondition is stated where it is depended on, matching `currentPlayStateInfo`'s own guard.

### 2. `hasPlaybackStarted` and `progress` are not scoped to the item

Neither is reset on an item switch. Once the new stream lands, the effect fires with `PositionTicks: msToTicks(progress.get())`, which still holds the previous episode's position, since `progress` is only written from `onProgress`.

For a downloaded item that runs through `usePlaybackManager`, where `playedPercentage` is computed against the *new* item's runtime and anything over 90% writes `Played: true` locally. An episode that was never opened can end up marked as watched.

Reset both where the rest of the per-item state is already cleared, next to `setItem(null)` / `setStream(null)`.

## Why this and not what #1872 did first

**The effect stays, the ref does not come back.** The first revision of #1872 tracked play state in `isPlayingRef` and read it at each reporting site. It works, but it is correct only as long as every current and future call site remembers to read the ref, and both bots found sites the revision had missed. The effect has one reporting point and is correct by construction, because it runs after the commit that changed the state. Same reason the duplicate `reportPlaybackStart` on unpause could be dropped, which is a real gain on its own: re-sending Start on every resume re-registers the session server side, where jellyfin-web sends a Progress with `IsPaused: false`.

So the effect is the right shape. What it needs is the guards that the call sites used to provide implicitly. Reporting from inside the MPV `playing` / `paused` handlers could not see a null stream, because those events cannot fire without one. Hoisting the report into an effect removes that implicit precondition, so it has to be written down.

**Reset in the item effect rather than a session ref.** Tracking which session `hasPlaybackStarted` belongs to would work, but it adds a concept for something the file already does: the item effect is where `item`, `downloadedItem` and `stream` are cleared, so the started flag and the position belong there too. It also costs nothing visually, since the loader overlay this flag drives is already up while `stream` is null.

**`progress.set(0)` is safe at that point.** React runs effect cleanups before effect bodies, so on an item change the cleanup that reports "stopped" for the outgoing item runs first and still reads the correct position. The reset only lands afterwards.

## Not changed here, worth a separate look

The mount report still sends `IsPaused: true`. `reportPlaybackStart` is its own effect and reads `currentPlayStateInfo()` while `isPlaying` is still `false`, so the first Start is inverted and corrected by the first progress a moment later. #1872's description says this case is fixed, which was true of the ref revision but not of the current one. Out of scope for this follow-up, but the description is worth updating.

## 🏷️ Ticket / Issue

Follow-up on #1872.

### 🖼️ Screenshots / GIFs (if UI)

N/A, no UI changes. The visible effect is in the Jellyfin dashboard's active session panel.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

Device testing pending, see below. Not marking the platform box until it is done.

## 🔍 Testing Instructions

Open the Jellyfin web dashboard on **Dashboard → Active Devices** alongside the app.

**Next episode, the case this PR is about**
1. Play an episode of a series and let it reach a late position, or seek near the end
2. Trigger the next episode
3. Confirm the new episode does not appear at the previous one's position, on the dashboard or on the item page after exiting
4. With a downloaded series, repeat and confirm the next episode is not marked as watched

**No regression on #1872's fix**
1. Pause and resume a few times, confirm the dashboard state always matches and never inverts
2. Confirm the play/pause reporting still flips immediately rather than a second later

**Offline**
1. Go offline with a downloaded item and play it
2. Confirm playback works, the resume position is still saved locally, and no red box appears on entering or leaving
