### PR TITLE
fix(player): release keep-awake while "still watching" prompt is shown

### DIFF
--- a/components/video-player/controls/ContinueWatchingOverlay.tsx
+++ b/components/video-player/controls/ContinueWatchingOverlay.tsx
@@ -1,5 +1,6 @@
+import { deactivateKeepAwake } from "expo-keep-awake";
 import { t } from "i18next";
-import React from "react";
+import React, { useEffect } from "react";
 import { View } from "react-native";
 import { Button } from "@/components/Button";
 import { Text } from "@/components/common/Text";
@@ -19,8 +20,16 @@ const ContinueWatchingOverlay: React.FC<ContinueWatchingOverlayProps> = ({
   const { settings } = useSettings();
   const router = useRouter();
 
-  return settings.autoPlayEpisodeCount >=
-    settings.maxAutoPlayEpisodeCount.value ? (
+  const isVisible =
+    settings.autoPlayEpisodeCount >= settings.maxAutoPlayEpisodeCount.value;
+
+  // Release the playback wake lock while the "still watching?" prompt is up so the screen can sleep normally after
+  // inactivity
+  useEffect(() => {
+    if (isVisible) deactivateKeepAwake().catch(() => {});
+  }, [isVisible]);
+
+  return isVisible ? (
     <View
       className={
         "absolute top-0 bottom-0 left-0 right-0 z-50 flex flex-col px-4 items-center justify-center bg-[#000000B3]"


### PR DESCRIPTION
# 📦 Pull Request

<!-- 
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#) -->

## 📝 Description

When the player shows the "you still watching"-popup the screen stayed on forever until now. With this fix the normal screen inactivity behaviour kicks in to turn the screen off after a few seconds/minutes.


## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [ ] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

- Set number of auto play episodes to 1 in settings
- watch an episode
- "still watching"-popup should appear
- Wait
- Check if screen turns off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Continue Watching overlay’s visibility behavior for a more consistent playback experience.
  * Playback wake lock is now released when the overlay appears, helping prevent unnecessary screen wakefulness.
  * Wake-lock deactivation errors are handled gracefully without disrupting the viewing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->