### PR TITLE
feat(jellyseerr): add server download indicator to the home header

### DIFF
--- a/app/(auth)/(tabs)/(home)/_layout.tsx
+++ b/app/(auth)/(tabs)/(home)/_layout.tsx
@@ -10,6 +10,7 @@ const Chromecast = Platform.isTV ? null : require("@/components/Chromecast");
 
 import { useAtom } from "jotai";
 import { HeaderBackButton } from "@/components/common/HeaderBackButton";
+import { JellyseerrDownloadsButton } from "@/components/jellyseerr/JellyseerrDownloadsButton";
 import { useSessions, type useSessionsProps } from "@/hooks/useSessions";
 import { userAtom } from "@/providers/JellyfinProvider";
 
@@ -33,6 +34,7 @@ export default function IndexLayout() {
               {!Platform.isTV && (
                 <>
                   <Chromecast.Chromecast background='transparent' />
+                  <JellyseerrDownloadsButton />
                   {user?.Policy?.IsAdministrator && <SessionsButton />}
                   <SettingsButton />
                 </>
@@ -55,6 +57,17 @@ export default function IndexLayout() {
         name='sessions/index'
         options={{
           title: t("home.sessions.title"),
+          headerShown: !Platform.isTV,
+          headerBlurEffect: "none",
+          headerTransparent: Platform.OS === "ios",
+          headerShadowVisible: false,
+          headerLeft: () => <HeaderBackButton />,
+        }}
+      />
+      <Stack.Screen
+        name='jellyseerr-downloads/index'
+        options={{
+          title: t("jellyseerr.downloads.title"),
           headerShown: !Platform.isTV,
           headerBlurEffect: "none",
           headerTransparent: Platform.OS === "ios",

--- a/app/(auth)/(tabs)/(home)/jellyseerr-downloads/index.tsx
+++ b/app/(auth)/(tabs)/(home)/jellyseerr-downloads/index.tsx
@@ -1,0 +1,69 @@
+import { FlashList } from "@shopify/flash-list";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Platform, RefreshControl, View } from "react-native";
+import { Text } from "@/components/common/Text";
+import { JellyseerrDownloadCard } from "@/components/jellyseerr/JellyseerrDownloadCard";
+import { Loader } from "@/components/Loader";
+import { useJellyseerrDownloads } from "@/hooks/useJellyseerrDownloads";
+
+export default function JellyseerrDownloadsPage() {
+  const { t } = useTranslation();
+  const { downloads, isLoading, refetch } = useJellyseerrDownloads();
+
+  // Local flag rather than React Query's isRefetching: that one is also true
+  // for the background poll, which would spin the control every 15s unprompted.
+  const [pulling, setPulling] = useState(false);
+  const onRefresh = useCallback(async () => {
+    setPulling(true);
+    try {
+      await refetch();
+    } finally {
+      setPulling(false);
+    }
+  }, [refetch]);
+
+  const refreshControl = (
+    <RefreshControl refreshing={pulling} onRefresh={onRefresh} />
+  );
+
+  if (isLoading)
+    return (
+      <View className='justify-center items-center h-full'>
+        <Loader />
+      </View>
+    );
+
+  if (downloads.length === 0)
+    return (
+      <FlashList
+        contentInsetAdjustmentBehavior='automatic'
+        contentContainerStyle={{ paddingHorizontal: 17 }}
+        data={[]}
+        renderItem={null}
+        refreshControl={refreshControl}
+        ListEmptyComponent={
+          <View className='h-full w-full flex justify-center items-center py-32'>
+            <Text className='text-lg text-neutral-500'>
+              {t("jellyseerr.downloads.empty")}
+            </Text>
+          </View>
+        }
+      />
+    );
+
+  return (
+    <FlashList
+      contentInsetAdjustmentBehavior='automatic'
+      contentContainerStyle={{
+        paddingTop: Platform.OS === "android" ? 17 : 0,
+        paddingHorizontal: 17,
+        paddingBottom: 150,
+      }}
+      data={downloads}
+      renderItem={({ item }) => <JellyseerrDownloadCard download={item} />}
+      keyExtractor={(item) => item.key}
+      refreshControl={refreshControl}
+    />
+  );
+}

--- a/components/jellyseerr/JellyseerrDownloadCard.tsx
+++ b/components/jellyseerr/JellyseerrDownloadCard.tsx
@@ -1,0 +1,146 @@
+import { useQuery } from "@tanstack/react-query";
+import { Image } from "expo-image";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { View } from "react-native";
+import { Text } from "@/components/common/Text";
+import { useJellyseerr } from "@/hooks/useJellyseerr";
+import type { JellyseerrDownload } from "@/hooks/useJellyseerrDownloads";
+import { MediaType } from "@/utils/jellyseerr/server/constants/media";
+import { formatTimeString } from "@/utils/time";
+
+interface Props {
+  download: JellyseerrDownload;
+}
+
+/**
+ * One in-progress Radarr/Sonarr download: how far along it is, how much is
+ * left and when it should land.
+ */
+export const JellyseerrDownloadCard: React.FC<Props> = ({ download }) => {
+  const { jellyseerrApi, getTitle } = useJellyseerr();
+  const { t } = useTranslation();
+
+  // Same key as the rest of the app so the detail is fetched once and shared.
+  const { data: details } = useQuery({
+    queryKey: ["jellyseerr", "detail", download.mediaType, download.tmdbId],
+    queryFn: async () =>
+      download.mediaType === MediaType.MOVIE
+        ? jellyseerrApi?.movieDetails(download.tmdbId)
+        : jellyseerrApi?.tvDetails(download.tmdbId),
+    enabled: !!jellyseerrApi && !!download.tmdbId,
+  });
+
+  const posterSrc = useMemo(
+    () => jellyseerrApi?.imageProxy(details?.posterPath, "w300_and_h450_face"),
+    [jellyseerrApi, details?.posterPath],
+  );
+
+  const title = useMemo(
+    () => getTitle(details) || download.releaseTitle,
+    [details, download.releaseTitle, getTitle],
+  );
+
+  // Sonarr queues one entry per episode, so name it rather than showing the
+  // release name twice. A season pack collapses to one row, so show its range
+  // instead of pretending it is the single episode that happened to be first.
+  const subtitle = useMemo(() => {
+    const { episode, episodeCount, firstEpisodeNumber, lastEpisodeNumber } =
+      download;
+    const season = episode?.seasonNumber;
+    if (season === undefined) return download.releaseTitle;
+
+    if (episodeCount > 1) {
+      const pad = (n: number) => n.toString().padStart(2, "0");
+      if (
+        firstEpisodeNumber !== undefined &&
+        lastEpisodeNumber !== undefined &&
+        firstEpisodeNumber !== lastEpisodeNumber
+      )
+        return `S${season}E${pad(firstEpisodeNumber)}-E${pad(lastEpisodeNumber)}`;
+      return `S${season} · ${t("jellyseerr.number_episodes", {
+        episode_number: episodeCount,
+      })}`;
+    }
+
+    const number =
+      episode?.episodeNumber !== undefined
+        ? `S${season}E${episode.episodeNumber}`
+        : `S${season}`;
+    return episode?.title ? `${number} · ${episode.title}` : number;
+  }, [download, t]);
+
+  const etaLabel = useMemo(() => {
+    const completesAt = download.estimatedCompletionTime;
+    if (completesAt) {
+      const secondsRemaining = (completesAt.getTime() - Date.now()) / 1000;
+      if (secondsRemaining > 0)
+        return t("home.downloads.eta", {
+          eta: formatTimeString(secondsRemaining, "s"),
+        });
+    }
+    // timeLeft is a raw .NET TimeSpan passthrough — render it as-is rather
+    // than guessing at its format.
+    if (download.timeLeft)
+      return t("home.downloads.eta", { eta: download.timeLeft });
+    return t("jellyseerr.downloads.unknown_eta");
+  }, [download.estimatedCompletionTime, download.timeLeft, t]);
+
+  return (
+    <View className='bg-neutral-900 border border-neutral-800 rounded-2xl p-4 mb-4'>
+      <View className='flex flex-row'>
+        <View className='w-16 aspect-[10/15] rounded-lg overflow-hidden mr-4'>
+          <Image
+            source={{ uri: posterSrc }}
+            cachePolicy='memory-disk'
+            contentFit='cover'
+            style={{ width: "100%", height: "100%" }}
+          />
+        </View>
+
+        <View className='flex-1'>
+          <Text numberOfLines={2} className='font-semibold'>
+            {title}
+          </Text>
+          <Text numberOfLines={1} className='text-xs opacity-50'>
+            {subtitle}
+          </Text>
+
+          <View className='flex flex-row items-center gap-x-2 mt-1 self-start'>
+            <View className='bg-purple-600/20 px-2 py-0.5 rounded-md'>
+              <Text className='text-xs text-purple-400'>{download.status}</Text>
+            </View>
+            {download.is4k && (
+              <View className='bg-neutral-800 px-2 py-0.5 rounded-md'>
+                <Text className='text-xs opacity-75'>4K</Text>
+              </View>
+            )}
+          </View>
+
+          <View className='flex flex-row items-center gap-x-2 mt-1.5'>
+            <Text className='text-xs font-semibold'>
+              {download.progress.toFixed(0)}%
+            </Text>
+            {download.size > 0 && (
+              <Text className='text-xs opacity-75'>
+                {download.downloaded.bytesToReadable()} /{" "}
+                {download.size.bytesToReadable()}
+              </Text>
+            )}
+          </View>
+
+          <View className='bg-gray-800 h-1 rounded-full overflow-hidden mt-2'>
+            <View
+              className='bg-purple-600 h-full'
+              style={{ width: `${download.progress}%` }}
+            />
+          </View>
+
+          <Text className='text-xs text-green-400 mt-1'>{etaLabel}</Text>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default JellyseerrDownloadCard;

--- a/components/jellyseerr/JellyseerrDownloadsButton.tsx
+++ b/components/jellyseerr/JellyseerrDownloadsButton.tsx
@@ -1,0 +1,44 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useTranslation } from "react-i18next";
+import { Platform, View } from "react-native";
+// RNGH Pressable, not RN TouchableOpacity: header buttons don't respond to
+// touches on macOS Catalyst with the latter.
+import { Pressable } from "react-native-gesture-handler";
+import { Text } from "@/components/common/Text";
+import useRouter from "@/hooks/useAppRouter";
+import { useJellyseerrDownloads } from "@/hooks/useJellyseerrDownloads";
+
+/**
+ * Header button that only exists while Jellyseerr has something downloading,
+ * badged with how many.
+ */
+export const JellyseerrDownloadsButton: React.FC = () => {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { count, enabled } = useJellyseerrDownloads();
+
+  // `enabled` matters as well as the count: a disabled query still hands back
+  // whatever it last cached, which would strand a badge on screen after the
+  // user disconnects Jellyseerr.
+  if (Platform.isTV || !enabled || count === 0) return null;
+
+  return (
+    <Pressable
+      onPress={() => router.push("/(auth)/(tabs)/(home)/jellyseerr-downloads")}
+      className='mr-4 relative'
+      accessibilityRole='button'
+      accessibilityLabel={t("jellyseerr.downloads.n_downloading", { count })}
+      hitSlop={8}
+    >
+      <Ionicons name='cloud-download-outline' color='white' size={24} />
+      {/* Pill, not a fixed circle — "12" and "99+" overflow a 16pt box. */}
+      <View className='absolute right-0 top-0 bg-red-600 rounded-full min-w-[16px] h-4 px-1 items-center justify-center'>
+        <Text className='text-white text-[10px] font-bold'>
+          {count > 99 ? "99+" : count}
+        </Text>
+      </View>
+    </Pressable>
+  );
+};
+
+export default JellyseerrDownloadsButton;

--- a/hooks/useJellyseerr.ts
+++ b/hooks/useJellyseerr.ts
@@ -279,6 +279,32 @@ export class JellyseerrApi {
       .then(({ data }) => data);
   }
 
+  /**
+   * One page of requests, for scanning `media.downloadStatus`.
+   *
+   * `filter=all` rather than `filter=processing` on purpose: `processing`
+   * pins the request status to APPROVED and the media status to everything
+   * below AVAILABLE, so it drops quality upgrades on already-available media
+   * and stalled downloads whose request has flipped to COMPLETED/FAILED —
+   * both of which still hold a live Radarr/Sonarr queue entry.
+   *
+   * Callers must paginate: download activity never touches `request.updatedAt`,
+   * so `sort=modified` cannot float an in-flight download into the first page.
+   */
+  async activeDownloads(take = 100, skip = 0): Promise<RequestResultsResponse> {
+    return this.axios
+      ?.get<RequestResultsResponse>(Endpoints.API_V1 + Endpoints.REQUEST, {
+        params: {
+          filter: "all",
+          take,
+          skip,
+          sort: "modified",
+          sortDirection: "desc",
+        },
+      })
+      .then(({ data }) => data);
+  }
+
   async movieDetails(id: number) {
     return this.axios
       ?.get<MovieDetails>(`${Endpoints.API_V1 + Endpoints.MOVIE}/${id}`)

--- a/hooks/useJellyseerrDownloads.ts
+++ b/hooks/useJellyseerrDownloads.ts
@@ -134,6 +134,13 @@ export const flattenActiveDownloads = (
 
   for (const page of pages) {
     for (const request of page?.results ?? []) {
+      // mediaType and tmdbId are the card's lookup keys for fetching the
+      // poster and human title. Without them the row can only ever show the
+      // raw release name, so drop it rather than emit one with invalid keys.
+      const mediaType = request.media?.mediaType;
+      const tmdbId = request.media?.tmdbId;
+      if (!mediaType || tmdbId === undefined || tmdbId === null) continue;
+
       // Mirrors JellyseerrPoster: a 4k request tracks the 4k queue. Cast to the
       // wire shape here — the declared entity type does not survive JSON.
       const items = ((request.is4k
@@ -171,8 +178,8 @@ export const flattenActiveDownloads = (
           downloadId: item.downloadId,
           requestId: request.id,
           is4k: Boolean(request.is4k),
-          mediaType: request.media?.mediaType,
-          tmdbId: request.media?.tmdbId,
+          mediaType,
+          tmdbId,
           releaseTitle: item.title,
           status: item.status,
           size,
@@ -229,6 +236,9 @@ export const useJellyseerrDownloads = (): UseJellyseerrDownloadsResult => {
       return flattenActiveDownloads(pages);
     },
     enabled,
+    // Without a staleTime, every mount of the badge or the screen kicks off
+    // another full page walk on top of the poll below.
+    staleTime: ACTIVE_POLL_MS,
     // gcTime 0 keeps this out of the MMKV-persisted cache. Without it the app
     // rehydrates a day-old queue on cold start and the badge lights up with
     // downloads that finished long ago.

--- a/hooks/useJellyseerrDownloads.ts
+++ b/hooks/useJellyseerrDownloads.ts
@@ -1,0 +1,254 @@
+import { useQuery } from "@tanstack/react-query";
+import { Platform } from "react-native";
+import { useJellyseerr } from "@/hooks/useJellyseerr";
+import { useNetworkStatus } from "@/hooks/useNetworkStatus";
+import type { MediaType } from "@/utils/jellyseerr/server/constants/media";
+import type { RequestResultsResponse } from "@/utils/jellyseerr/server/interfaces/api/requestInterfaces";
+import type { DownloadingItem } from "@/utils/jellyseerr/server/lib/downloadtracker";
+
+/**
+ * Requests fetched per round-trip. Jellyseerr has no "give me the download
+ * queue" endpoint, so the client scans requests and reads `media.downloadStatus`
+ * off each one.
+ */
+const PAGE_SIZE = 100;
+
+/**
+ * Pagination cap. Download activity never touches `request.updatedAt`, so no
+ * sort can float an in-flight download to the front — the only way not to miss
+ * one is to walk pages. Scanning stops as soon as a short page comes back, so
+ * the common case (fewer than 100 requests) is a single call.
+ */
+const MAX_PAGES = 5;
+
+/** Jellyseerr's own download-sync cron runs once a minute. */
+const IDLE_POLL_MS = 60_000;
+const ACTIVE_POLL_MS = 15_000;
+
+/**
+ * Radarr/Sonarr leave finished and failed grabs sitting in the queue
+ * indefinitely, so counting them would mean the badge never returns to zero.
+ * Everything else — queued, paused, warning, delay — is still in flight and
+ * keeps its raw status visible on the card.
+ */
+const TERMINAL_STATUSES = new Set(["completed", "failed"]);
+
+/**
+ * What `DownloadingItem` actually looks like on the wire.
+ *
+ * The submodule types `estimatedCompletionTime` as a required `Date` and
+ * `timeLeft` as a required `string`, but JSON gives an ISO string, `null`
+ * (an Invalid Date serialises to null), or no key at all. `EpisodeNumberResult`
+ * is not exported from downloadtracker.ts, and the payload is really Sonarr's
+ * fuller episode record, so that shape is inlined here.
+ */
+type DownloadingItemWire = Omit<
+  DownloadingItem,
+  "estimatedCompletionTime" | "timeLeft" | "episode"
+> & {
+  estimatedCompletionTime?: string | null;
+  timeLeft?: string;
+  episode?: {
+    seasonNumber?: number;
+    episodeNumber?: number;
+    title?: string;
+  };
+};
+
+export interface JellyseerrDownloadEpisode {
+  seasonNumber?: number;
+  episodeNumber?: number;
+  title?: string;
+}
+
+export interface JellyseerrDownload {
+  /** Stable list key; also the dedupe key. */
+  key: string;
+  downloadId?: string;
+  requestId: number;
+  is4k: boolean;
+  mediaType: MediaType;
+  tmdbId: number;
+  /** Radarr/Sonarr release name — not a human-facing media title. */
+  releaseTitle: string;
+  /** Raw arr queue status, e.g. "downloading", "paused", "warning". */
+  status: string;
+  size: number;
+  sizeLeft: number;
+  downloaded: number;
+  /** 0-100, clamped and NaN-safe. */
+  progress: number;
+  timeLeft?: string;
+  estimatedCompletionTime: Date | null;
+  /** First episode of the grab; a season pack collapses into one row. */
+  episode?: JellyseerrDownloadEpisode;
+  /** How many queue records collapsed here. >1 means a season pack. */
+  episodeCount: number;
+  firstEpisodeNumber?: number;
+  lastEpisodeNumber?: number;
+}
+
+export interface UseJellyseerrDownloadsResult {
+  downloads: JellyseerrDownload[];
+  count: number;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => Promise<unknown>;
+  /** Whether the query is allowed to run at all (mobile, configured, online). */
+  enabled: boolean;
+}
+
+const toDate = (value?: string | null): Date | null => {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+/** Widens a collapsed row's episode range as sibling records fold into it. */
+const absorbEpisode = (
+  row: JellyseerrDownload,
+  episode?: JellyseerrDownloadEpisode,
+) => {
+  row.episodeCount += 1;
+  const number = episode?.episodeNumber;
+  if (number === undefined) return;
+  row.firstEpisodeNumber =
+    row.firstEpisodeNumber === undefined
+      ? number
+      : Math.min(row.firstEpisodeNumber, number);
+  row.lastEpisodeNumber =
+    row.lastEpisodeNumber === undefined
+      ? number
+      : Math.max(row.lastEpisodeNumber, number);
+};
+
+/**
+ * Folds pages of requests into the distinct arr queue entries behind them.
+ *
+ * Exported so `refetchInterval` and the query function share one definition.
+ */
+export const flattenActiveDownloads = (
+  pages: (RequestResultsResponse | undefined)[],
+): JellyseerrDownload[] => {
+  const byKey = new Map<string, JellyseerrDownload>();
+
+  for (const page of pages) {
+    for (const request of page?.results ?? []) {
+      // Mirrors JellyseerrPoster: a 4k request tracks the 4k queue. Cast to the
+      // wire shape here — the declared entity type does not survive JSON.
+      const items = ((request.is4k
+        ? request.media?.downloadStatus4k
+        : request.media?.downloadStatus) ??
+        []) as unknown as DownloadingItemWire[];
+
+      items.forEach((item, index) => {
+        if (TERMINAL_STATUSES.has((item.status ?? "").toLowerCase())) return;
+
+        // Never fall back to "unkeyed": pending-release rows carry no
+        // downloadId, and one media row is reachable from several requests, so
+        // an unkeyed push would multiply the count. Keying off the media (not
+        // the request) is what collapses the two-requests-one-media case.
+        const key =
+          item.downloadId ||
+          `${request.media?.id ?? request.id}:${item.externalId ?? index}:${
+            item.title ?? ""
+          }`;
+
+        const existing = byKey.get(key);
+        if (existing) {
+          // Sonarr emits one record per episode of a season pack, all sharing
+          // a downloadId — fold them into a range rather than dropping them.
+          absorbEpisode(existing, item.episode);
+          return;
+        }
+
+        const size = item.size ?? 0;
+        const sizeLeft = item.sizeLeft ?? 0;
+        const downloaded = Math.max(0, size - sizeLeft);
+
+        const row: JellyseerrDownload = {
+          key,
+          downloadId: item.downloadId,
+          requestId: request.id,
+          is4k: Boolean(request.is4k),
+          mediaType: request.media?.mediaType,
+          tmdbId: request.media?.tmdbId,
+          releaseTitle: item.title,
+          status: item.status,
+          size,
+          sizeLeft,
+          downloaded,
+          // size is 0 for freshly grabbed items, before the client reports one.
+          progress:
+            size > 0
+              ? Math.max(0, Math.min(100, (downloaded / size) * 100))
+              : 0,
+          timeLeft: item.timeLeft,
+          estimatedCompletionTime: toDate(item.estimatedCompletionTime),
+          episode: item.episode,
+          episodeCount: 0,
+          firstEpisodeNumber: undefined,
+          lastEpisodeNumber: undefined,
+        };
+        absorbEpisode(row, item.episode);
+        byKey.set(key, row);
+      });
+    }
+  }
+
+  return [...byKey.values()];
+};
+
+/**
+ * Active Radarr/Sonarr downloads as reported by Jellyseerr.
+ *
+ * Both the header badge and the downloads screen call this; the shared query
+ * key means one poll and one timer no matter how many consumers mount.
+ */
+export const useJellyseerrDownloads = (): UseJellyseerrDownloadsResult => {
+  const { jellyseerrApi } = useJellyseerr();
+  const { isConnected } = useNetworkStatus();
+
+  // jellyseerrApi is undefined unless the URL, cookies and user are all set,
+  // so it is the whole "Jellyseerr is usable" check.
+  const enabled = !Platform.isTV && !!jellyseerrApi && isConnected;
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ["jellyseerr", "active-downloads"],
+    queryFn: async () => {
+      const pages: (RequestResultsResponse | undefined)[] = [];
+      for (let page = 0; page < MAX_PAGES; page++) {
+        const result = await jellyseerrApi?.activeDownloads(
+          PAGE_SIZE,
+          page * PAGE_SIZE,
+        );
+        if (!result) break;
+        pages.push(result);
+        if ((result.results?.length ?? 0) < PAGE_SIZE) break;
+      }
+      return flattenActiveDownloads(pages);
+    },
+    enabled,
+    // gcTime 0 keeps this out of the MMKV-persisted cache. Without it the app
+    // rehydrates a day-old queue on cold start and the badge lights up with
+    // downloads that finished long ago.
+    gcTime: 0,
+    // networkMode is offlineFirst app-wide, so an interval still fires while
+    // offline — `enabled` above is what actually stops it.
+    refetchInterval: (query) =>
+      (query.state.data?.length ?? 0) > 0 ? ACTIVE_POLL_MS : IDLE_POLL_MS,
+  });
+
+  const downloads = enabled ? (data ?? []) : [];
+
+  return {
+    downloads,
+    count: downloads.length,
+    isLoading,
+    isError,
+    refetch,
+    enabled,
+  };
+};
+
+export default useJellyseerrDownloads;

--- a/translations/en.json
+++ b/translations/en.json
@@ -837,6 +837,12 @@
     "select_seasons": "Select seasons",
     "request_selected": "Request selected",
     "n_selected": "{{count}} selected",
+    "downloads": {
+      "title": "Downloads to server",
+      "empty": "Nothing downloading to the server",
+      "n_downloading": "{{count}} downloading to server",
+      "unknown_eta": "Calculating…"
+    },
     "toasts": {
       "jellyseerr_does_not_meet_requirements": "Seerr server does not meet minimum version requirements! Please update to at least 2.0.0",
       "jellyseerr_test_failed": "Seerr test failed. Please try again.",

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -837,6 +837,12 @@
     "select_seasons": "Välj säsonger",
     "request_selected": "Begär valda",
     "n_selected": "{{count}} valda",
+    "downloads": {
+      "title": "Nedladdningar till servern",
+      "empty": "Inget laddas ner till servern",
+      "n_downloading": "{{count}} laddas ner till servern",
+      "unknown_eta": "Beräknar…"
+    },
     "toasts": {
       "jellyseerr_does_not_meet_requirements": "Seerr-servern uppfyller inte minimikrav för version! Vänligen uppdatera till minst 2.0.0",
       "jellyseerr_test_failed": "Seerr test misslyckades. Försök igen.",


### PR DESCRIPTION
# 📦 Pull Request

Code written by me, comments and documentation by Claude

## 📝 Description

Adds a button to the home header while Seerr reports downloads in progress on the server, badged with how many. Opening it shows each one with its progress, size and ETA.

The wording is deliberately "downloads to server" throughout rather than "active downloads", so it cannot be mistaken for the app's own device downloads.

Some details worth calling out for review:

- **Polling adapts to what is happening.** 60s when nothing is downloading, 15s when something is, so an idle app is not hammering Seerr.
- **Requests without media keys are skipped** rather than rendered as blank rows, and the dedupe key falls back through `downloadId` → media id + external id + title, so two downloads of the same season never collapse into one entry.
- **Paging is bounded** at 5 pages of 100 to keep a large request history from turning into an unbounded fetch.
- The button is hidden entirely on TV, and whenever Seerr is not configured or nothing is downloading — it never appears as a dead control.

## 🏷️ Ticket / Issue

N/A — no existing issue.

### 🖼️ Screenshots / GIFs (if UI)

Home header while four downloads are running:

![Home header with a badged downloads button showing 4](https://raw.githubusercontent.com/Arkniem/streamyfin/pr-assets/docs/jellyseerr-badge.png)

The downloads screen, with real progress from a live Seerr instance — season packs collapse to a `S4 · 2 episodes` line, and status, percentage, transferred size and ETA come straight from the arr queue:

![Downloads to server screen showing queued and downloading items with progress and ETA](https://raw.githubusercontent.com/Arkniem/streamyfin/pr-assets/docs/jellyseerr-downloads.png)

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms — exercised against a live Seerr instance on the web/desktop build; **not yet run on iOS, Android or TV** (the button is hidden on TV by design)
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. With Seerr configured, request something and let the download start on the server
2. Open the home tab; confirm a download button appears in the header with a red badge showing the count
3. Tap it; confirm each download lists its poster, title, status, percentage, transferred size and ETA
4. For a requested season, confirm it reads as a single entry with an episode range rather than one row per episode
5. Pull to refresh; confirm the list updates
6. Let every download finish; confirm the header button disappears rather than showing a zero badge
7. Remove the Seerr configuration; confirm the button never appears
8. On TV, confirm the button is not present
