### PR TITLE
fix(chromecast): correct HLS content type and use fMP4 segments for H265 casting

### DIFF
--- a/components/PlayButton.tsx
+++ b/components/PlayButton.tsx
@@ -8,6 +8,8 @@ import { useTranslation } from "react-i18next";
 import { Alert, Platform, TouchableOpacity, View } from "react-native";
 import CastContext, {
   CastButton,
+  MediaHlsSegmentFormat,
+  MediaHlsVideoSegmentFormat,
   MediaStreamType,
   PlayServicesState,
   useMediaStatus,
@@ -179,8 +181,6 @@ export const PlayButton: React.FC<Props> = ({
                     subtitleStreamIndex: selectedOptions.subtitleIndex,
                   });
 
-                  console.log("URL: ", data?.url, enableH265);
-
                   if (!data?.url) {
                     console.warn("No URL returned from getStreamUrl", data);
                     Alert.alert(
@@ -199,12 +199,30 @@ export const PlayButton: React.FC<Props> = ({
                     ? item.RunTimeTicks / 10000000
                     : undefined;
 
+                  // HLS transcodes must be declared as HLS, otherwise the
+                  // receiver tries to parse the m3u8 playlist as an MP4 file
+                  // and the cast session dies immediately.
+                  const isHls = data.url.includes(".m3u8");
+                  // Jellyfin puts the HLS segment container in the URL; the
+                  // receiver needs the matching hint (HEVC only works in fMP4).
+                  const isFmp4 = data.url.includes("SegmentContainer=mp4");
+
                   client
                     .loadMedia({
                       mediaInfo: {
                         contentId: item.Id,
                         contentUrl: data?.url,
-                        contentType: "video/mp4",
+                        contentType: isHls
+                          ? "application/x-mpegURL"
+                          : "video/mp4",
+                        ...(isHls && {
+                          hlsSegmentFormat: isFmp4
+                            ? MediaHlsSegmentFormat.FMP4
+                            : MediaHlsSegmentFormat.TS,
+                          hlsVideoSegmentFormat: isFmp4
+                            ? MediaHlsVideoSegmentFormat.FMP4
+                            : MediaHlsVideoSegmentFormat.MPEG2_TS,
+                        }),
                         streamType: MediaStreamType.BUFFERED,
                         streamDuration: streamDurationSeconds,
                         metadata:
@@ -266,6 +284,9 @@ export const PlayButton: React.FC<Props> = ({
                         return;
                       }
                       CastContext.showExpandedControls();
+                    })
+                    .catch((e) => {
+                      console.error("Chromecast loadMedia failed:", e);
                     });
                 } catch (e) {
                   console.log(e);

--- a/utils/profiles/chromecasth265.ts
+++ b/utils/profiles/chromecasth265.ts
@@ -17,8 +17,9 @@ export const chromecasth265: DeviceProfile = {
   ],
   ContainerProfiles: [],
   DirectPlayProfiles: [
+    // No mkv here: the Cast receiver cannot demux Matroska, only mp4/webm.
     {
-      Container: "mp4,mkv",
+      Container: "mp4",
       Type: "Video",
       VideoCodec: "hevc,h264",
       AudioCodec: "aac,mp3,opus,vorbis",
@@ -41,8 +42,11 @@ export const chromecasth265: DeviceProfile = {
     },
   ],
   TranscodingProfiles: [
+    // The Cast receiver only supports HEVC in fMP4 HLS segments (MPEG-TS
+    // segments are AVC-only), so HEVC transcodes must use the mp4 segment
+    // container.
     {
-      Container: "ts",
+      Container: "mp4",
       Type: "Video",
       VideoCodec: "hevc,h264",
       AudioCodec: "aac,mp3",
@@ -53,7 +57,7 @@ export const chromecasth265: DeviceProfile = {
       BreakOnNonKeyFrames: true,
     },
     {
-      Container: "mp4,mkv",
+      Container: "mp4",
       Type: "Video",
       VideoCodec: "hevc,h264",
       AudioCodec: "aac",


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Casting a movie to Chromecast failed instantly (expanded controls opened and closed, TV flashed black) whenever Jellyfin returned an HLS transcode — which is the case for most mkv files or anything with unsupported audio/subtitles. Two stacked bugs:

1. **Wrong content type for HLS**: `loadMedia` always declared `contentType: "video/mp4"`, even when the stream URL was an HLS `master.m3u8`. The receiver tried to parse the playlist as an MP4 file and killed the session. HLS URLs are now declared as `application/x-mpegURL`, with the matching `hlsSegmentFormat`/`hlsVideoSegmentFormat` hints derived from the URL's `SegmentContainer` param.
2. **HEVC in MPEG-TS segments**: with "H265 for Chromecast" enabled, the `chromecasth265` profile transcoded to HEVC inside TS segments. The Cast receiver only supports AVC in TS segments — HEVC requires fMP4 (per the Cast SDK's `MediaHlsVideoSegmentFormat` docs). The HLS transcoding profile now uses the `mp4` segment container.

Also removed `mkv` from the H265 profile's direct play/http profiles (the Cast receiver cannot demux Matroska, so those entries caused the same silent failure), and added a `.catch` on `loadMedia` so load failures are logged instead of being silently swallowed.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A (no UI changes)

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms (tested on iOS with a real Chromecast; casting is a mobile-only feature and the change is platform-agnostic JS)
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Pick a movie that requires transcoding for Chromecast (e.g. an mkv with AC3/EAC3/DTS audio — check that PlaybackInfo returns a `TranscodingUrl`)
2. With **Settings → Chromecast → H265 disabled**: cast the movie and verify it plays (H264 in TS segments)
3. With **H265 enabled** (on an HEVC-capable device: Chromecast Ultra / Chromecast with Google TV): cast again and verify it plays; the stream URL should contain `SegmentContainer=mp4`
4. Verify a direct-play-compatible mp4 (h264 + aac) still casts as before

https://claude.ai/code/session_01GD4Qe5MhYDkEzdipGtJqbx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chromecast playback for HLS and fMP4 streams.
  * Added clearer error reporting when media loading fails.
  * Updated Chromecast H.265 playback to use compatible MP4 formats and avoid unsupported Matroska containers.
  * Removed sensitive media URL logging during playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->