### PR TITLE
feat: add native hero media-bar on the home screen

### DIFF
--- a/components/home/Home.tsx
+++ b/components/home/Home.tsx
@@ -28,6 +28,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button } from "@/components/Button";
 import { Text } from "@/components/common/Text";
 import { InfiniteScrollingCollectionList } from "@/components/home/InfiniteScrollingCollectionList";
+import { PromotedHeroCarousel } from "@/components/home/PromotedHeroCarousel";
 import { StreamystatsPromotedWatchlists } from "@/components/home/StreamystatsPromotedWatchlists";
 import { StreamystatsRecommendations } from "@/components/home/StreamystatsRecommendations";
 import { Loader } from "@/components/Loader";
@@ -200,6 +201,56 @@ const HomeMobile = () => {
     () => data?.filter((l) => !settings?.hiddenLibraries?.includes(l.Id!)),
     [data, settings?.hiddenLibraries],
   );
+
+  // Fetch hero items (Continue Watching + Next Up combined)
+  const { data: heroItems } = useQuery({
+    queryKey: ["home", "heroCarousel", user?.Id],
+    queryFn: async () => {
+      if (!api || !user?.Id) return [];
+
+      const [resumeResponse, nextUpResponse] = await Promise.all([
+        getItemsApi(api).getResumeItems({
+          userId: user.Id,
+          enableImageTypes: ["Primary", "Backdrop", "Thumb"],
+          includeItemTypes: ["Movie", "Series", "Episode"],
+          fields: ["Overview", "Genres"],
+          startIndex: 0,
+          limit: 10,
+        }),
+        getTvShowsApi(api).getNextUp({
+          userId: user.Id,
+          startIndex: 0,
+          limit: 10,
+          fields: ["Overview", "Genres"],
+          enableImageTypes: ["Primary", "Backdrop", "Thumb"],
+          enableResumable: false,
+        }),
+      ]);
+
+      const resumeItems = resumeResponse.data.Items || [];
+      const nextUpItems = nextUpResponse.data.Items || [];
+
+      const combined = [...resumeItems, ...nextUpItems];
+      const sorted = combined.sort((a, b) => {
+        const dateA = a.UserData?.LastPlayedDate || a.DateCreated || "";
+        const dateB = b.UserData?.LastPlayedDate || b.DateCreated || "";
+        return new Date(dateB).getTime() - new Date(dateA).getTime();
+      });
+
+      const seen = new Set<string>();
+      const deduped: BaseItemDto[] = [];
+      for (const item of sorted) {
+        if (!item.Id || seen.has(item.Id)) continue;
+        seen.add(item.Id);
+        deduped.push(item);
+      }
+
+      return deduped.slice(0, 15);
+    },
+    enabled: !!api && !!user?.Id && settings.showLargeHomeCarousel,
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
+  });
 
   const collections = useMemo(() => {
     const allow = ["movies", "tvshows"];
@@ -505,6 +556,11 @@ const HomeMobile = () => {
 
   const sections = settings?.home?.sections ? customSections : defaultSections;
 
+  const showHero = useMemo(
+    () => !!heroItems && heroItems.length > 0 && settings.showLargeHomeCarousel,
+    [heroItems, settings.showLargeHomeCarousel],
+  );
+
   // Get all high priority section keys and check if all have loaded
   const highPrioritySectionKeys = useMemo(() => {
     return sections
@@ -619,6 +675,7 @@ const HomeMobile = () => {
         className='flex flex-col space-y-4'
         style={{ paddingTop: Platform.OS === "android" ? 10 : 0 }}
       >
+        {showHero && heroItems && <PromotedHeroCarousel items={heroItems} />}
         {sections.map((section, index) => {
           // Render Streamystats sections after Recently Added sections
           // For default sections: place after Recently Added, before Suggested Movies (if present)

--- a/components/home/Home.tsx
+++ b/components/home/Home.tsx
@@ -35,6 +35,7 @@ import { Loader } from "@/components/Loader";
 import { MediaListSection } from "@/components/medialists/MediaListSection";
 import { Colors } from "@/constants/Colors";
 import useRouter from "@/hooks/useAppRouter";
+import { useHeroItems } from "@/hooks/useHeroItems";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import { useRefreshLibraryOnFocus } from "@/hooks/useRefreshLibraryOnFocus";
 import { useInvalidatePlaybackProgressCache } from "@/hooks/useRevalidatePlaybackProgressCache";
@@ -202,55 +203,8 @@ const HomeMobile = () => {
     [data, settings?.hiddenLibraries],
   );
 
-  // Fetch hero items (Continue Watching + Next Up combined)
-  const { data: heroItems } = useQuery({
-    queryKey: ["home", "heroCarousel", user?.Id],
-    queryFn: async () => {
-      if (!api || !user?.Id) return [];
-
-      const [resumeResponse, nextUpResponse] = await Promise.all([
-        getItemsApi(api).getResumeItems({
-          userId: user.Id,
-          enableImageTypes: ["Primary", "Backdrop", "Thumb"],
-          includeItemTypes: ["Movie", "Series", "Episode"],
-          fields: ["Overview", "Genres"],
-          startIndex: 0,
-          limit: 10,
-        }),
-        getTvShowsApi(api).getNextUp({
-          userId: user.Id,
-          startIndex: 0,
-          limit: 10,
-          fields: ["Overview", "Genres"],
-          enableImageTypes: ["Primary", "Backdrop", "Thumb"],
-          enableResumable: false,
-        }),
-      ]);
-
-      const resumeItems = resumeResponse.data.Items || [];
-      const nextUpItems = nextUpResponse.data.Items || [];
-
-      const combined = [...resumeItems, ...nextUpItems];
-      const sorted = combined.sort((a, b) => {
-        const dateA = a.UserData?.LastPlayedDate || a.DateCreated || "";
-        const dateB = b.UserData?.LastPlayedDate || b.DateCreated || "";
-        return new Date(dateB).getTime() - new Date(dateA).getTime();
-      });
-
-      const seen = new Set<string>();
-      const deduped: BaseItemDto[] = [];
-      for (const item of sorted) {
-        if (!item.Id || seen.has(item.Id)) continue;
-        seen.add(item.Id);
-        deduped.push(item);
-      }
-
-      return deduped.slice(0, 15);
-    },
-    enabled: !!api && !!user?.Id && settings.showLargeHomeCarousel,
-    staleTime: 60 * 1000,
-    refetchInterval: 60 * 1000,
-  });
+  // Hero items (Continue Watching + Next Up combined), shared with Home.tv.tsx
+  const { data: heroItems } = useHeroItems(settings.showLargeHomeCarousel);
 
   const collections = useMemo(() => {
     const allow = ["movies", "tvshows"];

--- a/components/home/Home.tv.tsx
+++ b/components/home/Home.tv.tsx
@@ -34,6 +34,7 @@ import { TVHeroCarousel } from "@/components/home/TVHeroCarousel";
 import { Loader } from "@/components/Loader";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import useRouter from "@/hooks/useAppRouter";
+import { useHeroItems } from "@/hooks/useHeroItems";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import { useRefreshLibraryOnFocus } from "@/hooks/useRefreshLibraryOnFocus";
 import { useInvalidatePlaybackProgressCache } from "@/hooks/useRevalidatePlaybackProgressCache";
@@ -220,56 +221,8 @@ export const Home = () => {
     refetchInterval: 60 * 1000,
   });
 
-  // Fetch hero items (Continue Watching + Next Up combined)
-  const { data: heroItems } = useQuery({
-    queryKey: ["home", "heroItems", user?.Id],
-    queryFn: async () => {
-      if (!api || !user?.Id) return [];
-
-      const [resumeResponse, nextUpResponse] = await Promise.all([
-        getItemsApi(api).getResumeItems({
-          userId: user.Id,
-          enableImageTypes: ["Primary", "Backdrop", "Thumb"],
-          includeItemTypes: ["Movie", "Series", "Episode"],
-          fields: ["Overview"],
-          startIndex: 0,
-          limit: 10,
-        }),
-        getTvShowsApi(api).getNextUp({
-          userId: user.Id,
-          startIndex: 0,
-          limit: 10,
-          fields: ["Overview"],
-          enableImageTypes: ["Primary", "Backdrop", "Thumb"],
-          enableResumable: false,
-        }),
-      ]);
-
-      const resumeItems = resumeResponse.data.Items || [];
-      const nextUpItems = nextUpResponse.data.Items || [];
-
-      // Combine, sort by recent activity, and dedupe
-      const combined = [...resumeItems, ...nextUpItems];
-      const sorted = combined.sort((a, b) => {
-        const dateA = a.UserData?.LastPlayedDate || a.DateCreated || "";
-        const dateB = b.UserData?.LastPlayedDate || b.DateCreated || "";
-        return new Date(dateB).getTime() - new Date(dateA).getTime();
-      });
-
-      const seen = new Set<string>();
-      const deduped: BaseItemDto[] = [];
-      for (const item of sorted) {
-        if (!item.Id || seen.has(item.Id)) continue;
-        seen.add(item.Id);
-        deduped.push(item);
-      }
-
-      return deduped.slice(0, 15);
-    },
-    enabled: !!api && !!user?.Id,
-    staleTime: 60 * 1000,
-    refetchInterval: 60 * 1000,
-  });
+  // Hero items (Continue Watching + Next Up combined), shared with Home.tsx
+  const { data: heroItems } = useHeroItems();
 
   useEffect(() => {
     updateTVDiscovery({

--- a/components/home/PromotedHeroCarousel.tsx
+++ b/components/home/PromotedHeroCarousel.tsx
@@ -5,7 +5,11 @@ import { useIsFocused } from "expo-router";
 import { useAtomValue } from "jotai";
 import React, { useCallback, useMemo, useRef } from "react";
 import { StyleSheet, useWindowDimensions, View } from "react-native";
-import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import {
+  Gesture,
+  GestureDetector,
+  type PanGesture,
+} from "react-native-gesture-handler";
 import Animated, {
   runOnJS,
   useSharedValue,
@@ -142,6 +146,16 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
     [progress],
   );
 
+  // Without this, the carousel's underlying pan gesture has no directional
+  // restriction and will claim any drag - including a vertical scroll
+  // attempt - before the parent ScrollView ever sees it. Restricting it to
+  // horizontal movement lets a vertical drag fail fast here and fall
+  // through to the ScrollView, while a horizontal drag still activates the
+  // slide swipe normally.
+  const configurePanGesture = useCallback((gesture: PanGesture) => {
+    gesture.activeOffsetX([-10, 10]).failOffsetY([-10, 10]);
+  }, []);
+
   const heroTooTall = heroHeight > windowHeight * MAX_HERO_HEIGHT_RATIO;
 
   if (cappedItems.length === 0 || heroTooTall) return null;
@@ -158,6 +172,7 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
         width={windowWidth}
         height={heroHeight}
         data={cappedItems}
+        onConfigurePanGesture={configurePanGesture}
         mode='parallax'
         modeConfig={{
           parallaxScrollingScale: 0.96,
@@ -357,6 +372,13 @@ const HeroSlide: React.FC<HeroSlideProps> = React.memo(
     const tap = Gesture.Tap()
       .maxDuration(2000)
       .shouldCancelWhenOutside(true)
+      // No default distance limit exists on a tap gesture - without one, it
+      // only fails once the touch leaves the card's bounds, which a
+      // vertical scroll attempt often never does (it just moves up/down
+      // within the same card). That let this gesture sit active for the
+      // whole press, blocking the ScrollView above it from ever seeing the
+      // touch. Failing fast on any real drag hands it off immediately.
+      .maxDistance(10)
       .onBegin(() => {
         pressOverlayOpacity.value = withTiming(0.2, { duration: 100 });
       })

--- a/components/home/PromotedHeroCarousel.tsx
+++ b/components/home/PromotedHeroCarousel.tsx
@@ -4,6 +4,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import { useIsFocused } from "expo-router";
 import { useAtomValue } from "jotai";
 import React, { useCallback, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { StyleSheet, useWindowDimensions, View } from "react-native";
 import {
   Gesture,
@@ -303,6 +304,7 @@ const HeroSlide: React.FC<HeroSlideProps> = React.memo(
     const api = useAtomValue(apiAtom);
     const router = useAppRouter();
     const lightHapticFeedback = useHaptic("light");
+    const { t } = useTranslation();
     // A scrim overlay rather than dimming the card's own opacity: the wide
     // layout's left panel is a solid near-black background, so fading its
     // opacity toward transparent is barely visible there while the image
@@ -402,8 +404,10 @@ const HeroSlide: React.FC<HeroSlideProps> = React.memo(
           <Animated.View
             accessible
             accessibilityRole='button'
-            accessibilityLabel={`Open ${displayTitle}`}
-            accessibilityHint='Opens item details'
+            accessibilityLabel={t("home.open_item", {
+              title: displayTitle,
+            })}
+            accessibilityHint={t("home.open_item_hint")}
             accessibilityActions={[{ name: "activate" }]}
             onAccessibilityAction={({ nativeEvent }) => {
               if (nativeEvent.actionName === "activate") handlePress();

--- a/components/home/PromotedHeroCarousel.tsx
+++ b/components/home/PromotedHeroCarousel.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import { useIsFocused } from "expo-router";
 import { useAtomValue } from "jotai";
 import React, { useCallback, useMemo, useRef } from "react";
-import { Dimensions, StyleSheet, View } from "react-native";
+import { StyleSheet, useWindowDimensions, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
   runOnJS,
@@ -27,13 +27,14 @@ import { getBackdropUrl } from "@/utils/jellyfin/image/getBackdropUrl";
 import { getLogoImageUrlById } from "@/utils/jellyfin/image/getLogoImageUrlById";
 import { runtimeTicksToMinutes } from "@/utils/time";
 
-const { width: SCREEN_WIDTH } = Dimensions.get("window");
-
-// Cards are inset from the screen edges so neighboring slides peek in via
-// the parallax carousel mode.
-const HERO_CARD_WIDTH = SCREEN_WIDTH - 32;
-// 16:9 backdrop plus room for the logo/title + overview overlay.
-const HERO_HEIGHT = Math.round(HERO_CARD_WIDTH * (9 / 16)) + 100;
+// Card width is capped so wide screens (iPad, Android tablets, phones in
+// landscape) get a centered card with breathing room instead of one
+// stretched edge-to-edge into a banner. Below this width the cap has no
+// effect and behavior matches the original edge-to-edge phone layout.
+const MAX_CARD_WIDTH = 720;
+const CARD_SIDE_GUTTER = 16;
+// How much of the neighboring card should peek in past its own gutter.
+const NEIGHBOR_PEEK = 20;
 
 const getYear = (item: BaseItemDto): string | null => {
   if (item.ProductionYear) return item.ProductionYear.toString();
@@ -55,14 +56,33 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
   const ref = useRef<ICarouselInstance>(null);
   const progress = useSharedValue(0);
   const { settings } = useSettings();
+  const { width: windowWidth } = useWindowDimensions();
   const autoPlayIntervalMs =
     (settings?.heroCarouselRotationSeconds ?? 6) * 1000;
 
   const cappedItems = useMemo(() => items.slice(0, 8), [items]);
 
+  // Everything below is derived purely from the current window width, so it
+  // adapts live to rotation and iPad multitasking (Split View, Stage
+  // Manager) with no phone/tablet branching.
+  const cardWidth = useMemo(
+    () => Math.min(windowWidth - CARD_SIDE_GUTTER * 2, MAX_CARD_WIDTH),
+    [windowWidth],
+  );
+  // 16:9 backdrop plus room for the logo/title + overview overlay.
+  const heroHeight = useMemo(
+    () => Math.round(cardWidth * (9 / 16)) + 100,
+    [cardWidth],
+  );
+  // Half the leftover width once the card is centered - equals
+  // CARD_SIDE_GUTTER until the cap above kicks in, then grows from there.
+  const sideGutter = (windowWidth - cardWidth) / 2;
+
   const renderItem = useCallback(
-    ({ item }: { item: BaseItemDto }) => <HeroSlide item={item} />,
-    [],
+    ({ item }: { item: BaseItemDto }) => (
+      <HeroSlide item={item} cardWidth={cardWidth} heroHeight={heroHeight} />
+    ),
+    [cardWidth, heroHeight],
   );
 
   const onPressPagination = useCallback(
@@ -86,13 +106,13 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
         loop={cappedItems.length > 1}
         snapEnabled
         vertical={false}
-        width={SCREEN_WIDTH}
-        height={HERO_HEIGHT}
+        width={windowWidth}
+        height={heroHeight}
         data={cappedItems}
         mode='parallax'
         modeConfig={{
           parallaxScrollingScale: 0.96,
-          parallaxScrollingOffset: 36,
+          parallaxScrollingOffset: sideGutter + NEIGHBOR_PEEK,
         }}
         onProgressChange={progress}
         renderItem={renderItem}
@@ -118,190 +138,201 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
   );
 };
 
-const HeroSlide: React.FC<{ item: BaseItemDto }> = React.memo(({ item }) => {
-  const api = useAtomValue(apiAtom);
-  const router = useRouter();
-  const lightHapticFeedback = useHaptic("light");
-  const opacity = useSharedValue(1);
+interface HeroSlideProps {
+  item: BaseItemDto;
+  cardWidth: number;
+  heroHeight: number;
+}
 
-  const backdropUrl = useMemo(
-    () =>
-      getBackdropUrl({
-        api,
-        item,
-        quality: 80,
-        width: Math.floor(HERO_CARD_WIDTH * 2),
-      }),
-    [api, item],
-  );
+const HeroSlide: React.FC<HeroSlideProps> = React.memo(
+  ({ item, cardWidth, heroHeight }) => {
+    const api = useAtomValue(apiAtom);
+    const router = useRouter();
+    const lightHapticFeedback = useHaptic("light");
+    const opacity = useSharedValue(1);
 
-  const logoUrl = useMemo(
-    () => getLogoImageUrlById({ api, item, height: 56 }),
-    [api, item],
-  );
+    const backdropUrl = useMemo(
+      () =>
+        getBackdropUrl({
+          api,
+          item,
+          quality: 80,
+          width: Math.floor(cardWidth * 2),
+        }),
+      [api, item, cardWidth],
+    );
 
-  const displayTitle =
-    item.Type === "Episode"
-      ? item.SeriesName || item.Name || ""
-      : item.Name || "";
+    const logoUrl = useMemo(
+      () => getLogoImageUrlById({ api, item, height: 56 }),
+      [api, item],
+    );
 
-  const episodeSubtitle =
-    item.Type === "Episode"
-      ? `S${item.ParentIndexNumber} E${item.IndexNumber} · ${item.Name}`
+    const displayTitle =
+      item.Type === "Episode"
+        ? item.SeriesName || item.Name || ""
+        : item.Name || "";
+
+    const episodeSubtitle =
+      item.Type === "Episode"
+        ? `S${item.ParentIndexNumber} E${item.IndexNumber} · ${item.Name}`
+        : null;
+
+    const year = useMemo(() => getYear(item), [item]);
+    const duration = item.RunTimeTicks
+      ? runtimeTicksToMinutes(item.RunTimeTicks)
       : null;
+    const communityRating =
+      typeof item.CommunityRating === "number"
+        ? `★ ${item.CommunityRating.toFixed(1)}`
+        : null;
+    const genres = useMemo(
+      () => (item.Genres || []).slice(0, 3),
+      [item.Genres],
+    );
 
-  const year = useMemo(() => getYear(item), [item]);
-  const duration = item.RunTimeTicks
-    ? runtimeTicksToMinutes(item.RunTimeTicks)
-    : null;
-  const communityRating =
-    typeof item.CommunityRating === "number"
-      ? `★ ${item.CommunityRating.toFixed(1)}`
-      : null;
-  const genres = useMemo(() => (item.Genres || []).slice(0, 3), [item.Genres]);
+    const handlePress = useCallback(() => {
+      lightHapticFeedback();
+      // This component only ever mounts on the Home screen, so "(home)" is
+      // always the correct `from` segment - matches TVHeroCarousel's usage.
+      router.push(getItemNavigation(item, "(home)") as any);
+    }, [item, router, lightHapticFeedback]);
 
-  const handlePress = useCallback(() => {
-    lightHapticFeedback();
-    // This component only ever mounts on the Home screen, so "(home)" is
-    // always the correct `from` segment - matches TVHeroCarousel's usage.
-    router.push(getItemNavigation(item, "(home)") as any);
-  }, [item, router, lightHapticFeedback]);
+    const tap = Gesture.Tap()
+      .maxDuration(2000)
+      .shouldCancelWhenOutside(true)
+      .onBegin(() => {
+        opacity.value = withTiming(0.8, { duration: 100 });
+      })
+      .onEnd(() => {
+        runOnJS(handlePress)();
+      })
+      .onFinalize(() => {
+        opacity.value = withTiming(1, { duration: 100 });
+      });
 
-  const tap = Gesture.Tap()
-    .maxDuration(2000)
-    .shouldCancelWhenOutside(true)
-    .onBegin(() => {
-      opacity.value = withTiming(0.8, { duration: 100 });
-    })
-    .onEnd(() => {
-      runOnJS(handlePress)();
-    })
-    .onFinalize(() => {
-      opacity.value = withTiming(1, { duration: 100 });
-    });
-
-  return (
-    <View style={{ paddingHorizontal: 16 }}>
-      <GestureDetector gesture={tap}>
-        <Animated.View
-          style={{
-            width: HERO_CARD_WIDTH,
-            height: HERO_HEIGHT,
-            borderRadius: 18,
-            overflow: "hidden",
-            borderWidth: 1,
-            borderColor: "#262626",
-            backgroundColor: "#0f0f10",
-            opacity,
-          }}
-        >
-          {backdropUrl && (
-            <Image
-              source={{ uri: backdropUrl }}
-              style={StyleSheet.absoluteFill}
-              contentFit='cover'
-            />
-          )}
-          <View
+    return (
+      <View style={{ alignItems: "center" }}>
+        <GestureDetector gesture={tap}>
+          <Animated.View
             style={{
-              position: "absolute",
-              width: "100%",
-              height: "100%",
-              backgroundColor: "rgba(0,0,0,0.35)",
+              width: cardWidth,
+              height: heroHeight,
+              borderRadius: 18,
+              overflow: "hidden",
+              borderWidth: 1,
+              borderColor: "#262626",
+              backgroundColor: "#0f0f10",
+              opacity,
             }}
-          />
-          <LinearGradient
-            colors={["transparent", "rgba(0,0,0,0.92)"]}
-            locations={[0.4, 1]}
-            style={{
-              position: "absolute",
-              left: 0,
-              right: 0,
-              bottom: 0,
-              height: "65%",
-            }}
-          />
-          <View
-            style={{ position: "absolute", left: 16, right: 16, bottom: 16 }}
           >
-            {logoUrl ? (
+            {backdropUrl && (
               <Image
-                source={{ uri: logoUrl }}
-                style={{
-                  height: 56,
-                  width: HERO_CARD_WIDTH * 0.6,
-                  marginBottom: 8,
-                }}
-                contentFit='contain'
-                contentPosition='left'
+                source={{ uri: backdropUrl }}
+                style={StyleSheet.absoluteFill}
+                contentFit='cover'
               />
-            ) : (
-              <Text
-                style={{
-                  color: "#FFFFFF",
-                  fontWeight: "bold",
-                  fontSize: 26,
-                  marginBottom: 8,
-                }}
-                numberOfLines={1}
-              >
-                {displayTitle}
-              </Text>
             )}
-            {episodeSubtitle && (
-              <Text
-                style={{ color: "rgba(255,255,255,0.9)", marginBottom: 4 }}
-                numberOfLines={1}
-              >
-                {episodeSubtitle}
-              </Text>
-            )}
-            {(communityRating || year || duration) && (
-              <View
-                style={{
-                  flexDirection: "row",
-                  alignItems: "center",
-                  flexWrap: "wrap",
-                  gap: 8,
-                  marginBottom: 4,
-                }}
-              >
-                {communityRating && (
-                  <Text
-                    style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
-                  >
-                    {communityRating}
-                  </Text>
-                )}
-                {year && (
-                  <Text
-                    style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
-                  >
-                    {year}
-                  </Text>
-                )}
-                {duration && (
-                  <Text
-                    style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
-                  >
-                    {duration}
-                  </Text>
-                )}
-              </View>
-            )}
-            {item.Overview && (
-              <Text
-                style={{ color: "rgba(255,255,255,0.8)" }}
-                numberOfLines={2}
-              >
-                {item.Overview}
-              </Text>
-            )}
-            {genres.length > 0 && <GenreTags genres={genres} />}
-          </View>
-          <ProgressBar item={item} />
-        </Animated.View>
-      </GestureDetector>
-    </View>
-  );
-});
+            <View
+              style={{
+                position: "absolute",
+                width: "100%",
+                height: "100%",
+                backgroundColor: "rgba(0,0,0,0.35)",
+              }}
+            />
+            <LinearGradient
+              colors={["transparent", "rgba(0,0,0,0.92)"]}
+              locations={[0.4, 1]}
+              style={{
+                position: "absolute",
+                left: 0,
+                right: 0,
+                bottom: 0,
+                height: "65%",
+              }}
+            />
+            <View
+              style={{ position: "absolute", left: 16, right: 16, bottom: 16 }}
+            >
+              {logoUrl ? (
+                <Image
+                  source={{ uri: logoUrl }}
+                  style={{
+                    height: 56,
+                    width: cardWidth * 0.6,
+                    marginBottom: 8,
+                  }}
+                  contentFit='contain'
+                  contentPosition='left'
+                />
+              ) : (
+                <Text
+                  style={{
+                    color: "#FFFFFF",
+                    fontWeight: "bold",
+                    fontSize: 26,
+                    marginBottom: 8,
+                  }}
+                  numberOfLines={1}
+                >
+                  {displayTitle}
+                </Text>
+              )}
+              {episodeSubtitle && (
+                <Text
+                  style={{ color: "rgba(255,255,255,0.9)", marginBottom: 4 }}
+                  numberOfLines={1}
+                >
+                  {episodeSubtitle}
+                </Text>
+              )}
+              {(communityRating || year || duration) && (
+                <View
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "center",
+                    flexWrap: "wrap",
+                    gap: 8,
+                    marginBottom: 4,
+                  }}
+                >
+                  {communityRating && (
+                    <Text
+                      style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
+                    >
+                      {communityRating}
+                    </Text>
+                  )}
+                  {year && (
+                    <Text
+                      style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
+                    >
+                      {year}
+                    </Text>
+                  )}
+                  {duration && (
+                    <Text
+                      style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
+                    >
+                      {duration}
+                    </Text>
+                  )}
+                </View>
+              )}
+              {item.Overview && (
+                <Text
+                  style={{ color: "rgba(255,255,255,0.8)" }}
+                  numberOfLines={2}
+                >
+                  {item.Overview}
+                </Text>
+              )}
+              {genres.length > 0 && <GenreTags genres={genres} />}
+            </View>
+            <ProgressBar item={item} />
+          </Animated.View>
+        </GestureDetector>
+      </View>
+    );
+  },
+);

--- a/components/home/PromotedHeroCarousel.tsx
+++ b/components/home/PromotedHeroCarousel.tsx
@@ -1,0 +1,305 @@
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+import { Image } from "expo-image";
+import { LinearGradient } from "expo-linear-gradient";
+import { useIsFocused } from "expo-router";
+import { useAtomValue } from "jotai";
+import React, { useCallback, useMemo, useRef } from "react";
+import { Dimensions, StyleSheet, View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+  runOnJS,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import Carousel, {
+  type ICarouselInstance,
+  Pagination,
+} from "react-native-reanimated-carousel";
+import { ProgressBar } from "@/components/common/ProgressBar";
+import { Text } from "@/components/common/Text";
+import { getItemNavigation } from "@/components/common/TouchableItemRouter";
+import { GenreTags } from "@/components/GenreTags";
+import useRouter from "@/hooks/useAppRouter";
+import { useHaptic } from "@/hooks/useHaptic";
+import { apiAtom } from "@/providers/JellyfinProvider";
+import { getBackdropUrl } from "@/utils/jellyfin/image/getBackdropUrl";
+import { getLogoImageUrlById } from "@/utils/jellyfin/image/getLogoImageUrlById";
+import { runtimeTicksToMinutes } from "@/utils/time";
+
+const { width: SCREEN_WIDTH } = Dimensions.get("window");
+
+// Dwell time per slide - long enough to read title + overview before rotating.
+const HERO_AUTOPLAY_INTERVAL_MS = 6000;
+// Cards are inset from the screen edges so neighboring slides peek in via
+// the parallax carousel mode.
+const HERO_CARD_WIDTH = SCREEN_WIDTH - 32;
+// 16:9 backdrop plus room for the logo/title + overview overlay.
+const HERO_HEIGHT = Math.round(HERO_CARD_WIDTH * (9 / 16)) + 100;
+
+const getYear = (item: BaseItemDto): string | null => {
+  if (item.ProductionYear) return item.ProductionYear.toString();
+  if (!item.PremiereDate) return null;
+
+  const parsed = new Date(item.PremiereDate);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.getFullYear().toString();
+};
+
+interface PromotedHeroCarouselProps {
+  items: BaseItemDto[];
+}
+
+export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
+  items,
+}) => {
+  const isFocused = useIsFocused();
+  const ref = useRef<ICarouselInstance>(null);
+  const progress = useSharedValue(0);
+
+  const cappedItems = useMemo(() => items.slice(0, 8), [items]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: BaseItemDto }) => <HeroSlide item={item} />,
+    [],
+  );
+
+  const onPressPagination = useCallback(
+    (index: number) => {
+      ref.current?.scrollTo({
+        count: index - progress.value,
+        animated: true,
+      });
+    },
+    [progress],
+  );
+
+  if (cappedItems.length === 0) return null;
+
+  return (
+    <View>
+      <Carousel
+        ref={ref}
+        autoPlay={isFocused && cappedItems.length > 1}
+        autoPlayInterval={HERO_AUTOPLAY_INTERVAL_MS}
+        loop={cappedItems.length > 1}
+        snapEnabled
+        vertical={false}
+        width={SCREEN_WIDTH}
+        height={HERO_HEIGHT}
+        data={cappedItems}
+        mode='parallax'
+        modeConfig={{
+          parallaxScrollingScale: 0.96,
+          parallaxScrollingOffset: 36,
+        }}
+        onProgressChange={progress}
+        renderItem={renderItem}
+        scrollAnimationDuration={600}
+      />
+      {cappedItems.length > 1 && (
+        <Pagination.Basic
+          progress={progress}
+          data={cappedItems}
+          dotStyle={{
+            backgroundColor: "rgba(255,255,255,0.25)",
+            borderRadius: 99,
+          }}
+          activeDotStyle={{
+            backgroundColor: "rgba(255,255,255,0.85)",
+            borderRadius: 99,
+          }}
+          containerStyle={{ gap: 5, marginTop: 12 }}
+          onPress={onPressPagination}
+        />
+      )}
+    </View>
+  );
+};
+
+const HeroSlide: React.FC<{ item: BaseItemDto }> = React.memo(({ item }) => {
+  const api = useAtomValue(apiAtom);
+  const router = useRouter();
+  const lightHapticFeedback = useHaptic("light");
+  const opacity = useSharedValue(1);
+
+  const backdropUrl = useMemo(
+    () =>
+      getBackdropUrl({
+        api,
+        item,
+        quality: 80,
+        width: Math.floor(HERO_CARD_WIDTH * 2),
+      }),
+    [api, item],
+  );
+
+  const logoUrl = useMemo(
+    () => getLogoImageUrlById({ api, item, height: 56 }),
+    [api, item],
+  );
+
+  const displayTitle =
+    item.Type === "Episode"
+      ? item.SeriesName || item.Name || ""
+      : item.Name || "";
+
+  const episodeSubtitle =
+    item.Type === "Episode"
+      ? `S${item.ParentIndexNumber} E${item.IndexNumber} · ${item.Name}`
+      : null;
+
+  const year = useMemo(() => getYear(item), [item]);
+  const duration = item.RunTimeTicks
+    ? runtimeTicksToMinutes(item.RunTimeTicks)
+    : null;
+  const communityRating =
+    typeof item.CommunityRating === "number"
+      ? `★ ${item.CommunityRating.toFixed(1)}`
+      : null;
+  const genres = useMemo(() => (item.Genres || []).slice(0, 3), [item.Genres]);
+
+  const handlePress = useCallback(() => {
+    lightHapticFeedback();
+    // This component only ever mounts on the Home screen, so "(home)" is
+    // always the correct `from` segment - matches TVHeroCarousel's usage.
+    router.push(getItemNavigation(item, "(home)") as any);
+  }, [item, router, lightHapticFeedback]);
+
+  const tap = Gesture.Tap()
+    .maxDuration(2000)
+    .shouldCancelWhenOutside(true)
+    .onBegin(() => {
+      opacity.value = withTiming(0.8, { duration: 100 });
+    })
+    .onEnd(() => {
+      runOnJS(handlePress)();
+    })
+    .onFinalize(() => {
+      opacity.value = withTiming(1, { duration: 100 });
+    });
+
+  return (
+    <View style={{ paddingHorizontal: 16 }}>
+      <GestureDetector gesture={tap}>
+        <Animated.View
+          style={{
+            width: HERO_CARD_WIDTH,
+            height: HERO_HEIGHT,
+            borderRadius: 18,
+            overflow: "hidden",
+            borderWidth: 1,
+            borderColor: "#262626",
+            backgroundColor: "#0f0f10",
+            opacity,
+          }}
+        >
+          {backdropUrl && (
+            <Image
+              source={{ uri: backdropUrl }}
+              style={StyleSheet.absoluteFill}
+              contentFit='cover'
+            />
+          )}
+          <View
+            style={{
+              position: "absolute",
+              width: "100%",
+              height: "100%",
+              backgroundColor: "rgba(0,0,0,0.35)",
+            }}
+          />
+          <LinearGradient
+            colors={["transparent", "rgba(0,0,0,0.92)"]}
+            locations={[0.4, 1]}
+            style={{
+              position: "absolute",
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: "65%",
+            }}
+          />
+          <View
+            style={{ position: "absolute", left: 16, right: 16, bottom: 16 }}
+          >
+            {logoUrl ? (
+              <Image
+                source={{ uri: logoUrl }}
+                style={{
+                  height: 56,
+                  width: HERO_CARD_WIDTH * 0.6,
+                  marginBottom: 8,
+                }}
+                contentFit='contain'
+                contentPosition='left'
+              />
+            ) : (
+              <Text
+                style={{
+                  color: "#FFFFFF",
+                  fontWeight: "bold",
+                  fontSize: 26,
+                  marginBottom: 8,
+                }}
+                numberOfLines={1}
+              >
+                {displayTitle}
+              </Text>
+            )}
+            {episodeSubtitle && (
+              <Text
+                style={{ color: "rgba(255,255,255,0.9)", marginBottom: 4 }}
+                numberOfLines={1}
+              >
+                {episodeSubtitle}
+              </Text>
+            )}
+            {(communityRating || year || duration) && (
+              <View
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  flexWrap: "wrap",
+                  gap: 8,
+                  marginBottom: 4,
+                }}
+              >
+                {communityRating && (
+                  <Text
+                    style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
+                  >
+                    {communityRating}
+                  </Text>
+                )}
+                {year && (
+                  <Text
+                    style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
+                  >
+                    {year}
+                  </Text>
+                )}
+                {duration && (
+                  <Text
+                    style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
+                  >
+                    {duration}
+                  </Text>
+                )}
+              </View>
+            )}
+            {item.Overview && (
+              <Text
+                style={{ color: "rgba(255,255,255,0.8)" }}
+                numberOfLines={2}
+              >
+                {item.Overview}
+              </Text>
+            )}
+            {genres.length > 0 && <GenreTags genres={genres} />}
+          </View>
+          <ProgressBar item={item} />
+        </Animated.View>
+      </GestureDetector>
+    </View>
+  );
+});

--- a/components/home/PromotedHeroCarousel.tsx
+++ b/components/home/PromotedHeroCarousel.tsx
@@ -31,11 +31,6 @@ import { getBackdropUrl } from "@/utils/jellyfin/image/getBackdropUrl";
 import { getLogoImageUrlById } from "@/utils/jellyfin/image/getLogoImageUrlById";
 import { runtimeTicksToMinutes } from "@/utils/time";
 
-// Card width is capped so wide screens (iPad, Android tablets, phones in
-// landscape) get a centered card with breathing room instead of one
-// stretched edge-to-edge into a banner. Below this width the cap has no
-// effect and behavior matches the original edge-to-edge phone layout.
-const MAX_CARD_WIDTH = 720;
 const CARD_SIDE_GUTTER = 16;
 // How much of the neighboring card should peek in past its own gutter.
 const NEIGHBOR_PEEK = 20;
@@ -45,7 +40,6 @@ const NEIGHBOR_PEEK = 20;
 // side, à la the tvOS/iPadOS App Store hero) - the overlay reads cramped
 // once there's this much extra horizontal room to use instead.
 const WIDE_LAYOUT_BREAKPOINT = 700;
-const WIDE_MAX_CARD_WIDTH = 1100;
 const WIDE_LEFT_PANEL_RATIO = 0.4;
 // Fraction of the card's width (past the panel edge) the image takes to
 // fully fade in from the panel's solid color.
@@ -104,12 +98,8 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
   // Manager) with no phone/tablet branching.
   const isWide = windowWidth >= WIDE_LAYOUT_BREAKPOINT;
   const cardWidth = useMemo(
-    () =>
-      Math.min(
-        windowWidth - CARD_SIDE_GUTTER * 2,
-        isWide ? WIDE_MAX_CARD_WIDTH : MAX_CARD_WIDTH,
-      ),
-    [windowWidth, isWide],
+    () => windowWidth - CARD_SIDE_GUTTER * 2,
+    [windowWidth],
   );
   const heroHeight = useMemo(() => {
     // Wide layout is a side-by-side banner - a fixed-ish height that scales
@@ -120,9 +110,7 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
     // + overview overlaid at the bottom.
     return Math.round(cardWidth * (9 / 16)) + 100;
   }, [cardWidth, isWide]);
-  // Half the leftover width once the card is centered - equals
-  // CARD_SIDE_GUTTER until the cap above kicks in, then grows from there.
-  const sideGutter = (windowWidth - cardWidth) / 2;
+  const sideGutter = CARD_SIDE_GUTTER;
 
   const renderItem = useCallback(
     ({ item }: { item: BaseItemDto }) => (

--- a/components/home/PromotedHeroCarousel.tsx
+++ b/components/home/PromotedHeroCarousel.tsx
@@ -50,6 +50,13 @@ const CARD_BACKGROUND = "#0f0f10";
 const CARD_BACKGROUND_RGB = "15, 15, 16"; // matches CARD_BACKGROUND
 const CARD_BORDER = "#262626";
 
+// Short/landscape windows (rotated phones, iPad Split View or Stage Manager)
+// can make the poster layout's height rival or exceed the window itself.
+// Past this fraction of the window's height the hero stops reading as a
+// "hero" and just becomes an obstacle, so it hides itself rather than
+// shrinking into something illegibly small.
+const MAX_HERO_HEIGHT_RATIO = 0.8;
+
 // Alpha doesn't fade linearly to the eye - a plain two-stop fade reads as if
 // it's already halfway transparent right after the panel edge. Holding
 // closer to opaque through the first half of the blend and only dropping
@@ -82,7 +89,7 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
   const ref = useRef<ICarouselInstance>(null);
   const progress = useSharedValue(0);
   const { settings } = useSettings();
-  const { width: windowWidth } = useWindowDimensions();
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const autoPlayIntervalMs =
     (settings?.heroCarouselRotationSeconds ?? 6) * 1000;
 
@@ -135,7 +142,9 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
     [progress],
   );
 
-  if (cappedItems.length === 0) return null;
+  const heroTooTall = heroHeight > windowHeight * MAX_HERO_HEIGHT_RATIO;
+
+  if (cappedItems.length === 0 || heroTooTall) return null;
 
   return (
     <View>

--- a/components/home/PromotedHeroCarousel.tsx
+++ b/components/home/PromotedHeroCarousel.tsx
@@ -36,6 +36,32 @@ const CARD_SIDE_GUTTER = 16;
 // How much of the neighboring card should peek in past its own gutter.
 const NEIGHBOR_PEEK = 20;
 
+// Past this width the card switches from a phone-style poster (backdrop with
+// text overlaid at the bottom) to a wide banner (text panel + image side by
+// side, à la the tvOS/iPadOS App Store hero) - the overlay reads cramped
+// once there's this much extra horizontal room to use instead.
+const WIDE_LAYOUT_BREAKPOINT = 700;
+const WIDE_MAX_CARD_WIDTH = 1100;
+const WIDE_LEFT_PANEL_RATIO = 0.4;
+// Fraction of the card's width (past the panel edge) the image takes to
+// fully fade in from the panel's solid color.
+const WIDE_GRADIENT_BLEND_RATIO = 0.2;
+const CARD_BACKGROUND = "#0f0f10";
+const CARD_BACKGROUND_RGB = "15, 15, 16"; // matches CARD_BACKGROUND
+const CARD_BORDER = "#262626";
+
+// Alpha doesn't fade linearly to the eye - a plain two-stop fade reads as if
+// it's already halfway transparent right after the panel edge. Holding
+// closer to opaque through the first half of the blend and only dropping
+// off sharply near the end reads as a smooth, gradual fade instead.
+const WIDE_GRADIENT_EASE: { t: number; alpha: number }[] = [
+  { t: 0, alpha: 1 },
+  { t: 0.25, alpha: 0.85 },
+  { t: 0.5, alpha: 0.55 },
+  { t: 0.75, alpha: 0.25 },
+  { t: 1, alpha: 0 },
+];
+
 const getYear = (item: BaseItemDto): string | null => {
   if (item.ProductionYear) return item.ProductionYear.toString();
   if (!item.PremiereDate) return null;
@@ -65,24 +91,38 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
   // Everything below is derived purely from the current window width, so it
   // adapts live to rotation and iPad multitasking (Split View, Stage
   // Manager) with no phone/tablet branching.
+  const isWide = windowWidth >= WIDE_LAYOUT_BREAKPOINT;
   const cardWidth = useMemo(
-    () => Math.min(windowWidth - CARD_SIDE_GUTTER * 2, MAX_CARD_WIDTH),
-    [windowWidth],
+    () =>
+      Math.min(
+        windowWidth - CARD_SIDE_GUTTER * 2,
+        isWide ? WIDE_MAX_CARD_WIDTH : MAX_CARD_WIDTH,
+      ),
+    [windowWidth, isWide],
   );
-  // 16:9 backdrop plus room for the logo/title + overview overlay.
-  const heroHeight = useMemo(
-    () => Math.round(cardWidth * (9 / 16)) + 100,
-    [cardWidth],
-  );
+  const heroHeight = useMemo(() => {
+    // Wide layout is a side-by-side banner - a fixed-ish height that scales
+    // gently with width, clamped so it can't get too short or too tall.
+    if (isWide)
+      return Math.min(360, Math.max(240, Math.round(cardWidth / 2.6)));
+    // Narrow layout is a poster: 16:9 backdrop plus room for the logo/title
+    // + overview overlaid at the bottom.
+    return Math.round(cardWidth * (9 / 16)) + 100;
+  }, [cardWidth, isWide]);
   // Half the leftover width once the card is centered - equals
   // CARD_SIDE_GUTTER until the cap above kicks in, then grows from there.
   const sideGutter = (windowWidth - cardWidth) / 2;
 
   const renderItem = useCallback(
     ({ item }: { item: BaseItemDto }) => (
-      <HeroSlide item={item} cardWidth={cardWidth} heroHeight={heroHeight} />
+      <HeroSlide
+        item={item}
+        cardWidth={cardWidth}
+        heroHeight={heroHeight}
+        isWide={isWide}
+      />
     ),
-    [cardWidth, heroHeight],
+    [cardWidth, heroHeight, isWide],
   );
 
   const onPressPagination = useCallback(
@@ -138,18 +178,126 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
   );
 };
 
+interface HeroSlideInfoProps {
+  logoUrl: string | null;
+  logoWidth: number;
+  logoHeight: number;
+  titleFontSize: number;
+  displayTitle: string;
+  episodeSubtitle: string | null;
+  communityRating: string | null;
+  year: string | null;
+  duration: string | null;
+  overview?: string | null;
+  overviewLines: number;
+  genres: string[];
+  showGenres: boolean;
+}
+
+// Shared between both layouts below - only how it's positioned/sized
+// (overlay vs. side panel) differs, not the metadata it shows.
+const HeroSlideInfo: React.FC<HeroSlideInfoProps> = ({
+  logoUrl,
+  logoWidth,
+  logoHeight,
+  titleFontSize,
+  displayTitle,
+  episodeSubtitle,
+  communityRating,
+  year,
+  duration,
+  overview,
+  overviewLines,
+  genres,
+  showGenres,
+}) => (
+  <>
+    {logoUrl ? (
+      <Image
+        source={{ uri: logoUrl }}
+        style={{ height: logoHeight, width: logoWidth, marginBottom: 8 }}
+        contentFit='contain'
+        contentPosition='left'
+      />
+    ) : (
+      <Text
+        style={{
+          color: "#FFFFFF",
+          fontWeight: "bold",
+          fontSize: titleFontSize,
+          marginBottom: 8,
+        }}
+        numberOfLines={1}
+      >
+        {displayTitle}
+      </Text>
+    )}
+    {episodeSubtitle && (
+      <Text
+        style={{ color: "rgba(255,255,255,0.9)", marginBottom: 4 }}
+        numberOfLines={1}
+      >
+        {episodeSubtitle}
+      </Text>
+    )}
+    {(communityRating || year || duration) && (
+      <View
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 8,
+          marginBottom: 4,
+        }}
+      >
+        {communityRating && (
+          <Text style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}>
+            {communityRating}
+          </Text>
+        )}
+        {year && (
+          <Text style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}>
+            {year}
+          </Text>
+        )}
+        {duration && (
+          <Text style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}>
+            {duration}
+          </Text>
+        )}
+      </View>
+    )}
+    {overview && (
+      <Text
+        style={{ color: "rgba(255,255,255,0.8)" }}
+        numberOfLines={overviewLines}
+      >
+        {overview}
+      </Text>
+    )}
+    {showGenres && genres.length > 0 && <GenreTags genres={genres} />}
+  </>
+);
+
 interface HeroSlideProps {
   item: BaseItemDto;
   cardWidth: number;
   heroHeight: number;
+  isWide: boolean;
 }
 
 const HeroSlide: React.FC<HeroSlideProps> = React.memo(
-  ({ item, cardWidth, heroHeight }) => {
+  ({ item, cardWidth, heroHeight, isWide }) => {
     const api = useAtomValue(apiAtom);
     const router = useRouter();
     const lightHapticFeedback = useHaptic("light");
-    const opacity = useSharedValue(1);
+    // A scrim overlay rather than dimming the card's own opacity: the wide
+    // layout's left panel is a solid near-black background, so fading its
+    // opacity toward transparent is barely visible there while the image
+    // side visibly dims - making the press feedback look like it only
+    // applies to one half. An overlay painted on top of everything dims
+    // both halves by the same visible amount.
+    const pressOverlayOpacity = useSharedValue(0);
 
     const backdropUrl = useMemo(
       () =>
@@ -163,8 +311,8 @@ const HeroSlide: React.FC<HeroSlideProps> = React.memo(
     );
 
     const logoUrl = useMemo(
-      () => getLogoImageUrlById({ api, item, height: 56 }),
-      [api, item],
+      () => getLogoImageUrlById({ api, item, height: isWide ? 72 : 56 }),
+      [api, item, isWide],
     );
 
     const displayTitle =
@@ -201,14 +349,33 @@ const HeroSlide: React.FC<HeroSlideProps> = React.memo(
       .maxDuration(2000)
       .shouldCancelWhenOutside(true)
       .onBegin(() => {
-        opacity.value = withTiming(0.8, { duration: 100 });
+        pressOverlayOpacity.value = withTiming(0.2, { duration: 100 });
       })
       .onEnd(() => {
         runOnJS(handlePress)();
       })
       .onFinalize(() => {
-        opacity.value = withTiming(1, { duration: 100 });
+        pressOverlayOpacity.value = withTiming(0, { duration: 100 });
       });
+
+    const leftPanelWidth = Math.round(cardWidth * WIDE_LEFT_PANEL_RATIO);
+    const panelFraction = leftPanelWidth / cardWidth;
+    // Explicit leading stop at the panel's solid color rather than relying
+    // on the gradient to clamp before its first location - that clamping
+    // isn't guaranteed across platforms, which is what left the transition
+    // uneven. Everything from there on eases per WIDE_GRADIENT_EASE.
+    const gradientColors = [
+      CARD_BACKGROUND,
+      ...WIDE_GRADIENT_EASE.map(
+        ({ alpha }) => `rgba(${CARD_BACKGROUND_RGB}, ${alpha})`,
+      ),
+    ];
+    const gradientLocations = [
+      0,
+      ...WIDE_GRADIENT_EASE.map(({ t }) =>
+        Math.min(1, panelFraction + t * WIDE_GRADIENT_BLEND_RATIO),
+      ),
+    ];
 
     return (
       <View style={{ alignItems: "center" }}>
@@ -220,115 +387,124 @@ const HeroSlide: React.FC<HeroSlideProps> = React.memo(
               borderRadius: 18,
               overflow: "hidden",
               borderWidth: 1,
-              borderColor: "#262626",
-              backgroundColor: "#0f0f10",
-              opacity,
+              borderColor: CARD_BORDER,
+              backgroundColor: CARD_BACKGROUND,
             }}
           >
-            {backdropUrl && (
-              <Image
-                source={{ uri: backdropUrl }}
-                style={StyleSheet.absoluteFill}
-                contentFit='cover'
-              />
-            )}
-            <View
-              style={{
-                position: "absolute",
-                width: "100%",
-                height: "100%",
-                backgroundColor: "rgba(0,0,0,0.35)",
-              }}
-            />
-            <LinearGradient
-              colors={["transparent", "rgba(0,0,0,0.92)"]}
-              locations={[0.4, 1]}
-              style={{
-                position: "absolute",
-                left: 0,
-                right: 0,
-                bottom: 0,
-                height: "65%",
-              }}
-            />
-            <View
-              style={{ position: "absolute", left: 16, right: 16, bottom: 16 }}
-            >
-              {logoUrl ? (
-                <Image
-                  source={{ uri: logoUrl }}
-                  style={{
-                    height: 56,
-                    width: cardWidth * 0.6,
-                    marginBottom: 8,
-                  }}
-                  contentFit='contain'
-                  contentPosition='left'
+            {isWide ? (
+              <>
+                {/* The image spans the full card behind everything, and the
+                    text panel is an opaque layer positioned on top of its
+                    left portion - rather than two flex siblings meeting at a
+                    computed edge, which left a hairline gap where the two
+                    independently-rounded widths didn't quite meet. Painting
+                    one fully over the other means there's no seam to line up
+                    in the first place. */}
+                {backdropUrl && (
+                  <Image
+                    source={{ uri: backdropUrl }}
+                    style={StyleSheet.absoluteFill}
+                    contentFit='cover'
+                  />
+                )}
+                <LinearGradient
+                  colors={gradientColors as [string, string, ...string[]]}
+                  start={{ x: 0, y: 0.5 }}
+                  end={{ x: 1, y: 0.5 }}
+                  locations={gradientLocations as [number, number, ...number[]]}
+                  style={StyleSheet.absoluteFill}
                 />
-              ) : (
-                <Text
+                <View
+                  pointerEvents='none'
                   style={{
-                    color: "#FFFFFF",
-                    fontWeight: "bold",
-                    fontSize: 26,
-                    marginBottom: 8,
+                    position: "absolute",
+                    top: 0,
+                    bottom: 0,
+                    left: 0,
+                    width: leftPanelWidth,
+                    backgroundColor: CARD_BACKGROUND,
+                    padding: 28,
+                    justifyContent: "center",
                   }}
-                  numberOfLines={1}
                 >
-                  {displayTitle}
-                </Text>
-              )}
-              {episodeSubtitle && (
-                <Text
-                  style={{ color: "rgba(255,255,255,0.9)", marginBottom: 4 }}
-                  numberOfLines={1}
-                >
-                  {episodeSubtitle}
-                </Text>
-              )}
-              {(communityRating || year || duration) && (
+                  <HeroSlideInfo
+                    logoUrl={logoUrl}
+                    logoWidth={leftPanelWidth * 0.85}
+                    logoHeight={64}
+                    titleFontSize={30}
+                    displayTitle={displayTitle}
+                    episodeSubtitle={episodeSubtitle}
+                    communityRating={communityRating}
+                    year={year}
+                    duration={duration}
+                    overview={item.Overview}
+                    overviewLines={3}
+                    genres={genres}
+                    showGenres
+                  />
+                </View>
+              </>
+            ) : (
+              <>
+                {backdropUrl && (
+                  <Image
+                    source={{ uri: backdropUrl }}
+                    style={StyleSheet.absoluteFill}
+                    contentFit='cover'
+                  />
+                )}
                 <View
                   style={{
-                    flexDirection: "row",
-                    alignItems: "center",
-                    flexWrap: "wrap",
-                    gap: 8,
-                    marginBottom: 4,
+                    position: "absolute",
+                    width: "100%",
+                    height: "100%",
+                    backgroundColor: "rgba(0,0,0,0.35)",
+                  }}
+                />
+                <LinearGradient
+                  colors={["transparent", "rgba(0,0,0,0.92)"]}
+                  locations={[0.4, 1]}
+                  style={{
+                    position: "absolute",
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    height: "65%",
+                  }}
+                />
+                <View
+                  style={{
+                    position: "absolute",
+                    left: 16,
+                    right: 16,
+                    bottom: 16,
                   }}
                 >
-                  {communityRating && (
-                    <Text
-                      style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
-                    >
-                      {communityRating}
-                    </Text>
-                  )}
-                  {year && (
-                    <Text
-                      style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
-                    >
-                      {year}
-                    </Text>
-                  )}
-                  {duration && (
-                    <Text
-                      style={{ color: "rgba(255,255,255,0.7)", fontSize: 12 }}
-                    >
-                      {duration}
-                    </Text>
-                  )}
+                  <HeroSlideInfo
+                    logoUrl={logoUrl}
+                    logoWidth={cardWidth * 0.6}
+                    logoHeight={56}
+                    titleFontSize={26}
+                    displayTitle={displayTitle}
+                    episodeSubtitle={episodeSubtitle}
+                    communityRating={communityRating}
+                    year={year}
+                    duration={duration}
+                    overview={item.Overview}
+                    overviewLines={2}
+                    genres={genres}
+                    showGenres={false}
+                  />
                 </View>
-              )}
-              {item.Overview && (
-                <Text
-                  style={{ color: "rgba(255,255,255,0.8)" }}
-                  numberOfLines={2}
-                >
-                  {item.Overview}
-                </Text>
-              )}
-              {genres.length > 0 && <GenreTags genres={genres} />}
-            </View>
+              </>
+            )}
+            <Animated.View
+              pointerEvents='none'
+              style={[
+                StyleSheet.absoluteFill,
+                { backgroundColor: "#000000", opacity: pressOverlayOpacity },
+              ]}
+            />
             <ProgressBar item={item} />
           </Animated.View>
         </GestureDetector>

--- a/components/home/PromotedHeroCarousel.tsx
+++ b/components/home/PromotedHeroCarousel.tsx
@@ -23,7 +23,7 @@ import { ProgressBar } from "@/components/common/ProgressBar";
 import { Text } from "@/components/common/Text";
 import { getItemNavigation } from "@/components/common/TouchableItemRouter";
 import { GenreTags } from "@/components/GenreTags";
-import useRouter from "@/hooks/useAppRouter";
+import { useAppRouter } from "@/hooks/useAppRouter";
 import { useHaptic } from "@/hooks/useHaptic";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { useSettings } from "@/utils/atoms/settings";
@@ -313,7 +313,7 @@ interface HeroSlideProps {
 const HeroSlide: React.FC<HeroSlideProps> = React.memo(
   ({ item, cardWidth, heroHeight, isWide }) => {
     const api = useAtomValue(apiAtom);
-    const router = useRouter();
+    const router = useAppRouter();
     const lightHapticFeedback = useHaptic("light");
     // A scrim overlay rather than dimming the card's own opacity: the wide
     // layout's left panel is a solid near-black background, so fading its
@@ -412,6 +412,14 @@ const HeroSlide: React.FC<HeroSlideProps> = React.memo(
       <View style={{ alignItems: "center" }}>
         <GestureDetector gesture={tap}>
           <Animated.View
+            accessible
+            accessibilityRole='button'
+            accessibilityLabel={`Open ${displayTitle}`}
+            accessibilityHint='Opens item details'
+            accessibilityActions={[{ name: "activate" }]}
+            onAccessibilityAction={({ nativeEvent }) => {
+              if (nativeEvent.actionName === "activate") handlePress();
+            }}
             style={{
               width: cardWidth,
               height: heroHeight,

--- a/components/home/PromotedHeroCarousel.tsx
+++ b/components/home/PromotedHeroCarousel.tsx
@@ -22,14 +22,13 @@ import { GenreTags } from "@/components/GenreTags";
 import useRouter from "@/hooks/useAppRouter";
 import { useHaptic } from "@/hooks/useHaptic";
 import { apiAtom } from "@/providers/JellyfinProvider";
+import { useSettings } from "@/utils/atoms/settings";
 import { getBackdropUrl } from "@/utils/jellyfin/image/getBackdropUrl";
 import { getLogoImageUrlById } from "@/utils/jellyfin/image/getLogoImageUrlById";
 import { runtimeTicksToMinutes } from "@/utils/time";
 
 const { width: SCREEN_WIDTH } = Dimensions.get("window");
 
-// Dwell time per slide - long enough to read title + overview before rotating.
-const HERO_AUTOPLAY_INTERVAL_MS = 6000;
 // Cards are inset from the screen edges so neighboring slides peek in via
 // the parallax carousel mode.
 const HERO_CARD_WIDTH = SCREEN_WIDTH - 32;
@@ -55,6 +54,9 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
   const isFocused = useIsFocused();
   const ref = useRef<ICarouselInstance>(null);
   const progress = useSharedValue(0);
+  const { settings } = useSettings();
+  const autoPlayIntervalMs =
+    (settings?.heroCarouselRotationSeconds ?? 6) * 1000;
 
   const cappedItems = useMemo(() => items.slice(0, 8), [items]);
 
@@ -80,7 +82,7 @@ export const PromotedHeroCarousel: React.FC<PromotedHeroCarouselProps> = ({
       <Carousel
         ref={ref}
         autoPlay={isFocused && cappedItems.length > 1}
-        autoPlayInterval={HERO_AUTOPLAY_INTERVAL_MS}
+        autoPlayInterval={autoPlayIntervalMs}
         loop={cappedItems.length > 1}
         snapEnabled
         vertical={false}

--- a/components/settings/AppearanceSettings.tsx
+++ b/components/settings/AppearanceSettings.tsx
@@ -83,6 +83,14 @@ export const AppearanceSettings: React.FC = () => {
             }
           />
         </ListItem>
+        <ListItem title={t("home.settings.other.show_large_home_carousel")}>
+          <SettingSwitch
+            value={settings.showLargeHomeCarousel}
+            onValueChange={(value) =>
+              updateSettings({ showLargeHomeCarousel: value })
+            }
+          />
+        </ListItem>
         <ListItem
           onPress={() =>
             router.push("/settings/appearance/hide-libraries/page")

--- a/components/settings/AppearanceSettings.tsx
+++ b/components/settings/AppearanceSettings.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Linking } from "react-native";
 import { SettingSwitch } from "@/components/common/SettingSwitch";
+import { Stepper } from "@/components/inputs/Stepper";
 import DisabledSetting from "@/components/settings/DisabledSetting";
 import useRouter from "@/hooks/useAppRouter";
 import { useSettings } from "@/utils/atoms/settings";
@@ -91,6 +92,22 @@ export const AppearanceSettings: React.FC = () => {
             }
           />
         </ListItem>
+        {settings.showLargeHomeCarousel && (
+          <ListItem
+            title={t("home.settings.other.hero_carousel_rotation_interval")}
+          >
+            <Stepper
+              value={settings.heroCarouselRotationSeconds}
+              step={1}
+              min={2}
+              max={20}
+              appendValue='s'
+              onUpdate={(value) =>
+                updateSettings({ heroCarouselRotationSeconds: value })
+              }
+            />
+          </ListItem>
+        )}
         <ListItem
           onPress={() =>
             router.push("/settings/appearance/hide-libraries/page")

--- a/hooks/useHeroItems.ts
+++ b/hooks/useHeroItems.ts
@@ -24,7 +24,7 @@ export const useHeroItems = (enabled = true) => {
       const [resumeResponse, nextUpResponse] = await Promise.all([
         getItemsApi(api).getResumeItems({
           userId: user.Id,
-          enableImageTypes: ["Primary", "Backdrop", "Thumb"],
+          enableImageTypes: ["Primary", "Backdrop", "Thumb", "Logo"],
           includeItemTypes: ["Movie", "Series", "Episode"],
           fields: ["Overview", "Genres"],
           startIndex: 0,
@@ -35,7 +35,7 @@ export const useHeroItems = (enabled = true) => {
           startIndex: 0,
           limit: 10,
           fields: ["Overview", "Genres"],
-          enableImageTypes: ["Primary", "Backdrop", "Thumb"],
+          enableImageTypes: ["Primary", "Backdrop", "Thumb", "Logo"],
           enableResumable: false,
         }),
       ]);

--- a/hooks/useHeroItems.ts
+++ b/hooks/useHeroItems.ts
@@ -1,0 +1,68 @@
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+import { getItemsApi, getTvShowsApi } from "@jellyfin/sdk/lib/utils/api";
+import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
+
+const HERO_ITEMS_LIMIT = 15;
+
+/**
+ * Shared Continue Watching + Next Up fetch for the home hero carousel, used
+ * by both Home.tsx and Home.tv.tsx. Keeping this on one query key
+ * (["home", "heroItems", userId]) is what lets WebSocketProvider's
+ * UserDataChanged invalidation reach both platforms instead of only one.
+ */
+export const useHeroItems = (enabled = true) => {
+  const api = useAtomValue(apiAtom);
+  const user = useAtomValue(userAtom);
+
+  return useQuery({
+    queryKey: ["home", "heroItems", user?.Id],
+    queryFn: async () => {
+      if (!api || !user?.Id) return [];
+
+      const [resumeResponse, nextUpResponse] = await Promise.all([
+        getItemsApi(api).getResumeItems({
+          userId: user.Id,
+          enableImageTypes: ["Primary", "Backdrop", "Thumb"],
+          includeItemTypes: ["Movie", "Series", "Episode"],
+          fields: ["Overview", "Genres"],
+          startIndex: 0,
+          limit: 10,
+        }),
+        getTvShowsApi(api).getNextUp({
+          userId: user.Id,
+          startIndex: 0,
+          limit: 10,
+          fields: ["Overview", "Genres"],
+          enableImageTypes: ["Primary", "Backdrop", "Thumb"],
+          enableResumable: false,
+        }),
+      ]);
+
+      const resumeItems = resumeResponse.data.Items || [];
+      const nextUpItems = nextUpResponse.data.Items || [];
+
+      // Combine, sort by recent activity, and dedupe
+      const combined = [...resumeItems, ...nextUpItems];
+      const sorted = combined.sort((a, b) => {
+        const dateA = a.UserData?.LastPlayedDate || a.DateCreated || "";
+        const dateB = b.UserData?.LastPlayedDate || b.DateCreated || "";
+        return new Date(dateB).getTime() - new Date(dateA).getTime();
+      });
+
+      const seen = new Set<string>();
+      const deduped: BaseItemDto[] = [];
+      for (const item of sorted) {
+        if (!item.Id || seen.has(item.Id)) continue;
+        seen.add(item.Id);
+        deduped.push(item);
+      }
+
+      return deduped.slice(0, HERO_ITEMS_LIMIT);
+    },
+    enabled: !!api && !!user?.Id && enabled,
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
+  });
+};

--- a/translations/en.json
+++ b/translations/en.json
@@ -322,7 +322,7 @@
         "safe_area_in_controls": "Safe area in controls",
         "show_custom_menu_links": "Show custom menu links",
         "show_custom_menu_links_hint": "Show the custom links your server administrator added in the web config.",
-        "show_large_home_carousel": "Show large home carousel (beta)",
+        "show_large_home_carousel": "Show home carousel",
         "hero_carousel_rotation_interval": "Hero carousel rotation interval",
         "hide_libraries": "Hide libraries",
         "select_libraries_you_want_to_hide": "Select the libraries you want to hide from the Library tab and home page sections.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -323,6 +323,7 @@
         "show_custom_menu_links": "Show custom menu links",
         "show_custom_menu_links_hint": "Show the custom links your server administrator added in the web config.",
         "show_large_home_carousel": "Show large home carousel (beta)",
+        "hero_carousel_rotation_interval": "Hero carousel rotation interval",
         "hide_libraries": "Hide libraries",
         "select_libraries_you_want_to_hide": "Select the libraries you want to hide from the Library tab and home page sections.",
         "disable_haptic_feedback": "Disable haptic feedback",

--- a/translations/en.json
+++ b/translations/en.json
@@ -106,6 +106,8 @@
     "recently_added_in": "Recently added in {{libraryName}}",
     "suggested_movies": "Suggested movies",
     "suggested_episodes": "Suggested episodes",
+    "open_item": "Open {{title}}",
+    "open_item_hint": "Opens the details screen for this title",
     "intro": {
       "welcome_to_streamyfin": "Welcome to Streamyfin",
       "a_free_and_open_source_client_for_jellyfin": "A free and open-source client for Jellyfin.",

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -320,6 +320,9 @@ export type Settings = {
   // Use the episode's own image (instead of the series thumb) for the
   // "Next Up" and "Continue Watching" home rows.
   useEpisodeImagesForNextUp: boolean;
+  // Phone-only: auto-rotating hero carousel at the top of the Home screen
+  // (Continue Watching + Next Up). Mirrors showTVHeroCarousel's intent for TV.
+  showLargeHomeCarousel: boolean;
   // TV-specific settings
   showHomeBackdrop: boolean;
   showTVHeroCarousel: boolean;
@@ -431,6 +434,7 @@ export const defaultValues: Settings = {
   usePopularPlugin: true,
   mergeNextUpAndContinueWatching: false,
   useEpisodeImagesForNextUp: false,
+  showLargeHomeCarousel: false,
   // TV-specific settings
   showHomeBackdrop: true,
   showTVHeroCarousel: true,

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -323,6 +323,8 @@ export type Settings = {
   // Phone-only: auto-rotating hero carousel at the top of the Home screen
   // (Continue Watching + Next Up). Mirrors showTVHeroCarousel's intent for TV.
   showLargeHomeCarousel: boolean;
+  // Phone-only: seconds between auto-rotations of the hero carousel above.
+  heroCarouselRotationSeconds: number;
   // TV-specific settings
   showHomeBackdrop: boolean;
   showTVHeroCarousel: boolean;
@@ -435,6 +437,7 @@ export const defaultValues: Settings = {
   mergeNextUpAndContinueWatching: false,
   useEpisodeImagesForNextUp: false,
   showLargeHomeCarousel: false,
+  heroCarouselRotationSeconds: 6,
   // TV-specific settings
   showHomeBackdrop: true,
   showTVHeroCarousel: true,


### PR DESCRIPTION
<!-- 
Use a conventional commit title for the PR title, 
for example `feat(auth): add MFA`
All sections below are required. Write N/A if a section is not applicable.
If you use AI to help implement this PR, you must declare it below. It's very important that the feature or fix implemented has been tested thoroughly by you personally on all target platforms. Only adding AI generated code without proper testing is not allowed and this PR will be closed immediately.
-->

# 📦 Pull Request

<!-- 
  🤖 AI ASSISTED? 
  Uncomment the line below if AI was used to assist with this PR:
-->
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#) 
Most of the code in this PR was copied from prexisting code in the code base and #1466.
AI was used to write some new code, merge the best parts of both implementations, and to help me find the right spots around the code base.
This is my first PR, and first time working with mobile apps. I am very open to feedback!
I am used to using gitlab, so you may have to watch me fight a bit with github.

## 📝 Description
<!--
A short description of the changes and why you're making them.
Example: “Add option to clean image cache, to mitigate stuck/blank movie poster issues.”
-->
This PR adds a hero media bar on the home screen of the mobile app.
The appropiate settings were also readded.
For more details, please read #1702 


## 🏷️ Ticket / Issue
<!--
Link to the related ticket, issue or user story.
Example: Fixes #123
-->
Resolves #1702 

## Acceptance criteria

- [x] `showLargeHomeCarousel` is restored to the `Settings` type and `defaultValues` (default `false`) in `utils/atoms/settings.ts`.
- [x] A toggle bound to `t('home.settings.other.show_large_home_carousel')` appears in `AppearanceSettings.tsx`; flipping it shows/hides the hero with no app restart.
- [x] `components/home/PromotedHeroCarousel.tsx` exists and renders on **phone** at the top of `HomeMobile`, inside the existing home `ScrollView`.
- [x] Hero items come from the **shared** Continue Watching + Next Up data path (extracted hook reused by both `Home.tv.tsx` and the phone hero); deduped and capped at 15; no duplicate/divergent query.
- [x] Slides show backdrop + logo (fallback to title) + truncated overview; tapping a slide navigates to that item's detail screen.
- [x] Auto-rotates on a configurable interval; pauses on user drag and when the home screen is not focused; rotation interval is exposed as a constant/setting (not a hidden magic number).

- [ ] No hardcoded colors — theme tokens only, consistent with `TVHeroCarousel`.
I could not find any theme tokens in TVHeroCarousel. So they have not been used in this PR.

- [x] When the setting is `false`, no hero query fires and nothing renders (no wasted network/render).
- [x] The orphaned `home.settings.other.show_large_home_carousel` key now has a real reader; `git grep showLargeHomeCarousel` returns code matches again.

- [ ] TV behavior (`showTVHeroCarousel` / `TVHeroCarousel`) is unchanged.
Have to look into this: It seems a media their logo was previously excluded from the data fetch. Which means the logo handling never triggered, and always used the title as fallback. This might be an unintended bug fix. 

- [x] biome/lint clean; LF line endings.

### 🖼️ Screenshots / GIFs (if UI)
<!-- 
Include screenshots of relevant UI changes for both Android and iOS.
Before/After, responsive states (if relevant). 
-->
<img width="400" alt="image" src="https://github.com/user-attachments/assets/92f54d15-e8a1-42d8-a5ca-eb6fd78ebec7" />
<img width="400" " alt="image" src="https://github.com/user-attachments/assets/d65b104c-ea7c-4aa3-96a5-8903d0392e0d" />
<img width="1282" height="842" alt="image" src="https://github.com/user-attachments/assets/b216a256-c1dd-450d-a617-3e36b3ae97d1" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/a39c6141-d477-4439-8909-89aa7faaac18" />
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/66af38c6-73ca-4730-a3a3-02cbd84f8b02" />


## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
:warning: Has yet to be tested on TV versions. iOS / android are tested by me.
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions
<!--
Describe how reviewers can test your changes. This will help the PR get merged faster.
Example:
1. Open the settings page and scroll to the bottom
2. Verify that the clear data button is visible and pressable
3. Verify that when you click the clear data button, a dialog appears prompting you to confirm
4. Verify that when you click the confirm button, the data is cleared and a toast message is displayed
-->
1. Open the settings page, go to appearance and enable the show large home carousel option.
2. Verify the media is now visible in the carousel on the home page.
3. Verify that when you click on a media item in the carousel, the item's detail page opens.
4. Open the settings page, go to appearance and change the hero carousel rotation interval to a different number.
5. Verify the time between an automated carousel rotation has changed.


## TODO:
- ~Allow scrolling up/down when holding the carousel item.~
- Verify nothing has broken on TV.,
- ~Hide carousel automatically on certain screen widths.~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a responsive hero carousel to the home screen with autoplay, swipe navigation, pagination, artwork, metadata, progress, and quick access to content.
  * Carousel content combines Continue Watching and Next Up items, showing up to 15 recent items.
  * Added appearance settings to enable the large home carousel and configure rotation intervals from 2–20 seconds.
  * Carousel pauses automatically when the app is not focused and remains hidden when no content is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->