### PR TITLE
fix(android): pin okhttp to 4.12.0 to match React Native

### DIFF
--- a/modules/background-downloader/android/build.gradle
+++ b/modules/background-downloader/android/build.gradle
@@ -16,11 +16,19 @@ android {
 }
 
 dependencies {
-  // Must stay on 4.x: React Native 0.86 declares okhttp 4.9.2 in
+  // Must stay on 4.x. React Native 0.86 declares okhttp 4.9.2 in
   // gradle/libs.versions.toml and exposes it with api(), so it sits on the app
-  // classpath. Gradle resolves the highest version across the classpath, so a
+  // classpath. Gradle resolves the highest version across that classpath, so a
   // 5.x here silently upgrades React Native's own okhttp and breaks the classes
   // it was compiled against (JavaNetCookieJar moved in 5), throwing
   // NoClassDefFoundError on the first request that carries cookies.
-  implementation "com.squareup.okhttp3:okhttp:4.12.0"
+  //
+  // strictly rather than a plain version: a plain one only *requests* 4.12.0,
+  // so any future transitive 5.x would quietly win again. This turns that
+  // conflict into a resolution failure instead of a runtime crash.
+  implementation("com.squareup.okhttp3:okhttp") {
+    version {
+      strictly("4.12.0")
+    }
+  }
 }

--- a/modules/background-downloader/android/build.gradle
+++ b/modules/background-downloader/android/build.gradle
@@ -16,5 +16,11 @@ android {
 }
 
 dependencies {
-  implementation "com.squareup.okhttp3:okhttp:5.4.0"
+  // Must stay on 4.x: React Native 0.86 declares okhttp 4.9.2 in
+  // gradle/libs.versions.toml and exposes it with api(), so it sits on the app
+  // classpath. Gradle resolves the highest version across the classpath, so a
+  // 5.x here silently upgrades React Native's own okhttp and breaks the classes
+  // it was compiled against (JavaNetCookieJar moved in 5), throwing
+  // NoClassDefFoundError on the first request that carries cookies.
+  implementation "com.squareup.okhttp3:okhttp:4.12.0"
 }


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

`modules/background-downloader` pinned `com.squareup.okhttp3:okhttp:5.4.0`. That single pin decides the okhttp version for the **whole app**, not just this module.

React Native 0.86 declares `okhttp = "4.9.2"` in `node_modules/react-native/gradle/libs.versions.toml` and exposes it with `api()` (`ReactAndroid/build.gradle.kts`), so React Native's own okhttp sits on the app classpath. Gradle resolves the highest version found across that classpath, so the 5.4.0 here silently upgraded React Native's dependency to a major version it was never compiled against. `JavaNetCookieJar` moved in okhttp 5, so the first request carrying cookies throws `NoClassDefFoundError`.

Symptom on a fresh debug build: the app crashes on startup with a blank screen, and the expo-dev-client launcher reports "The last time you tried to open an app the development build crashed". Release builds survived, which is why CI stayed green and the bump auto-merged.

Repinned to 4.12.0, the last 4.x, with the reasoning left in the file so a future dependency bump does not silently reintroduce it.

Introduced by #1631.

## 🏷️ Ticket / Issue

N/A — regression on `develop`, no issue filed.

### 🖼️ Screenshots / GIFs (if UI)

N/A — build configuration only.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms _(Android-only change; verified on an Android phone emulator and an Android TV emulator — before the fix the dev build crashed on startup, after it the app launches and runs normally)_
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

## 🔍 Testing Instructions

Needs a **fresh** Android build — an existing `android/` directory keeps the previously resolved dependency graph and hides the problem.

1. `bun run prebuild` (or `bun run prebuild:tv` for TV)
2. `bun run android` (or `bun run android:tv`)
3. The app launches and reaches the home screen instead of crashing to a blank screen
4. Downloads still work, which is what this module is for

To reproduce the bug first, check out `develop`, run a clean prebuild and build, and watch the app crash on startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android background download reliability by tightening the networking library version handling to avoid silent dependency upgrades.
  * Prevented potential runtime missing-class crashes by ensuring the app uses the expected OkHttp major/minor version range instead of an incompatible one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->