### PR TITLE
fix(player): stop reporting playback the server cannot trust

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -239,6 +239,16 @@ export default function DirectPlayerPage() {
   const { nextItem, previousItem } = playbackManager;
   const { isConnected } = useNetworkStatus();
 
+  // usePlaybackManager returns a new object on every render, so the reporters
+  // below cannot list it as a dependency without being rebuilt constantly.
+  // Mirror the progress reporter instead: it closes over connectivity and the
+  // api, and a handler captured while either was different would keep
+  // reporting through the stale one for the rest of playback.
+  const reportProgressRef = useRef(playbackManager.reportPlaybackProgress);
+  useEffect(() => {
+    reportProgressRef.current = playbackManager.reportPlaybackProgress;
+  });
+
   // Resolve audio index: use URL param if provided, otherwise use stored index for offline playback
   const audioIndex = useMemo(() => {
     if (audioIndexFromUrl !== undefined) {
@@ -734,7 +744,7 @@ export default function DirectPlayerPage() {
     // instead of casting so a gap between the item and its stream can't reject.
     const progressInfo = currentPlayStateInfo();
     if (!progressInfo) return;
-    void playbackManager.reportPlaybackProgress(progressInfo);
+    void reportProgressRef.current(progressInfo);
     // isPlaying is what makes a transition land here: currentPlayStateInfo now
     // reads the play state through a ref, so its identity no longer changes
     // when the user pauses or resumes.
@@ -819,7 +829,7 @@ export default function DirectPlayerPage() {
 
       const progressInfo = currentPlayStateInfo();
       if (!progressInfo) return;
-      playbackManager.reportPlaybackProgress(progressInfo);
+      void reportProgressRef.current(progressInfo);
     },
     [
       // Depend on the builder itself rather than re-listing what it reads: it

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -376,6 +376,15 @@ export default function DirectPlayerPage() {
     isConnectedRef.current = isConnected;
   }, [isConnected]);
 
+  // The item the player is on as of the last commit. The MPV view holds the
+  // callbacks it was last rendered with, and on an in-place switch those close
+  // over the outgoing item for both the loaded item and the route param, so
+  // they agree with each other and pass a comparison between the two.
+  const currentItemIdRef = useRef(itemId);
+  useEffect(() => {
+    currentItemIdRef.current = itemId;
+  }, [itemId]);
+
   const releaseLiveStream = useCallback(
     (liveStreamId: string | null) => {
       if (!liveStreamId || !apiRef.current || offline) return;
@@ -659,9 +668,11 @@ export default function DirectPlayerPage() {
 
     // A downloaded item plays from a local file: it is neither streamed nor
     // transcoded, so report DirectPlay rather than mislabelling the session.
-    let playMethod: PlaybackProgressInfo["PlayMethod"] = "DirectStream";
-    if (offline) playMethod = "DirectPlay";
-    else if (stream.url.includes("m3u8")) playMethod = "Transcode";
+    const playMethod: PlaybackProgressInfo["PlayMethod"] = offline
+      ? "DirectPlay"
+      : stream.url.includes("m3u8")
+        ? "Transcode"
+        : "DirectStream";
 
     return {
       ItemId: item.Id,
@@ -743,8 +754,11 @@ export default function DirectPlayerPage() {
       // An in-place episode switch clears the stream and resets the position
       // while MPV can still emit one last tick for the previous episode.
       // Bail before touching shared state: writing that position into the URL
-      // would make it the next episode's start position.
+      // would make it the next episode's start position, and reporting it
+      // after the switch already reported "stopped" would put the outgoing
+      // episode back in the server session.
       if (!item?.Id || item.Id !== itemId || !stream) return;
+      if (item.Id !== currentItemIdRef.current) return;
 
       const { position, cacheSeconds } = data.nativeEvent;
       // MPV reports position in seconds, convert to ms

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -82,6 +82,15 @@ export default function DirectPlayerPage() {
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
 
   const [isPlaybackStopped, setIsPlaybackStopped] = useState(false);
+  // Mirror of isPlaybackStopped that is already set when a report is built.
+  // The MPV view keeps the onProgress it was last rendered with, so a tick
+  // already in flight when the user leaves would still report progress after
+  // the "stopped" report and bring the session back on the server.
+  const isPlaybackStoppedRef = useRef(false);
+  const markPlaybackStopped = useCallback(() => {
+    isPlaybackStoppedRef.current = true;
+    setIsPlaybackStopped(true);
+  }, []);
   const [showControls, _setShowControls] = useState(true);
   const [isPipMode, setIsPipMode] = useState(false);
   const [aspectRatio] = useState<"default" | "16:9" | "4:3" | "1:1" | "21:9">(
@@ -570,7 +579,7 @@ export default function DirectPlayerPage() {
       playbackPosition: msToTicks(progress.get()).toString(),
     });
     reportPlaybackStopped();
-    setIsPlaybackStopped(true);
+    markPlaybackStopped();
     // Synchronously destroy the mpv instance + decoder + surface buffers
     // BEFORE the screen unmounts. Otherwise the next screen (or the next
     // episode's player) mounts while the old 4K decoder is still alive,
@@ -588,7 +597,13 @@ export default function DirectPlayerPage() {
     // and only released on the "paused" event; without this, navigating
     // away mid-play leaves FLAG_KEEP_SCREEN_ON set on the window.
     deactivateKeepAwake();
-  }, [videoRef, reportPlaybackStopped, progress, resumeInactivityTimer]);
+  }, [
+    videoRef,
+    reportPlaybackStopped,
+    markPlaybackStopped,
+    progress,
+    resumeInactivityTimer,
+  ]);
 
   // Keep refs to the latest stop / stopped-report so the effects below don't
   // need these churning callbacks in their dependency arrays. Reporting
@@ -665,6 +680,9 @@ export default function DirectPlayerPage() {
   // on every render.
   useEffect(() => {
     if (!item?.Id || !stream || !hasPlaybackStarted) return;
+    // Destroying the player emits a last paused event, which lands here: read
+    // the ref so the transition report doesn't follow the "stopped" report.
+    if (isPlaybackStoppedRef.current) return;
     // currentPlayStateInfo() returns undefined without a stream, and
     // reportPlaybackProgress dereferences its argument immediately. Read it
     // instead of casting so a gap between the item and its stream can't reject.
@@ -695,7 +713,7 @@ export default function DirectPlayerPage() {
   /** Progress handler for MPV - position in seconds */
   const onProgress = useCallback(
     async (data: { nativeEvent: MpvOnProgressEventPayload }) => {
-      if (isSeeking.get() || isPlaybackStopped) return;
+      if (isSeeking.get() || isPlaybackStoppedRef.current) return;
 
       // An in-place episode switch clears the stream and resets the position
       // while MPV can still emit one last tick for the previous episode.
@@ -749,7 +767,6 @@ export default function DirectPlayerPage() {
       mediaSourceId,
       stream,
       isSeeking,
-      isPlaybackStopped,
       isBuffering,
     ],
   );

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -695,8 +695,14 @@ export default function DirectPlayerPage() {
   }, [currentPlayStateInfo, isPlaying, item?.Id, stream, hasPlaybackStarted]);
 
   const lastUrlUpdateTime = useSharedValue(0);
+  const lastProgressReportTime = useSharedValue(0);
   const wasJustSeeking = useSharedValue(false);
   const URL_UPDATE_INTERVAL = 30000; // Update URL every 30 seconds instead of every second
+  // Heartbeat cadence for the periodic progress report. MPV ticks once a
+  // second, but the server only needs the position often enough for Now
+  // Playing and resume: state changes (pause, resume, track, mute) are
+  // reported on their own by the effect above, and a seek reports immediately.
+  const PROGRESS_REPORT_INTERVAL = 10000;
 
   // Track when seeking ends to update URL immediately
   useAnimatedReaction(
@@ -751,6 +757,16 @@ export default function DirectPlayerPage() {
         });
         lastUrlUpdateTime.value = now;
       }
+
+      // Reporting every tick meant one request per second per player, and for
+      // a downloaded item the whole downloads database was serialized and
+      // written to storage on each one (plus two query invalidations). Report
+      // right after a seek, since the position jumped, otherwise heartbeat.
+      const shouldReportProgress =
+        shouldUpdateUrl ||
+        now - lastProgressReportTime.get() >= PROGRESS_REPORT_INTERVAL;
+      if (!shouldReportProgress) return;
+      lastProgressReportTime.value = now;
 
       const progressInfo = currentPlayStateInfo();
       if (!progressInfo) return;

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -70,6 +70,30 @@ import { writeToLog } from "@/utils/log";
 import { msToTicks, ticksToSeconds } from "@/utils/time";
 import { generateDeviceProfile } from "../../../utils/profiles/native";
 
+type PlayMethod = "DirectPlay" | "DirectStream" | "Transcode";
+
+/**
+ * How the session is actually being played. Shared by the reports sent to the
+ * server and the technical info overlay, so the dashboard and the app never
+ * disagree about the same playback.
+ */
+function getPlayMethod(
+  source: { url?: string | null; mediaSource?: MediaSourceInfo | null },
+  offline: boolean,
+): PlayMethod {
+  // A downloaded item plays from a local file, with no server in the path.
+  if (offline) return "DirectPlay";
+  const url = source.url ?? "";
+  if (url.includes("m3u8") || source.mediaSource?.TranscodingUrl) {
+    return "Transcode";
+  }
+  // Served through the stream endpoint rather than as the original file.
+  if (url.includes("/Videos/") && url.includes("/stream")) {
+    return "DirectStream";
+  }
+  return "DirectPlay";
+}
+
 export default function DirectPlayerPage() {
   const videoRef = useRef<MpvPlayerViewRef>(null);
   const user = useAtomValue(userAtom);
@@ -666,14 +690,6 @@ export default function DirectPlayerPage() {
     | undefined => {
     if (!stream || !item?.Id) return;
 
-    // A downloaded item plays from a local file: it is neither streamed nor
-    // transcoded, so report DirectPlay rather than mislabelling the session.
-    const playMethod: PlaybackProgressInfo["PlayMethod"] = offline
-      ? "DirectPlay"
-      : stream.url.includes("m3u8")
-        ? "Transcode"
-        : "DirectStream";
-
     return {
       ItemId: item.Id,
       // Report the live selection so server-side session/resume state reflects
@@ -687,7 +703,7 @@ export default function DirectPlayerPage() {
       // handlers that may have been created before the last transition, and a
       // report must describe the state at the moment it is built.
       IsPaused: !isPlayingRef.current,
-      PlayMethod: playMethod,
+      PlayMethod: getPlayMethod(stream, offline),
       PlaySessionId: stream.sessionId,
       IsMuted: isMuted,
       CanSeek: true,
@@ -1260,25 +1276,10 @@ export default function DirectPlayerPage() {
   }, []);
 
   // Determine play method based on stream URL and media source
-  const playMethod = useMemo<
-    "DirectPlay" | "DirectStream" | "Transcode" | undefined
-  >(() => {
+  const playMethod = useMemo<PlayMethod | undefined>(() => {
     if (!stream?.url) return undefined;
-
-    // Check if transcoding (m3u8 playlist or TranscodingUrl present)
-    if (stream.url.includes("m3u8") || stream.mediaSource?.TranscodingUrl) {
-      return "Transcode";
-    }
-
-    // Check if direct play (no container remuxing needed)
-    // Direct play means the file is being served as-is
-    if (stream.url.includes("/Videos/") && stream.url.includes("/stream")) {
-      return "DirectStream";
-    }
-
-    // Default to direct play if we're not transcoding
-    return "DirectPlay";
-  }, [stream?.url, stream?.mediaSource?.TranscodingUrl]);
+    return getPlayMethod(stream, offline);
+  }, [stream, offline]);
 
   // Extract transcode reasons from the TranscodingUrl
   const transcodeReasons = useMemo<string[]>(() => {

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -604,11 +604,15 @@ export default function DirectPlayerPage() {
   }, [stop, reportPlaybackStopped]);
 
   // Report playback stopped only on a real source switch or unmount.
+  // itemId (the route param) is listed alongside the loaded item so the report
+  // runs in the same commit as an in-place switch, before the effect that
+  // resets the shared position for the incoming item: keyed on item.Id alone,
+  // the report could land a commit later and carry a position of zero.
   useEffect(() => {
     return () => {
       reportPlaybackStoppedRef.current();
     };
-  }, [item?.Id, stream?.sessionId, mediaSourceId]);
+  }, [itemId, item?.Id, stream?.sessionId, mediaSourceId]);
 
   // Stop on navigation-away. Re-subscribing when the navigation object identity
   // changes (e.g. after a setParams) no longer reports anything on its own.

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -368,6 +368,14 @@ export default function DirectPlayerPage() {
     apiRef.current = api;
   }, [api]);
 
+  // Read connectivity without making it a dependency of the start report: a
+  // network flap mid-playback would otherwise fire a second PlaybackStart and
+  // move the server session back to the position playback began at.
+  const isConnectedRef = useRef(isConnected);
+  useEffect(() => {
+    isConnectedRef.current = isConnected;
+  }, [isConnected]);
+
   const releaseLiveStream = useCallback(
     (liveStreamId: string | null) => {
       if (!liveStreamId || !apiRef.current || offline) return;
@@ -482,7 +490,11 @@ export default function DirectPlayerPage() {
   ]);
 
   useEffect(() => {
-    if (!stream || !api || offline) return;
+    // Gate on connectivity rather than on the offline flag: a downloaded item
+    // played with the server reachable still reports progress and, since the
+    // stop report is connectivity-based too, would otherwise close a session
+    // it never opened, which the server's playback history then discards.
+    if (!stream || !api || !isConnectedRef.current) return;
     const reportPlaybackStart = async () => {
       const progressInfo = currentPlayStateInfo();
       if (progressInfo) {
@@ -512,7 +524,7 @@ export default function DirectPlayerPage() {
     // startTicks is read, not depended on: it is rewritten into the URL every
     // 30s during playback, and re-running this would report a new playback
     // start each time.
-  }, [stream, api, offline]);
+  }, [stream, api]);
 
   const togglePlay = async () => {
     lightHapticFeedback();
@@ -645,6 +657,12 @@ export default function DirectPlayerPage() {
     | undefined => {
     if (!stream || !item?.Id) return;
 
+    // A downloaded item plays from a local file: it is neither streamed nor
+    // transcoded, so report DirectPlay rather than mislabelling the session.
+    let playMethod: PlaybackProgressInfo["PlayMethod"] = "DirectStream";
+    if (offline) playMethod = "DirectPlay";
+    else if (stream.url.includes("m3u8")) playMethod = "Transcode";
+
     return {
       ItemId: item.Id,
       // Report the live selection so server-side session/resume state reflects
@@ -658,7 +676,7 @@ export default function DirectPlayerPage() {
       // handlers that may have been created before the last transition, and a
       // report must describe the state at the moment it is built.
       IsPaused: !isPlayingRef.current,
-      PlayMethod: stream?.url.includes("m3u8") ? "Transcode" : "DirectStream",
+      PlayMethod: playMethod,
       PlaySessionId: stream.sessionId,
       IsMuted: isMuted,
       CanSeek: true,
@@ -673,6 +691,7 @@ export default function DirectPlayerPage() {
     mediaSourceId,
     progress,
     isMuted,
+    offline,
   ]);
 
   // Report after the state commits. Deliberately excludes playbackManager:


### PR DESCRIPTION
# 📦 Pull Request

<!-- 
  🤖 AI ASSISTED? 
  Uncomment the line below if AI was used to assist with this PR:
-->
<!-- 
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#) -->

## 📝 Description

Four fixes in the same code path, one per commit, found while checking on device what the server actually receives after #1872, #1879 and #1873. Every claim below was measured against `LastPlaybackCheckIn` on the session, not read off the code: the server extrapolates `PositionTicks` between reports, so a moving position in `/Sessions` proves nothing on its own.

### 1. A session that keeps playing after you leave the player

**What you see today.** You exit the player, and the Jellyfin dashboard still shows you watching that episode, with the position climbing on its own. It stays that way until the server gives up on the session. Anyone sharing the server sees it, playback statistics count time nobody watched, and anything driven by session state acts on a session that ended minutes ago.

**Why.** Leaving reports "stopped", but the MPV view still holds the `onProgress` callback from the render before the exit, and destroying the player emits one last paused event that lands in the transition effect. Either one reports progress right after the stop, and a progress report for an item the server considers stopped puts it back in the session. From there the server extrapolates the position, which is why the counter keeps moving with no client sending anything.

**Fix.** `isPlaybackStopped` gets a ref mirror set synchronously by `stop()`, and both report paths read the ref instead of the state. A report already on its way now bails out. Same shape as the `isPlayingRef` mirror added in #1879, for the same class of race.

### 2. One request per second, and a full database rewrite per second offline

**What you see today.** Nothing directly, but the player sends its position to the server on every MPV tick, which is once a second: about 1300 requests over a 22 minute episode. On a downloaded item it is worse. Each report also rewrites the entire downloads database to storage and invalidates two query keys, so with a large downloads library that is a full serialize and write every second during playback.

**Why.** `onProgress` reported unconditionally. The heartbeat and the state changes were the same code path.

**Fix.** Report right after a seek, since the position jumped, and otherwise every ten seconds. State changes are unaffected: pause, resume, track and mute changes already report on their own through the effect that runs after the state commits, so they stay immediate. Measured: reports land exactly ten seconds apart, and pause and resume still reach the server in under a second.

### 3. A downloaded item was never a real session for the server

**What you see today.** Watch a downloaded episode with the server reachable and it does not show up in your playback history or statistics, even though the app is talking to the server the whole time. The session also claims `DirectStream` while the file is local.

**Why.** #1873 made the stop report connectivity-based, which is what closes the session, but the start report was still gated on the `offline` route flag. The server received a stop for a playback it never saw begin: it logs `Playback stop did not have a tracker` and drops the entry.

**Fix.** Gate the start report on connectivity too, so a download played online opens the session it later closes, and report `DirectPlay` for local playback. Connectivity is read through a ref rather than a dependency: as a dependency, a network flap mid-playback would fire a second `PlaybackStart` and move the session back to the position playback began at.

### 4. Stop position on an in-place episode switch

Hardening, not an observed failure. The stopped report is keyed on the loaded item, while the effect that prepares the incoming episode resets the shared position as soon as the route param changes. Both currently land in the same commit, so the report runs first, but only because the media source id happens to change along with the item. If it ever did not, the report would carry a position of zero and the episode you just left would lose its resume point. Depending on the route param as well makes the order explicit.

## 🏷️ Ticket / Issue

N/A. Follows #1872, #1879 and #1873.

### 🖼️ Screenshots / GIFs (if UI)

N/A, no UI change. The effects are visible in the Jellyfin dashboard under Dashboard → Active Devices.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Open **Dashboard → Active Devices** in the Jellyfin web UI alongside the app. Note that the position shown there keeps moving between reports on its own, so judge the reports themselves, not the counter.

**No session left behind**
1. Play any item for about twenty seconds, then exit the player
2. Confirm the device disappears from Active Devices and stays gone
3. Repeat immediately: play, exit, play, exit. The race is timing dependent, so a single pass can miss it

**Report cadence**
1. Play a streamed item and leave it running for a minute
2. Confirm the session stays alive and the reported state stays correct
3. Pause, wait ten seconds, resume, several times in a row
4. Confirm the dashboard flips to paused and back within about a second each time

**Downloaded item with the server reachable**
1. Play a downloaded item from the Downloads screen with network on
2. Confirm the dashboard shows it playing, and the play method is direct play
3. Exit, and confirm the item appears in the user's playback history

**In-place episode switch**
1. With two consecutive downloaded episodes, play the first, use the next episode button, then the previous one, then exit
2. Confirm each segment is reported at its own position and none is reported at zero

**Offline**
1. Enable airplane mode, play a downloaded item, exit
2. Confirm playback works, no crash, and the local resume position advanced

### Results measured while writing this

Android emulator, release build, server reports counted from `LastPlaybackCheckIn` and the server log.

| Case | Result |
|---|---|
| Streamed, one minute | reports exactly 10 s apart, pause and resume reported in under a second |
| Exit, twice in a row | one final report, session idle and stays idle |
| Same case before the fix | session came back 4 s after exit and kept extrapolating for about 90 s |
| Downloaded, network on | play method direct play, start tracker created, stop matched to it |
| Downloaded, before the fix | `Playback stop did not have a tracker`, playback dropped from history |
| In-place switch E1 → E2 → E1 | three reports, positions 752418 ms, 43753 ms, 810059 ms, none at zero |
| Airplane mode | no report attempted, no crash, local resume advanced |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback start/stop and progress reporting reliability during stop, in-place episode switches, and exiting the player.
  * Prevented stale progress and URL position updates from being sent after playback ends.
  * Refined playback-mode detection for consistent controls and reporting across streaming and downloaded scenarios.
* **Performance**
  * Throttled server playback progress reporting to reduce update frequency, while keeping immediate position updates after seeks and periodic refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->