### PR TITLE
fix(player): gate AV1 direct play on hardware decode support

### DIFF
--- a/modules/mpv-player/ios/MPVLayerRenderer.swift
+++ b/modules/mpv-player/ios/MPVLayerRenderer.swift
@@ -61,7 +61,20 @@ final class MPVLayerRenderer {
     
     // KVO observation for display layer status
     private var statusObservation: NSKeyValueObservation?
-    
+
+    // Display layer recovery (see performDecoderReset)
+    private static let maxDecoderResets = 3
+    private var _decoderResetCount = 0
+    private var decoderResetCount: Int {
+        get { stateQueue.sync { _decoderResetCount } }
+        set { stateQueue.sync(flags: .barrier) { _decoderResetCount = newValue } }
+    }
+
+    /// The hwdec mode this renderer was configured with in `start()`. Recovery
+    /// restores exactly this instead of `auto`, so a device that was told to
+    /// software-decode never gets silently promoted back to VideoToolbox.
+    private var configuredHwdec = "videotoolbox"
+
     weak var delegate: MPVLayerRendererDelegate?
     
     // Thread-safe state for playback
@@ -158,11 +171,36 @@ final class MPVLayerRenderer {
     }
     
     /// Actually performs the decoder reset (called by observer or manually)
+    ///
+    /// Bounded on purpose. The reset re-enables hardware decoding, so if the
+    /// layer failed *because* the codec has no hardware decoder on this device
+    /// (AV1 on any current Apple TV, for instance), the retry reproduces the
+    /// exact failure and the KVO observer fires again — an unbounded loop that
+    /// presents as a permanent hang rather than an error. After
+    /// `maxDecoderResets` consecutive failures we stop retrying and leave mpv
+    /// on software decoding, which at worst plays badly instead of not at all.
+    /// The budget is reset per loaded file in `load()`.
     private func performDecoderReset() {
         guard let handle = mpv else { return }
-        print("🔧 Resetting decoder: status=\(displayLayer.status.rawValue), requiresFlush=\(displayLayer.requiresFlushToResumeDecoding)")
+
+        let attempt = decoderResetCount + 1
+        guard attempt <= Self.maxDecoderResets else {
+            Logger.shared.log(
+                "Display layer failed again after \(Self.maxDecoderResets) decoder resets; staying on software decoding",
+                type: "Warn"
+            )
+            return
+        }
+        decoderResetCount = attempt
+
+        print("🔧 Resetting decoder (\(attempt)/\(Self.maxDecoderResets)): status=\(displayLayer.status.rawValue), requiresFlush=\(displayLayer.requiresFlushToResumeDecoding)")
         commandSync(handle, ["set", "hwdec", "no"])
-        commandSync(handle, ["set", "hwdec", "auto"])
+
+        // On the final attempt, stay on software decoding rather than handing
+        // the same unsupported stream back to VideoToolbox one more time.
+        if attempt < Self.maxDecoderResets {
+            commandSync(handle, ["set", "hwdec", configuredHwdec])
+        }
     }
     
     deinit {
@@ -208,10 +246,11 @@ final class MPVLayerRenderer {
         // On simulator, use software decoding since VideoToolbox is not available
         // On device, use VideoToolbox with software fallback enabled
         #if targetEnvironment(simulator)
-        checkError(mpv_set_option_string(handle, "hwdec", "no"))
+        configuredHwdec = "no"
         #else
-        checkError(mpv_set_option_string(handle, "hwdec", "videotoolbox"))
+        configuredHwdec = "videotoolbox"
         #endif
+        checkError(mpv_set_option_string(handle, "hwdec", configuredHwdec))
         checkError(mpv_set_option_string(handle, "hwdec-codecs", "all"))
         checkError(mpv_set_option_string(handle, "hwdec-software-fallback", "yes"))
 
@@ -320,6 +359,8 @@ final class MPVLayerRenderer {
             guard let self else { return }
             self.isLoading = true
             self.isReadyToSeek = false
+            // Fresh file, fresh recovery budget (see performDecoderReset)
+            self.decoderResetCount = 0
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.delegate?.renderer(self, didChangeLoading: true)

--- a/modules/mpv-player/ios/MpvPlayerModule.swift
+++ b/modules/mpv-player/ios/MpvPlayerModule.swift
@@ -1,4 +1,6 @@
 import ExpoModulesCore
+import CoreMedia
+import VideoToolbox
 
 public class MpvPlayerModule: Module {
   public func definition() -> ModuleDefinition {
@@ -10,6 +12,24 @@ public class MpvPlayerModule: Module {
     // Defines a JavaScript synchronous function that runs the native code on the JavaScript thread.
     Function("hello") {
       return "Hello from MPV Player! 👋"
+    }
+
+    /// Whether this device has a hardware AV1 decoder.
+    ///
+    /// Apple silicon only gained AV1 decode with A17 Pro / M3, so no Apple TV
+    /// shipped to date can decode it in hardware (Apple TV 4K 3rd gen is A15).
+    /// When VideoToolbox refuses the codec, mpv falls back to dav1d software
+    /// decode, whose `yuv420p10le` output has to be converted and uploaded per
+    /// frame before `vo_avfoundation` can enqueue it into the
+    /// AVSampleBufferDisplayLayer — on tvOS that stalls, and the display-layer
+    /// recovery in MPVLayerRenderer then retries the same failing hardware path.
+    ///
+    /// The JS device profile calls this to decide whether to advertise AV1 as
+    /// direct-play to Jellyfin, so unsupported devices get a transcode instead
+    /// of a hang. Querying VideoToolbox rather than hardcoding `Platform.isTV`
+    /// means a future AV1-capable Apple TV keeps direct play automatically.
+    Function("supportsAv1HardwareDecode") { () -> Bool in
+      return VTIsHardwareDecodeSupported(kCMVideoCodecType_AV1)
     }
 
     // Defines a JavaScript function that always returns a Promise and whose native code

--- a/modules/mpv-player/src/MpvPlayerModule.ts
+++ b/modules/mpv-player/src/MpvPlayerModule.ts
@@ -5,6 +5,14 @@ import { MpvPlayerModuleEvents } from "./MpvPlayer.types";
 declare class MpvPlayerModule extends NativeModule<MpvPlayerModuleEvents> {
   hello(): string;
   setValueAsync(value: string): Promise<void>;
+  /**
+   * Whether this device has a hardware AV1 decoder (`VTIsHardwareDecodeSupported`).
+   *
+   * **iOS/tvOS only** — not implemented on Android. Prefer
+   * `supportsAv1HardwareDecode` from `@/utils/profiles/codecSupport`, which
+   * handles the platform and older-binary cases.
+   */
+  supportsAv1HardwareDecode(): boolean;
 }
 
 // This call loads the native module object from the JSI.

--- a/utils/profiles/codecSupport.ts
+++ b/utils/profiles/codecSupport.ts
@@ -1,0 +1,68 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import { requireOptionalNativeModule } from "expo";
+import { Platform } from "react-native";
+
+/**
+ * Subset of the MpvPlayer native module used for capability probing.
+ * `supportsAv1HardwareDecode` is implemented on iOS/tvOS only.
+ */
+type MpvPlayerCapabilities = {
+  supportsAv1HardwareDecode?: () => boolean;
+};
+
+/**
+ * Result of the native probe. Only set once the native module has actually
+ * answered — a fallback answer is never cached, so an early call made before
+ * the module is reachable (e.g. the import-time profile in `./download`) cannot
+ * poison the value for the rest of the process.
+ */
+let cachedAv1Support: boolean | undefined;
+
+/**
+ * Fallback when the native check cannot be reached — most likely a JS-only OTA
+ * update running against an older binary. Mirrors the split the check would
+ * produce today: no Apple TV has an AV1 decoder, every AV1-capable iPhone does.
+ * Keeps phones on their existing direct-play behaviour rather than regressing
+ * them into needless transcodes.
+ */
+const assumedAv1Support = (): boolean => !Platform.isTV;
+
+const probeAv1HardwareDecode = (): boolean | undefined => {
+  // Android plays AV1 through mpv's own decoder stack (dav1d via FFmpeg) with
+  // vo=gpu, which handles 10-bit planar output natively and has never shown the
+  // Apple-platform stall. Leave Android behaviour exactly as it was.
+  if (Platform.OS !== "ios") return true;
+
+  const mpv = requireOptionalNativeModule<MpvPlayerCapabilities>("MpvPlayer");
+  if (typeof mpv?.supportsAv1HardwareDecode !== "function") return undefined;
+
+  try {
+    return mpv.supportsAv1HardwareDecode();
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Whether this device can decode AV1 in hardware.
+ *
+ * Apple silicon only gained AV1 decode with A17 Pro / M3, so no Apple TV
+ * shipped to date can do it (Apple TV 4K 3rd gen is A15) while recent iPhones
+ * can. When VideoToolbox refuses the codec, mpv falls back to software decode
+ * and the tvOS `vo_avfoundation` path stalls, so the player hangs instead of
+ * playing — hence gating what the device profile advertises to Jellyfin.
+ *
+ * Backed by `VTIsHardwareDecodeSupported` rather than a hardcoded
+ * `Platform.isTV`, so a future AV1-capable Apple TV regains direct play with no
+ * code change.
+ */
+export const supportsAv1HardwareDecode = (): boolean => {
+  if (cachedAv1Support === undefined) {
+    cachedAv1Support = probeAv1HardwareDecode();
+  }
+  return cachedAv1Support ?? assumedAv1Support();
+};

--- a/utils/profiles/native.ts
+++ b/utils/profiles/native.ts
@@ -6,6 +6,7 @@
 import type { DeviceProfile } from "@jellyfin/sdk/lib/generated-client/models";
 import { Platform } from "react-native";
 import MediaTypes from "../../constants/MediaTypes";
+import { supportsAv1HardwareDecode } from "./codecSupport";
 import { getSubtitleProfiles } from "./subtitles";
 
 export type PlatformType = "ios" | "android";
@@ -19,6 +20,11 @@ export interface ProfileOptions {
   player?: PlayerType;
   /** Audio transcoding mode */
   audioMode?: AudioTranscodeModeType;
+  /**
+   * Whether the device can decode AV1 in hardware. Defaults to probing the
+   * device (see `./codecSupport`); pass explicitly only for tests.
+   */
+  supportsAv1?: boolean;
 }
 
 /**
@@ -165,12 +171,61 @@ const getExoPlayerDirectPlayProfile = () => {
 };
 
 /**
+ * Video codecs the MPV player can direct play, minus anything this device has
+ * no viable decode path for.
+ *
+ * AV1 is conditional: without a hardware decoder mpv falls back to dav1d
+ * software decode, and on tvOS the resulting 10-bit planar frames stall
+ * `vo_avfoundation` before they reach the display layer — the player hangs
+ * rather than erroring. Dropping `av1` from the profile makes Jellyfin transcode
+ * to H.264/HEVC for those devices instead of handing over a stream they cannot
+ * show. Devices that do have the decoder (recent iPhones) are unaffected.
+ */
+const getMpvVideoCodecs = (supportsAv1: boolean) => {
+  const codecProfileCodecs = [
+    "h264",
+    "mpeg4",
+    "divx",
+    "xvid",
+    "wmv",
+    "vc1",
+    "vp8",
+    "vp9",
+  ];
+  const directPlayCodecs = [
+    "h264",
+    "hevc",
+    "mpeg4",
+    "divx",
+    "xvid",
+    "wmv",
+    "vc1",
+    "vp8",
+    "vp9",
+  ];
+
+  if (supportsAv1) {
+    codecProfileCodecs.push("av1");
+    directPlayCodecs.push("av1");
+  }
+
+  // Container-ish entries Jellyfin also matches on, kept at the tail as before
+  directPlayCodecs.push("avi", "mpeg", "mpeg2video");
+
+  return {
+    codecProfile: codecProfileCodecs.join(","),
+    directPlay: directPlayCodecs.join(","),
+  };
+};
+
+/**
  * Generates a device profile for Jellyfin playback.
  */
 export const generateDeviceProfile = (options: ProfileOptions = {}) => {
   const platform = (options.platform || Platform.OS) as PlatformType;
   const audioMode = options.audioMode || "auto";
   const player = options.player || "mpv";
+  const supportsAv1 = options.supportsAv1 ?? supportsAv1HardwareDecode();
 
   // ExoPlayer branch — Media3 capabilities on Android TV.
   if (player === "exoplayer" && platform === "android") {
@@ -245,6 +300,7 @@ export const generateDeviceProfile = (options: ProfileOptions = {}) => {
     platform,
     audioMode,
   );
+  const videoCodecs = getMpvVideoCodecs(supportsAv1);
 
   /**
    * Device profile for MPV player
@@ -256,7 +312,7 @@ export const generateDeviceProfile = (options: ProfileOptions = {}) => {
     CodecProfiles: [
       {
         Type: MediaTypes.Video,
-        Codec: "h264,mpeg4,divx,xvid,wmv,vc1,vp8,vp9,av1",
+        Codec: videoCodecs.codecProfile,
       },
       {
         Type: MediaTypes.Video,
@@ -282,8 +338,7 @@ export const generateDeviceProfile = (options: ProfileOptions = {}) => {
       {
         Type: MediaTypes.Video,
         Container: "mp4,mkv,avi,mov,flv,ts,m2ts,webm,ogv,3gp,hls",
-        VideoCodec:
-          "h264,hevc,mpeg4,divx,xvid,wmv,vc1,vp8,vp9,av1,avi,mpeg,mpeg2video",
+        VideoCodec: videoCodecs.directPlay,
         AudioCodec: directPlayCodec,
       },
       getAudioDirectPlayProfile(platform),


### PR DESCRIPTION
## Problem

AV1 files hang on Apple TV but play fine on recent iPhones. Reported with a 1080p 10-bit AV1 episode that plays on an iPhone 17 and hangs on tvOS with the same app version.

Apple silicon only gained AV1 hardware decode with A17 Pro / M3. No Apple TV shipped to date has it — Apple TV 4K 3rd gen is A15, 2nd gen A12 — while recent iPhones do.

The MPV device profile advertised `av1` as direct-play unconditionally (`utils/profiles/native.ts`). `Platform.OS` is `"ios"` on tvOS and the only branch in `generateDeviceProfile` was `player === "exoplayer" && platform === "android"`, so tvOS got the identical profile as iPhone and Jellyfin direct-played a raw AV1 stream the device cannot show. Nothing else forced a transcode either — the ASS subtitles in the reported file are `Embed`/`External`, not `Encode`, so there was no burn-in to trigger one.

mpv then fell back to dav1d software decode (`hwdec-software-fallback=yes`), whose `yuv420p10le` output has to be converted and uploaded per frame before `vo_avfoundation` can enqueue it into the `AVSampleBufferDisplayLayer`. That path stalls on tvOS.

The hang rather than an error came from the display-layer recovery in `MPVLayerRenderer`: on `.failed` status it set `hwdec` back to `auto`, re-enabling VideoToolbox, which failed on AV1 again and re-fired the KVO observer. No retry cap, no backoff — an unbounded loop.

## Changes

**Gate AV1 on a real capability check.** `MpvPlayerModule` gains a sync `supportsAv1HardwareDecode()` backed by `VTIsHardwareDecodeSupported(kCMVideoCodecType_AV1)` (available tvOS 11+, deployment target is 15.1). `utils/profiles/codecSupport.ts` wraps it and the profile drops `av1` from `DirectPlayProfiles` and `CodecProfiles` when it returns false, so unsupported devices get an H.264/HEVC transcode instead of a stream they cannot decode.

Probing VideoToolbox rather than hardcoding `Platform.isTV` means a future AV1-capable Apple TV regains direct play with no code change.

**Bound the display-layer recovery.** `performDecoderReset` now retries at most 3 times per loaded file, restores the hwdec mode the renderer was configured with instead of `auto`, and stays on software decoding once the budget is spent. Worth having independently of the profile fix — an unbounded reset loop on any layer failure is a latent hang.

## Notes

- **Android is untouched.** mpv decodes AV1 there through its own dav1d/FFmpeg stack with `vo=gpu`, which handles 10-bit planar output natively and has never shown this stall. `codecSupport` returns `true` without probing on Android, and the ExoPlayer profile branch is unchanged.
- **Needs a native rebuild to take full effect.** If a JS-only OTA update lands on an older binary the native function is missing; `codecSupport` then falls back to `!Platform.isTV`, which is the same answer the check produces today — Apple TVs stop advertising AV1, iPhones keep their current behaviour.
- Downloads inherit the gate automatically via `generateDownloadProfile`, which builds on `generateDeviceProfile`.

## Testing

`bun run typecheck` and `bun run check` pass. Not verified on device — I don't have an Apple TV here, so the AV1 playback path is unverified at runtime. Worth confirming on hardware that the reported episode now transcodes and plays, and that a non-AV1 file still direct-plays unchanged.

The stall specifically happening inside `vo_avfoundation`'s 10-bit software upload is inferred from `docs/research/hdr-mpv.md`, not directly observed. The profile mismatch and the unbounded reset loop are both verifiable in the code regardless.

https://claude.ai/code/session_019xkHUWrfqjYaSK4ihHBBPf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AV1 hardware-decoding capability detection across supported devices.
  * MPV profiles now automatically include AV1 when hardware decoding is available, with configurable overrides.
  * Added bounded decoder recovery with up to three reset attempts per loaded file.

* **Bug Fixes**
  * Decoder recovery now restores the configured hardware-decoding mode and safely falls back to software decoding after repeated failures.
  * Improved handling and logging when decoder recovery is exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->