### PR TITLE
fix(player): drive the next episode countdown from the remaining time

### DIFF
--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -386,7 +386,10 @@ export const Controls: FC<Props> = ({
 
   const showNextEpisode =
     showNextEpisodeFromCredits || showNextEpisodeFromRemainingTime;
-  const autoAdvanceNextEpisode = showNextEpisodeFromRemainingTime && isPlaying;
+  // Whether reaching the end of the item may advance on its own. Pausing is
+  // not a reason to take that away: the countdown follows the remaining time,
+  // which stops moving while playback does.
+  const autoAdvanceNextEpisode = showNextEpisodeFromRemainingTime;
 
   const goToItemCommon = useCallback(
     (item: BaseItemDto) => {
@@ -647,6 +650,9 @@ export const Controls: FC<Props> = ({
             willShowNextEpisode={willShowNextEpisode}
             showNextEpisode={showNextEpisode}
             autoAdvanceNextEpisode={autoAdvanceNextEpisode}
+            remainingTime={remainingTime}
+            isPlaying={isPlaying}
+            itemId={item.Id}
             skipIntro={skipIntro}
             skipCredit={skipCredit}
             onNextEpisodeFinish={handleNextEpisodeAutoPlay}

--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -382,7 +382,8 @@ export const Controls: FC<Props> = ({
   // Driven by actual playback position vs. duration, independent of segment
   // metadata, so it's safe to auto-advance from this trigger.
   const showNextEpisodeFromRemainingTime =
-    willShowNextEpisode && remainingTime < 10000;
+    willShowNextEpisode &&
+    remainingTime < CONTROLS_CONSTANTS.NEXT_EPISODE_COUNTDOWN_MS;
 
   const showNextEpisode =
     showNextEpisodeFromCredits || showNextEpisodeFromRemainingTime;

--- a/components/video-player/controls/NextEpisodeCountDownButton.tsx
+++ b/components/video-player/controls/NextEpisodeCountDownButton.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   TouchableOpacity,
@@ -9,7 +9,6 @@ import {
 import Animated, {
   cancelAnimation,
   Easing,
-  runOnJS,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -26,42 +25,97 @@ interface NextEpisodeCountDownButtonProps extends TouchableOpacityProps {
   // it (e.g. credits-segment metadata) isn't reliable enough to act on
   // without the user confirming.
   autoAdvance?: boolean;
+  /** Media time left in the current item, in milliseconds. */
+  remainingMs: number;
+  isPlaying: boolean;
+  /** Id of the item being played, to scope the countdown to it. */
+  itemId?: string | null;
 }
+
+/** Media time the fill represents, matching the window the button appears in. */
+const COUNTDOWN_WINDOW_MS = 10000;
+/**
+ * The player reports its position about once a second, so the last sample of
+ * an item can sit that far short of the end. Anything inside this window is
+ * the end of the item.
+ */
+const END_OF_ITEM_MS = 1000;
+/** One position sample: the interval a single fill step has to cover. */
+const SAMPLE_MS = 1000;
 
 const NextEpisodeCountDownButton: React.FC<NextEpisodeCountDownButtonProps> = ({
   onFinish,
   onPress,
   show,
   autoAdvance = true,
+  remainingMs,
+  isPlaying,
+  itemId,
   ...props
 }) => {
   const progress = useSharedValue(0);
+  // Advancing is one-way per appearance: without this, any re-render inside
+  // the end-of-item window would navigate again.
+  const hasAdvancedRef = useRef(false);
+  // The remaining time is only trustworthy once the player has reported a
+  // position for the item on screen. Until then it still describes the
+  // previous episode, which reads as "one second left" the moment the next one
+  // starts and would chain through a whole season. Advancing waits for a
+  // sample that is clearly not the end.
+  const hasSeenItemRunningRef = useRef(false);
+  const countedItemRef = useRef(itemId);
+
+  // Fill from the item's own clock rather than from a countdown of its own.
+  // A timer has to be told about everything that happens to playback: it
+  // drifts as soon as the speed is not 1x, keeps running while playback is
+  // paused, and ignores seeks. The remaining time already covers all three.
+  const target =
+    show && autoAdvance
+      ? Math.min(Math.max(1 - remainingMs / COUNTDOWN_WINDOW_MS, 0), 1)
+      : 0;
 
   useEffect(() => {
-    if (show && autoAdvance) {
+    if (!show) {
+      cancelAnimation(progress);
       progress.value = 0;
-      progress.value = withTiming(
-        1,
-        {
-          duration: 10000, // 10 seconds
-          easing: Easing.linear,
-        },
-        (finished) => {
-          if (finished && onFinish) {
-            runOnJS(onFinish)();
-          }
-        },
-      );
-
-      // Cancel animation on unmount to prevent onFinish from firing after exit
-      return () => {
-        cancelAnimation(progress);
-      };
+      hasAdvancedRef.current = false;
+      return;
     }
-    // Not auto-advancing (or not shown): keep the fill empty, no timer.
-    cancelAnimation(progress);
-    progress.value = 0;
-  }, [show, autoAdvance, onFinish]);
+
+    // Reach for the next sample instead of jumping to it, so the fill moves
+    // smoothly between two position reports. Paused playback stops moving the
+    // target, which leaves the fill where it is instead of emptying it.
+    progress.value = withTiming(target, {
+      duration: SAMPLE_MS,
+      easing: Easing.linear,
+    });
+
+    // Cancel on unmount so nothing keeps animating after the player is gone.
+    return () => {
+      cancelAnimation(progress);
+    };
+  }, [show, target, progress]);
+
+  useEffect(() => {
+    if (countedItemRef.current !== itemId) {
+      countedItemRef.current = itemId;
+      hasSeenItemRunningRef.current = false;
+      hasAdvancedRef.current = false;
+    }
+    if (remainingMs > END_OF_ITEM_MS) hasSeenItemRunningRef.current = true;
+
+    if (!show || !autoAdvance || !onFinish) return;
+    if (hasAdvancedRef.current || !hasSeenItemRunningRef.current) return;
+    // Android keeps the player open at the end of a file, so it pauses itself
+    // there instead of reporting a position past the end. Treat a pause inside
+    // the last sample as the end of the item, and keep the plain check for
+    // players that do report past the item's duration.
+    const reachedEnd = remainingMs <= 0;
+    const stoppedAtEnd = !isPlaying && remainingMs <= END_OF_ITEM_MS;
+    if (!reachedEnd && !stoppedAtEnd) return;
+    hasAdvancedRef.current = true;
+    onFinish();
+  }, [show, autoAdvance, remainingMs, isPlaying, itemId, onFinish]);
 
   const animatedStyle = useAnimatedStyle(() => {
     return {

--- a/components/video-player/controls/NextEpisodeCountDownButton.tsx
+++ b/components/video-player/controls/NextEpisodeCountDownButton.tsx
@@ -15,6 +15,7 @@ import Animated, {
 } from "react-native-reanimated";
 import { Text } from "@/components/common/Text";
 import { Colors } from "@/constants/Colors";
+import { CONTROLS_CONSTANTS } from "./constants";
 
 interface NextEpisodeCountDownButtonProps extends TouchableOpacityProps {
   onFinish?: () => void;
@@ -33,7 +34,7 @@ interface NextEpisodeCountDownButtonProps extends TouchableOpacityProps {
 }
 
 /** Media time the fill represents, matching the window the button appears in. */
-const COUNTDOWN_WINDOW_MS = 10000;
+const COUNTDOWN_WINDOW_MS = CONTROLS_CONSTANTS.NEXT_EPISODE_COUNTDOWN_MS;
 /**
  * The player reports its position about once a second, so the last sample of
  * an item can sit that far short of the end. Anything inside this window is

--- a/components/video-player/controls/SkipSegmentOverlay.tsx
+++ b/components/video-player/controls/SkipSegmentOverlay.tsx
@@ -19,6 +19,11 @@ interface Props {
   willShowNextEpisode: boolean;
   showNextEpisode: boolean;
   autoAdvanceNextEpisode: boolean;
+  /** Media time left in the current item, in milliseconds. */
+  remainingTime: number;
+  isPlaying: boolean;
+  /** Id of the item being played, to scope the countdown to it. */
+  itemId?: string | null;
   skipIntro: () => void;
   skipCredit: () => void;
   onNextEpisodeFinish: () => void;
@@ -73,6 +78,9 @@ export const SkipSegmentOverlay: FC<Props> = ({
   willShowNextEpisode,
   showNextEpisode,
   autoAdvanceNextEpisode,
+  remainingTime,
+  isPlaying,
+  itemId,
   skipIntro,
   skipCredit,
   onNextEpisodeFinish,
@@ -136,6 +144,9 @@ export const SkipSegmentOverlay: FC<Props> = ({
       <NextEpisodeCountDownButton
         show={showNextEpisode}
         autoAdvance={autoAdvanceNextEpisode}
+        remainingMs={remainingTime}
+        isPlaying={isPlaying}
+        itemId={itemId}
         onFinish={onNextEpisodeFinish}
         onPress={onNextEpisodePress}
       />

--- a/components/video-player/controls/constants.ts
+++ b/components/video-player/controls/constants.ts
@@ -1,5 +1,8 @@
 export const CONTROLS_CONSTANTS = {
   TIMEOUT: 4000,
+  // Media time left when the next episode button appears. The countdown fill
+  // spans the same window, so both must move together.
+  NEXT_EPISODE_COUNTDOWN_MS: 10000,
   SCRUB_INTERVAL_MS: 30 * 1000, // 30 seconds in ms
   SCRUB_INTERVAL_TICKS: 10 * 10000000, // 10 seconds in ticks
   TILE_WIDTH: 150,


### PR DESCRIPTION
# 📦 Pull Request

<!-- 
  🤖 AI ASSISTED? 
  Uncomment the line below if AI was used to assist with this PR:
-->
<!-- 
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#) -->

## 📝 Description

On top of #1877, targeting its branch so it can go in with it.

Splitting the two triggers is right and this keeps it. What this changes is the countdown itself, because the second commit there ("pause auto-skip when playback is paused") stops an episode watched to the end from ever advancing on Android, and the original "skips too soon" is still reachable at any speed other than 1x.

### What breaks today

**An episode watched to the end never advances.** Android configures mpv with `keep-open=always` (`MPVLayerRenderer.kt:253`), so at the end of a file the player pauses itself instead of stopping. `autoAdvanceNextEpisode` is gated on `isPlaying`, and the button reacts to losing that by cancelling the animation and setting `progress.value = 0`. The fill empties a moment before it would have completed, and nothing advances.

Reproduced on the branch as it stands, Android emulator, starting Avatar S1E3 25 seconds before the end:

| One second left | End of the episode |
|---|---|
| ![countdown almost full](https://raw.githubusercontent.com/Gauvino/streamyfin/assets/next-episode-countdown/before-countdown-full.png) | ![fill emptied, still on episode 3](https://raw.githubusercontent.com/Gauvino/streamyfin/assets/next-episode-countdown/before-reset-at-end.png) |

The second shot is eight seconds after the end: play button showing (mpv paused itself), fill empty, still episode 3. It stays there.

**Pausing on purpose has the same effect.** The fill is emptied rather than held, so resuming starts a fresh ten second countdown with less than ten seconds of media left. It can no longer complete before the end.

**Skipping too soon is still reachable.** The countdown is a ten second wall-clock timer, started when ten seconds of *media* remain. The two only agree at 1x. At 0.75x those ten seconds of media take 13.3 seconds, so the timer completes about three seconds before the episode ends and skips over the tail. Above 1x it completes after the end.

### What this changes

The fill is derived from the remaining time rather than run as a timer of its own: `1 - remainingMs / 10000`, animated toward each new position sample so it still moves smoothly. Advancing happens when the item ends, which is either the position reaching the end or the player pausing itself inside the last position sample.

That is one source of truth instead of two clocks that have to be kept in sync:

- playback speed is already baked into the remaining time, so no early or late skip at any speed
- pausing stops the remaining time from moving, so the fill freezes where it is and nothing has to detect the pause
- seeking backwards moves it back, forwards moves it forward
- the end of the file is the end of the countdown, by definition

The countdown is also scoped to the item it counts for. Right after an in-place episode switch the remaining time still describes the previous episode, which reads as "one second left" for the new one. Without that guard the first version of this patch chained from episode 3 to episode 6 in one go, which is a good illustration of why the trigger has to be tied to the item.

### After

| Same scenario, end of the episode | Pause during the countdown |
|---|---|
| ![episode 4 playing](https://raw.githubusercontent.com/Gauvino/streamyfin/assets/next-episode-countdown/after-advanced.png) | ![fill frozen mid way](https://raw.githubusercontent.com/Gauvino/streamyfin/assets/next-episode-countdown/after-frozen-on-pause.png) |

Episode 3 ends, episode 4 starts on its own, once. Pausing with four seconds left holds the fill where it is for as long as the pause lasts, and resuming advances at the end.

At 0.75x, where the old timer completed about three seconds early, the fill now tracks the media instead of the wall clock: one second of media left is a fill that is nearly complete, and the episode is still playing.

| 0.75x, one second of media left | Same run, after the end |
|---|---|
| ![still playing, fill nearly complete](https://raw.githubusercontent.com/Gauvino/streamyfin/assets/next-episode-countdown/after-075x-one-second-left.png) | ![episode 4 playing](https://raw.githubusercontent.com/Gauvino/streamyfin/assets/next-episode-countdown/after-075x-advanced.png) |

## 🏷️ Ticket / Issue

N/A. Builds on #1877.

### 🖼️ Screenshots / GIFs (if UI)

Above. No layout change, the button is the same, only what drives its fill.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Autoplay has to be enabled, and the consecutive episode counter has to be below the limit, otherwise the "Are you still watching?" overlay takes over.

**An episode watched to the end**
1. Start an episode that has a next one, and let it reach the end
2. Confirm the next episode starts on its own, once

**Pause during the countdown**
1. In the last ten seconds, pause
2. Confirm the fill stops where it is instead of emptying, and nothing advances while paused
3. Resume, and confirm it advances at the end

**Playback speed**
1. Set the speed to 0.75x and let an episode reach the end
2. Confirm nothing is skipped before the end, and that it advances when the episode is actually over

**Credits trigger**
1. On an episode whose credits segment reports content after them, confirm the button still appears without a fill and only advances when tapped

Measured on the Android emulator, starting an episode 25 seconds before its end:

| Case | Before | After |
|---|---|---|
| Episode watched to the end | fill emptied at the end, stayed on the same episode | next episode starts, once |
| Pause with four seconds left | fill emptied, could no longer complete | fill frozen where it was, nothing advances |
| Resume after that pause | ten second countdown restarted, never completed | advances at the end |
| 0.75x speed | timer completed about three seconds before the end | still playing one second from the end, advances when the episode is over |

The autoplay episode limit was set to disabled while measuring, so the "Are you still watching?" overlay could not take over the runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic next-episode playback to follow the current video’s actual remaining time.
  * Updated the next-episode countdown to pause, reset, and complete accurately when playback state or the video changes.
  * Improved skip and next-episode controls for paused playback and videos reaching their end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->