### PR TITLE
fix(mpv-ios): keep auto-PiP with the active player

### DIFF
--- a/modules/mpv-player/ios/PiPController.swift
+++ b/modules/mpv-player/ios/PiPController.swift
@@ -16,6 +16,8 @@ protocol PiPControllerDelegate: AnyObject {
 }
 
 final class PiPController: NSObject {
+    private static weak var automaticStartOwner: PiPController?
+
     private var pipController: AVPictureInPictureController?
     private weak var sampleBufferDisplayLayer: AVSampleBufferDisplayLayer?
     
@@ -84,13 +86,19 @@ final class PiPController: NSObject {
 
     /// Enable/disable auto-PiP ("swipe up while playing").
     ///
-    /// Armed per loaded video rather than once at init: leaving it enabled on an
-    /// outgoing player stopped the *next* video from entering PiP, and the view
-    /// is reused across videos so init doesn't run again. Set in `loadVideo()`,
-    /// cleared in `destroy()`.
+    /// Arming transfers eligibility from the outgoing controller and also
+    /// re-arms a reused controller. This keeps source changes independent of
+    /// which UI path initiated them.
     func setAutoStartEnabled(_ enabled: Bool) {
         #if !os(tvOS)
-        pipController?.canStartPictureInPictureAutomaticallyFromInline = enabled
+        guard let pipController else { return }
+        if enabled {
+            Self.automaticStartOwner?.pipController?.canStartPictureInPictureAutomaticallyFromInline = false
+            Self.automaticStartOwner = self
+        } else if Self.automaticStartOwner === self {
+            Self.automaticStartOwner = nil
+        }
+        pipController.canStartPictureInPictureAutomaticallyFromInline = enabled
         #endif
     }
 


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

GitHub Copilot was used to investigate the player lifecycle, implement the change, run validation, and draft this PR description. The author remains responsible for reviewing and testing the submitted change.

## 📝 Description

Fix automatic Picture in Picture failing after moving from one video to another on iOS, including next episode, autoplay, and other source-replacement paths.

PR #1870 made automatic PiP a per-video lifecycle by enabling `canStartPictureInPictureAutomaticallyFromInline` when loading a video and disabling it when destroying the player. Some transitions can reuse a native view while others can briefly overlap outgoing and incoming views, so tying correctness to a particular navigation caller or teardown order remains fragile.

This follow-up keeps the rule inside `PiPController`. Arming automatic PiP now:

1. Disables automatic start on the previously armed controller, if it still exists.
2. Records the current controller as a weak owner.
3. Enables automatic start on the current controller.

This also deliberately toggles a reused controller off and back on, preserving the re-arm behavior from #1870. A late destroy from an outgoing controller cannot clear a newer owner's registration.

The change is limited to iOS automatic inline PiP. It does not modify navigation, playback controls, manual PiP, Now Playing metadata, remote commands, or audio-session claiming. The code remains excluded from tvOS by the existing `#if !os(tvOS)` guard, and Android is untouched.

Validation performed:

- `xcrun swiftc -parse modules/mpv-player/ios/PiPController.swift`
- `xcodebuild -workspace ios/Streamyfin.xcworkspace -scheme MpvPlayer -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` (`BUILD SUCCEEDED`)
- No editor diagnostics in the changed file

Repository-wide `bun run typecheck` is currently blocked by an unrelated existing route-name comparison in `app/(auth)/(tabs)/_layout.tsx:54`.

## 🏷️ Ticket / Issue

N/A. Follow-up to #1870.

### 🖼️ Screenshots / GIFs (if UI)

N/A. No UI changes.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms (physical-device iOS auto-PiP verification is pending; tvOS and Android behavior are not changed)
- [ ] Code passes lint/formatting and type checks (`tsc`/`biome`) (the native module builds; repository TypeScript is blocked by the unrelated existing error documented above)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Automatic swipe-home PiP must be tested on a physical iPhone; the simulator does not reproduce this behavior reliably.

1. Run a fresh native iOS build (`bun run prebuild && bun run ios`) on a physical iPhone.
2. Play episode A and swipe to the Home Screen. Verify automatic PiP starts.
3. Return to Streamyfin and leave PiP/fullscreen normally.
4. Move to episode B using the in-player Next button, then swipe to the Home Screen. Verify automatic PiP starts for episode B.
5. Repeat using autoplay and an episode-list selection to cover other source transition paths.
6. Repeat across another episode transition to verify ownership continues transferring beyond one replacement.
7. Lock the phone or open Control Center and verify Now Playing metadata and play/pause controls still work.
8. Exit playback and verify audio from another app can resume, confirming audio-session teardown is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic Picture-in-Picture startup handling on iOS.
  * Ensured only one player controller can be armed for automatic Picture-in-Picture at a time.
  * Prevented older controllers from unintentionally clearing the active controller’s setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->