### PR TITLE
fix(player): stop play state reports from carrying a stale value

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -689,6 +689,12 @@ export default function DirectPlayerPage() {
     async (data: { nativeEvent: MpvOnProgressEventPayload }) => {
       if (isSeeking.get() || isPlaybackStopped) return;
 
+      // An in-place episode switch clears the stream and resets the position
+      // while MPV can still emit one last tick for the previous episode.
+      // Bail before touching shared state: writing that position into the URL
+      // would make it the next episode's start position.
+      if (!item?.Id || item.Id !== itemId || !stream) return;
+
       const { position, cacheSeconds } = data.nativeEvent;
       // MPV reports position in seconds, convert to ms
       const currentTime = position * 1000;
@@ -720,12 +726,6 @@ export default function DirectPlayerPage() {
         lastUrlUpdateTime.value = now;
       }
 
-      if (!item?.Id) return;
-
-      // An in-place episode switch clears the stream while MPV can still emit
-      // one last tick. currentPlayStateInfo() is undefined without a stream and
-      // reportPlaybackProgress dereferences its argument straight away, so the
-      // old cast turned that tick into a crash.
       const progressInfo = currentPlayStateInfo();
       if (!progressInfo) return;
       playbackManager.reportPlaybackProgress(progressInfo);
@@ -735,6 +735,7 @@ export default function DirectPlayerPage() {
       // also covers the mute state, which this list used to miss.
       currentPlayStateInfo,
       item?.Id,
+      itemId,
       currentAudioIndex,
       currentSubtitleIndex,
       mediaSourceId,

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -172,22 +172,22 @@ export default function DirectPlayerPage() {
   const [item, setItem] = useState<BaseItemDto | null>(null);
   const initialSeekDoneRef = useRef(false);
 
-  const initialPlaybackTicksRef = useRef<number>(
-    playbackPositionFromUrl
-      ? Number.parseInt(playbackPositionFromUrl, 10)
-      : (item?.UserData?.PlaybackPositionTicks ?? 0),
-  );
-
   /** Position MPV is told to start from: the URL param wins, since it is
    * rewritten during playback, otherwise the item's stored resume position.
-   * The route is deep-linkable, so a param that isn't a positive number falls
-   * back instead of reaching getStreamUrl and MPV as NaN. */
+   * The route is deep-linkable, so the param is parsed whole rather than by
+   * prefix: parseInt would turn "1200invalid" into a position instead of
+   * falling back, and NaN would reach getStreamUrl and MPV. */
   const startTicks = useMemo(() => {
-    const fromUrl = Number.parseInt(playbackPositionFromUrl ?? "", 10);
-    return Number.isFinite(fromUrl) && fromUrl >= 0
+    const raw = playbackPositionFromUrl?.trim();
+    const fromUrl = raw ? Number(raw) : Number.NaN;
+    return Number.isInteger(fromUrl) && fromUrl >= 0
       ? fromUrl
       : (item?.UserData?.PlaybackPositionTicks ?? 0);
   }, [playbackPositionFromUrl, item?.UserData?.PlaybackPositionTicks]);
+
+  // Pinned on mount: the initial seek must not follow the position the player
+  // writes back into the URL every 30s.
+  const initialPlaybackTicksRef = useRef<number>(startTicks);
 
   const [downloadedItem, setDownloadedItem] = useState<DownloadedItem | null>(
     null,

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -186,7 +186,10 @@ export default function DirectPlayerPage() {
   }, [playbackPositionFromUrl, item?.UserData?.PlaybackPositionTicks]);
 
   // Pinned on mount: the initial seek must not follow the position the player
-  // writes back into the URL every 30s.
+  // writes back into the URL every 30s. Zero here is not a missed resume:
+  // PlayButton always passes playbackPosition, and when it is absent the
+  // resume still happens through the stream offset and MPV's startPosition,
+  // which read startTicks after the item has loaded.
   const initialPlaybackTicksRef = useRef<number>(startTicks);
 
   const [downloadedItem, setDownloadedItem] = useState<DownloadedItem | null>(

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -179,14 +179,15 @@ export default function DirectPlayerPage() {
   );
 
   /** Position MPV is told to start from: the URL param wins, since it is
-   * rewritten during playback, otherwise the item's stored resume position. */
-  const startTicks = useMemo(
-    () =>
-      playbackPositionFromUrl
-        ? Number.parseInt(playbackPositionFromUrl, 10)
-        : (item?.UserData?.PlaybackPositionTicks ?? 0),
-    [playbackPositionFromUrl, item?.UserData?.PlaybackPositionTicks],
-  );
+   * rewritten during playback, otherwise the item's stored resume position.
+   * The route is deep-linkable, so a param that isn't a positive number falls
+   * back instead of reaching getStreamUrl and MPV as NaN. */
+  const startTicks = useMemo(() => {
+    const fromUrl = Number.parseInt(playbackPositionFromUrl ?? "", 10);
+    return Number.isFinite(fromUrl) && fromUrl >= 0
+      ? fromUrl
+      : (item?.UserData?.PlaybackPositionTicks ?? 0);
+  }, [playbackPositionFromUrl, item?.UserData?.PlaybackPositionTicks]);
 
   const [downloadedItem, setDownloadedItem] = useState<DownloadedItem | null>(
     null,

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -88,6 +88,15 @@ export default function DirectPlayerPage() {
   );
   const [isZoomedToFill, setIsZoomedToFill] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
+  // Mirror of isPlaying that is already correct when a report is built.
+  // setIsPlaying only applies on the next render, so an MPV progress tick that
+  // was already in flight when the user paused would carry the pre-transition
+  // value, and MPV stops ticking while paused, so nothing would correct it.
+  const isPlayingRef = useRef(false);
+  const setPlaying = useCallback((playing: boolean) => {
+    isPlayingRef.current = playing;
+    setIsPlaying(playing);
+  }, []);
   const [isMuted, setIsMuted] = useState(false);
   const [isBuffering, setIsBuffering] = useState(true);
   const [isVideoLoaded, setIsVideoLoaded] = useState(false);
@@ -168,6 +177,17 @@ export default function DirectPlayerPage() {
       ? Number.parseInt(playbackPositionFromUrl, 10)
       : (item?.UserData?.PlaybackPositionTicks ?? 0),
   );
+
+  /** Position MPV is told to start from: the URL param wins, since it is
+   * rewritten during playback, otherwise the item's stored resume position. */
+  const startTicks = useMemo(
+    () =>
+      playbackPositionFromUrl
+        ? Number.parseInt(playbackPositionFromUrl, 10)
+        : (item?.UserData?.PlaybackPositionTicks ?? 0),
+    [playbackPositionFromUrl, item?.UserData?.PlaybackPositionTicks],
+  );
+
   const [downloadedItem, setDownloadedItem] = useState<DownloadedItem | null>(
     null,
   );
@@ -393,11 +413,6 @@ export default function DirectPlayerPage() {
             return null;
           }
 
-          // Calculate start ticks directly from item to avoid stale closure
-          const startTicks = playbackPositionFromUrl
-            ? Number.parseInt(playbackPositionFromUrl, 10)
-            : (item?.UserData?.PlaybackPositionTicks ?? 0);
-
           const res = await getStreamUrl({
             api,
             item,
@@ -457,17 +472,40 @@ export default function DirectPlayerPage() {
       const progressInfo = currentPlayStateInfo();
       if (progressInfo) {
         await getPlaystateApi(api).reportPlaybackStart({
-          playbackStartInfo: progressInfo,
+          playbackStartInfo: {
+            ...progressInfo,
+            // This runs once the stream resolves, before MPV has produced a
+            // frame: the live state still says paused at 0:00. The source is
+            // built with autoplay, so describe the session that is starting
+            // instead, or the dashboard shows "paused at 0:00" until the first
+            // progress tick.
+            IsPaused: false,
+            PositionTicks: startTicks,
+          },
         });
       }
     };
-    reportPlaybackStart();
+    // Fire-and-forget, so swallow instead of leaving an unhandled rejection
+    // whenever the server is unreachable at the moment playback starts.
+    reportPlaybackStart().catch((error) => {
+      writeToLog(
+        "ERROR",
+        "reportPlaybackStart failed",
+        error instanceof Error ? error.message : String(error),
+      );
+    });
+    // startTicks is read, not depended on: it is rewritten into the URL every
+    // 30s during playback, and re-running this would report a new playback
+    // start each time.
   }, [stream, api, offline]);
 
   const togglePlay = async () => {
     lightHapticFeedback();
-    setIsPlaying(!isPlaying);
-    if (isPlaying) {
+    // Read the ref so two taps inside one render cycle don't both see the same
+    // stale state and cancel each other out.
+    const wasPlaying = isPlayingRef.current;
+    setPlaying(!wasPlaying);
+    if (wasPlaying) {
       await videoRef.current?.pause();
     } else {
       videoRef.current?.play();
@@ -589,7 +627,10 @@ export default function DirectPlayerPage() {
       SubtitleStreamIndex: currentSubtitleIndex,
       MediaSourceId: mediaSourceId,
       PositionTicks: msToTicks(progress.get()),
-      IsPaused: !isPlaying,
+      // Read through the ref, not the isPlaying state: this is called from
+      // handlers that may have been created before the last transition, and a
+      // report must describe the state at the moment it is built.
+      IsPaused: !isPlayingRef.current,
       PlayMethod: stream?.url.includes("m3u8") ? "Transcode" : "DirectStream",
       PlaySessionId: stream.sessionId,
       IsMuted: isMuted,
@@ -604,14 +645,12 @@ export default function DirectPlayerPage() {
     currentSubtitleIndex,
     mediaSourceId,
     progress,
-    isPlaying,
     isMuted,
   ]);
 
-  // Report after the state commits. Reporting inside the play/pause handlers
-  // sent the pre-transition value, since setIsPlaying only applies next render.
-  // Deliberately excludes playbackManager: usePlaybackManager returns a new
-  // object every render, which would fire this on every render.
+  // Report after the state commits. Deliberately excludes playbackManager:
+  // usePlaybackManager returns a new object every render, which would fire this
+  // on every render.
   useEffect(() => {
     if (!item?.Id || !stream || !hasPlaybackStarted) return;
     // currentPlayStateInfo() returns undefined without a stream, and
@@ -620,7 +659,10 @@ export default function DirectPlayerPage() {
     const progressInfo = currentPlayStateInfo();
     if (!progressInfo) return;
     void playbackManager.reportPlaybackProgress(progressInfo);
-  }, [currentPlayStateInfo, item?.Id, stream, hasPlaybackStarted]);
+    // isPlaying is what makes a transition land here: currentPlayStateInfo now
+    // reads the play state through a ref, so its identity no longer changes
+    // when the user pauses or resumes.
+  }, [currentPlayStateInfo, isPlaying, item?.Id, stream, hasPlaybackStarted]);
 
   const lastUrlUpdateTime = useSharedValue(0);
   const wasJustSeeking = useSharedValue(false);
@@ -676,16 +718,22 @@ export default function DirectPlayerPage() {
 
       if (!item?.Id) return;
 
-      playbackManager.reportPlaybackProgress(
-        currentPlayStateInfo() as PlaybackProgressInfo,
-      );
+      // An in-place episode switch clears the stream while MPV can still emit
+      // one last tick. currentPlayStateInfo() is undefined without a stream and
+      // reportPlaybackProgress dereferences its argument straight away, so the
+      // old cast turned that tick into a crash.
+      const progressInfo = currentPlayStateInfo();
+      if (!progressInfo) return;
+      playbackManager.reportPlaybackProgress(progressInfo);
     },
     [
+      // Depend on the builder itself rather than re-listing what it reads: it
+      // also covers the mute state, which this list used to miss.
+      currentPlayStateInfo,
       item?.Id,
       currentAudioIndex,
       currentSubtitleIndex,
       mediaSourceId,
-      isPlaying,
       stream,
       isSeeking,
       isPlaybackStopped,
@@ -745,10 +793,6 @@ export default function DirectPlayerPage() {
       isTranscoding,
     );
 
-    // Calculate start position directly here to avoid timing issues
-    const startTicks = playbackPositionFromUrl
-      ? Number.parseInt(playbackPositionFromUrl, 10)
-      : (item?.UserData?.PlaybackPositionTicks ?? 0);
     const startPos = ticksToSeconds(startTicks);
 
     // Build source config - headers only needed for online streaming
@@ -799,8 +843,7 @@ export default function DirectPlayerPage() {
     stream?.url,
     stream?.mediaSource,
     stream?.requiredHttpHeaders,
-    item?.UserData?.PlaybackPositionTicks,
-    playbackPositionFromUrl,
+    startTicks,
     api?.basePath,
     api?.accessToken,
     audioIndex,
@@ -897,7 +940,7 @@ export default function DirectPlayerPage() {
       const { isPaused, isPlaying: playing, isLoading } = e.nativeEvent;
 
       if (playing) {
-        setIsPlaying(true);
+        setPlaying(true);
         setIsBuffering(false);
         setHasPlaybackStarted(true);
         // Pause inactivity timer during playback (TV only)
@@ -907,7 +950,7 @@ export default function DirectPlayerPage() {
       }
 
       if (isPaused) {
-        setIsPlaying(false);
+        setPlaying(false);
         // Resume inactivity timer when paused (TV only)
         resumeInactivityTimer();
         await deactivateKeepAwake();
@@ -918,13 +961,7 @@ export default function DirectPlayerPage() {
         setIsBuffering(isLoading);
       }
     },
-    [
-      playbackManager,
-      item?.Id,
-      progress,
-      pauseInactivityTimer,
-      resumeInactivityTimer,
-    ],
+    [setPlaying, pauseInactivityTimer, resumeInactivityTimer],
   );
 
   const _onPictureInPictureChange = useCallback(


### PR DESCRIPTION
# 📦 Pull Request

<!-- 
  🤖 AI ASSISTED? 
  Uncomment the line below if AI was used to assist with this PR:
-->
<!-- 
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#) -->

## 📝 Description

Follow-up to #1872. That PR moved play state reporting out of the play/pause handlers into an effect that runs after the state commits, which measurably shortened the window where the dashboard shows the wrong state. Two of the cases it set out to fix are still open, and one crash in the same code path is still reachable.

**A report can still describe a state that is already obsolete.** `currentPlayStateInfo()` reads the `isPlaying` state variable, so anything built before the render commit carries the pre-transition value. The MPV progress tick that is already in flight when the user pauses is exactly that: it reports `IsPaused: false`, and nothing orders it against the effect's report. When it lands last, MPV has already stopped ticking, so nothing corrects it and the session stays "playing" on the dashboard for the whole pause. Play state now lives in a ref updated synchronously alongside `setIsPlaying`, and `currentPlayStateInfo` reads that ref, so a late report carries the current value instead of the previous one. This is the mechanism #1872's description promised; the code took a different route that narrows the window rather than closing it.

**Playback start still reports paused at 0:00.** `reportPlaybackStart` runs when the stream resolves, before MPV has produced a frame, so the live state says paused and the position is still 0. The source is built with `autoplay: true`, so the report now describes the session that is actually starting: playing, at the resume position.

**A cleared stream could crash the progress reporter.** `onProgress` cast `currentPlayStateInfo()` to `PlaybackProgressInfo`, and `reportPlaybackProgress` dereferences its argument straight away. An in-place episode switch clears the stream while MPV can still emit one last tick, so that cast turned the tick into a `TypeError`. It now reads and guards, the same way the effect added in #1872 already does.

Smaller items in the same path: `reportPlaybackStart` no longer leaves an unhandled rejection when the server is unreachable, the start position is computed once instead of in three places, and `onPlaybackStateChanged` drops the dependencies it stopped reading in #1872, including `playbackManager`, which returns a new object on every render.

## 🏷️ Ticket / Issue

N/A. Follows #1872.

### 🖼️ Screenshots / GIFs (if UI)

N/A, no UI change. The effect is visible in the Jellyfin dashboard under Dashboard → Active Devices.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Open **Dashboard → Active Devices** in the Jellyfin web UI alongside the app.

**Start of playback**
1. Fully exit the player, then start any item that has a resume position
2. Confirm the dashboard shows it as playing, at the resume position, without ever showing paused or 0:00 first

**Pause and resume**
1. Pause in the app and leave it paused for ten seconds
2. Confirm the dashboard shows paused for that whole time, and never flips back to playing on its own
3. Resume, and repeat several times in a row

**Next episode**
1. Roll into the next episode from the player
2. Confirm the new episode is reported as playing, at its own resume position, not the previous item's

**Offline**
1. Enable airplane mode and play a downloaded item, then exit
2. Confirm playback works, no crash, and the local resume position advanced

### Results measured while writing this

Release builds on an Android emulator against a Jellyfin 10.11 server, comparing develop before #1872, develop with #1872, and this branch. Session state was read from Jellyfin's WebSocket session feed rather than by polling `/Sessions`: polling through a reverse proxy stalls for several seconds at a time, which makes a missed report indistinguishable from a slow one.

| | before #1872 | #1872 | this branch |
| --- | --- | --- | --- |
| Time the dashboard shows "paused" when playback starts | 1.1 / 1.5 / 2.0 s | ~0.4 s | none, over 3 runs |
| Pause and resume transitions that reached the server | 4/6 | 5/6 | 12/12 |
| Next episode reported at the new item's position | yes | yes | yes |
| Offline downloaded item, local resume kept | yes | yes | yes |

One caveat for anyone repeating this: do not read transition latency off that feed. Jellyfin pushes session state on a timer rather than on change, around eleven pushes during an eight second pause while the app is sending nothing, with a median gap of 421 ms. Observed latency is dominated by the wait for the next push, so the feed is good for telling whether a transition was reported and bad for telling how fast.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback state reporting to better match rapid play/pause transitions and stabilize “paused” status.
  * Fixed resume/start positioning by consistently using the URL-specified playback position (or the item default) for both seeking and playback-start reporting.
  * Stabilized progress updates during episode switching, including safe handling when the stream context temporarily changes.
  * Made playback-start reporting more resilient by switching to non-blocking fire-and-forget behavior with controlled error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->