### PR TITLE
feat(downloads): show download progress in native ios live activity component

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,6 +20,8 @@
           "NSAllowsArbitraryLoads": true
         },
         "UISupportsTrueScreenSizeOnMac": true,
+        "NSSupportsLiveActivities": true,
+        "NSSupportsLiveActivitiesFrequentUpdates": true,
         "UIFileSharingEnabled": true,
         "LSSupportsOpeningDocumentsInPlace": true,
         "AVInitialRouteSharingPolicy": "LongFormAudio"
@@ -142,6 +144,7 @@
       ["./plugins/withGradleProperties.ts"],
       ["./plugins/withTVOSAppIcon.ts"],
       ["./plugins/withTVOSTopShelf.ts"],
+      ["./plugins/withDownloadLiveActivity.ts"],
       ["./plugins/withTVXcodeEnv.ts"],
       [
         "./plugins/withGitPod.ts",

--- a/bun.lock
+++ b/bun.lock
@@ -1558,7 +1558,7 @@
 
     "react-native-text-ticker": ["react-native-text-ticker@1.16.0", "", {}, "sha512-UHZcIrXzNQ3CnGSA6d5foR9weqSCEk5w+eJGnUf5OQkKbuq/xtt1ZaNVnsgcG5+3f9EnRrNCt52/a46LXVKGGw=="],
 
-    "react-native-track-player": ["react-native-track-player@github:lovegaoshi/react-native-track-player#33a3ecd", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-windows": "*", "shaka-player": "^4.7.9" }, "optionalPeers": ["react-native-windows", "shaka-player"] }, "lovegaoshi-react-native-track-player-33a3ecd", "sha512-vfkld2jUj7EPkAjIc/Vbx4Q4MtOOLmYtCYCE2dWJsyLnPqgj1f0xVzBxbeVP7dfT+eSh4KIXfdxESXaHgrXIlw=="],
+    "react-native-track-player": ["react-native-track-player@github:lovegaoshi/react-native-track-player#33a3ecd", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-windows": "*", "shaka-player": "^4.7.9" }, "optionalPeers": ["react-native-windows", "shaka-player"] }, "lovegaoshi-react-native-track-player-33a3ecd"],
 
     "react-native-udp": ["react-native-udp@4.1.7", "", { "dependencies": { "buffer": "^5.6.0", "events": "^3.1.0" } }, "sha512-NUE3zewu61NCdSsLlj+l0ad6qojcVEZPT4hVG/x6DU9U4iCzwtfZSASh9vm7teAcVzLkdD+cO3411LHshAi/wA=="],
 

--- a/components/settings/AppearanceSettings.tsx
+++ b/components/settings/AppearanceSettings.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Linking } from "react-native";
+import { Linking, Platform } from "react-native";
 import { SettingSwitch } from "@/components/common/SettingSwitch";
 import DisabledSetting from "@/components/settings/DisabledSetting";
 import useRouter from "@/hooks/useAppRouter";
@@ -83,6 +83,19 @@ export const AppearanceSettings: React.FC = () => {
             }
           />
         </ListItem>
+        {Platform.OS === "ios" && !Platform.isTV && (
+          <ListItem
+            title={t("home.settings.appearance.download_live_activity")}
+            subtitle={t("home.settings.appearance.download_live_activity_hint")}
+          >
+            <SettingSwitch
+              value={settings.showDownloadLiveActivity}
+              onValueChange={(value) =>
+                updateSettings({ showDownloadLiveActivity: value })
+              }
+            />
+          </ListItem>
+        )}
         <ListItem
           onPress={() =>
             router.push("/settings/appearance/hide-libraries/page")

--- a/components/settings/StorageSettings.tsx
+++ b/components/settings/StorageSettings.tsx
@@ -2,18 +2,15 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { Alert, Platform, View } from "react-native";
 import { toast } from "sonner-native";
-import { SettingSwitch } from "@/components/common/SettingSwitch";
 import { Text } from "@/components/common/Text";
 import { Colors } from "@/constants/Colors";
 import { useHaptic } from "@/hooks/useHaptic";
 import { useDownload } from "@/providers/DownloadProvider";
-import { useSettings } from "@/utils/atoms/settings";
 import { ListGroup } from "../list/ListGroup";
 import { ListItem } from "../list/ListItem";
 
 export const StorageSettings = () => {
   const { deleteAllFiles, appSizeUsage } = useDownload();
-  const { settings, updateSettings } = useSettings();
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const successHapticFeedback = useHaptic("success");
@@ -127,21 +124,6 @@ export const StorageSettings = () => {
           )}
         </View>
       </View>
-      {Platform.OS === "ios" && !Platform.isTV && settings && (
-        <ListGroup className='mt-4'>
-          <ListItem
-            title={t("home.settings.storage.download_live_activity")}
-            subtitle={t("home.settings.storage.download_live_activity_hint")}
-          >
-            <SettingSwitch
-              value={settings.showDownloadLiveActivity}
-              onValueChange={(value) =>
-                updateSettings({ showDownloadLiveActivity: value })
-              }
-            />
-          </ListItem>
-        </ListGroup>
-      )}
       {!Platform.isTV && (
         <ListGroup className='mt-4'>
           <ListItem

--- a/components/settings/StorageSettings.tsx
+++ b/components/settings/StorageSettings.tsx
@@ -2,15 +2,18 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { Alert, Platform, View } from "react-native";
 import { toast } from "sonner-native";
+import { SettingSwitch } from "@/components/common/SettingSwitch";
 import { Text } from "@/components/common/Text";
 import { Colors } from "@/constants/Colors";
 import { useHaptic } from "@/hooks/useHaptic";
 import { useDownload } from "@/providers/DownloadProvider";
+import { useSettings } from "@/utils/atoms/settings";
 import { ListGroup } from "../list/ListGroup";
 import { ListItem } from "../list/ListItem";
 
 export const StorageSettings = () => {
   const { deleteAllFiles, appSizeUsage } = useDownload();
+  const { settings, updateSettings } = useSettings();
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const successHapticFeedback = useHaptic("success");
@@ -124,8 +127,23 @@ export const StorageSettings = () => {
           )}
         </View>
       </View>
+      {Platform.OS === "ios" && !Platform.isTV && settings && (
+        <ListGroup className='mt-4'>
+          <ListItem
+            title={t("home.settings.storage.download_live_activity")}
+            subtitle={t("home.settings.storage.download_live_activity_hint")}
+          >
+            <SettingSwitch
+              value={settings.showDownloadLiveActivity}
+              onValueChange={(value) =>
+                updateSettings({ showDownloadLiveActivity: value })
+              }
+            />
+          </ListItem>
+        </ListGroup>
+      )}
       {!Platform.isTV && (
-        <ListGroup className={Platform.OS === "android" ? "mt-4" : undefined}>
+        <ListGroup className='mt-4'>
           <ListItem
             textColor='red'
             onPress={onDeleteClicked}

--- a/modules/background-downloader/android/src/main/java/expo/modules/backgrounddownloader/BackgroundDownloaderModule.kt
+++ b/modules/background-downloader/android/src/main/java/expo/modules/backgrounddownloader/BackgroundDownloaderModule.kt
@@ -12,7 +12,14 @@ import expo.modules.kotlin.modules.ModuleDefinition
 
 data class DownloadTaskInfo(
   val url: String,
-  val destinationPath: String?
+  val destinationPath: String?,
+  val itemId: String? = null
+)
+
+private data class QueuedDownload(
+  val url: String,
+  val destinationPath: String?,
+  val itemId: String?
 )
 
 class BackgroundDownloaderModule : Module() {
@@ -24,10 +31,18 @@ class BackgroundDownloaderModule : Module() {
     get() = requireNotNull(appContext.reactContext)
 
   private val downloadManager = OkHttpDownloadManager()
+
+  /// Guards all mutable download state below. The module is entered from the JS thread (function
+  /// bodies) and from OkHttp dispatcher threads (download callbacks); the collections must never
+  /// be touched from two of them at once. Methods suffixed `Locked` assume the lock is held.
+  private val stateLock = Any()
   private val downloadTasks = mutableMapOf<Int, DownloadTaskInfo>()
-  private val downloadQueue = mutableListOf<Pair<String, String?>>()
+  private val downloadQueue = mutableListOf<QueuedDownload>()
   private var taskIdCounter = 1
+
+  @Volatile
   private var downloadService: DownloadService? = null
+  @Volatile
   private var serviceBound = false
 
   private val serviceConnection = object : ServiceConnection {
@@ -72,32 +87,45 @@ class BackgroundDownloaderModule : Module() {
       }
     }
 
-    AsyncFunction("startDownload") { urlString: String, destinationPath: String?, promise: Promise ->
+    // `metadata` carries the iOS Live Activity payload; here only `itemId` is used, echoed back in
+    // events so JS can correlate them without a taskId bookkeeping layer. The parameter must exist
+    // on both platforms regardless — JS always passes three arguments.
+    AsyncFunction("startDownload") { urlString: String, destinationPath: String?, metadata: Map<String, Any?>?, promise: Promise ->
       try {
-        val taskId = startDownloadInternal(urlString, destinationPath)
+        val taskId = synchronized(stateLock) {
+          startDownloadLocked(urlString, destinationPath, metadata?.get("itemId") as? String)
+        }
         promise.resolve(taskId)
       } catch (e: Exception) {
         promise.reject("DOWNLOAD_ERROR", "Failed to start download: ${e.message}", e)
       }
     }
 
-    AsyncFunction("enqueueDownload") { urlString: String, destinationPath: String?, promise: Promise ->
+    AsyncFunction("enqueueDownload") { urlString: String, destinationPath: String?, metadata: Map<String, Any?>?, promise: Promise ->
       try {
         Log.d(TAG, "Enqueuing download: url=$urlString")
-        
-        // Add to queue
-        val wasEmpty = downloadQueue.isEmpty()
-        downloadQueue.add(Pair(urlString, destinationPath))
-        Log.d(TAG, "Queue size: ${downloadQueue.size}")
-        
-        // If queue was empty and no active downloads, start processing immediately
-        if (wasEmpty && downloadTasks.isEmpty()) {
-          val taskId = processNextInQueue()
-          promise.resolve(taskId)
-        } else {
-          // Return placeholder taskId for queued items
-          promise.resolve(-1)
+
+        val taskId = synchronized(stateLock) {
+          // Add to queue
+          val wasEmpty = downloadQueue.isEmpty()
+          downloadQueue.add(
+            QueuedDownload(
+              url = urlString,
+              destinationPath = destinationPath,
+              itemId = metadata?.get("itemId") as? String
+            )
+          )
+          Log.d(TAG, "Queue size: ${downloadQueue.size}")
+
+          // If queue was empty and no active downloads, start processing immediately
+          if (wasEmpty && downloadTasks.isEmpty()) {
+            processNextInQueueLocked()
+          } else {
+            // Return placeholder taskId for queued items
+            -1
+          }
         }
+        promise.resolve(taskId)
       } catch (e: Exception) {
         promise.reject("DOWNLOAD_ERROR", "Failed to enqueue download: ${e.message}", e)
       }
@@ -106,36 +134,47 @@ class BackgroundDownloaderModule : Module() {
     Function("cancelDownload") { taskId: Int ->
       Log.d(TAG, "Cancelling download: taskId=$taskId")
       downloadManager.cancelDownload(taskId)
-      downloadTasks.remove(taskId)
       downloadService?.stopDownload()
-      
-      // Process next item in queue after cancellation
-      processNextInQueue()
+
+      synchronized(stateLock) {
+        downloadTasks.remove(taskId)
+        // Process next item in queue after cancellation
+        processNextInQueueLocked()
+      }
     }
 
     Function("cancelQueuedDownload") { url: String ->
-      // Remove from queue by URL
-      downloadQueue.removeAll { queuedItem ->
-        queuedItem.first == url
+      synchronized(stateLock) {
+        // Remove from queue by URL
+        downloadQueue.removeAll { queuedItem ->
+          queuedItem.url == url
+        }
+        Log.d(TAG, "Removed queued download: $url, queue size: ${downloadQueue.size}")
       }
-      Log.d(TAG, "Removed queued download: $url, queue size: ${downloadQueue.size}")
     }
 
     Function("cancelAllDownloads") {
       Log.d(TAG, "Cancelling all downloads")
       downloadManager.cancelAllDownloads()
-      downloadTasks.clear()
-      downloadQueue.clear()
+      synchronized(stateLock) {
+        downloadTasks.clear()
+        downloadQueue.clear()
+      }
       stopDownloadService()
     }
 
     AsyncFunction("getActiveDownloads") { promise: Promise ->
       try {
-        val activeDownloads = downloadTasks.map { (taskId, taskInfo) ->
-          mapOf(
-            "taskId" to taskId,
-            "url" to taskInfo.url
-          )
+        val activeDownloads = synchronized(stateLock) {
+          downloadTasks.map { (taskId, taskInfo) ->
+            val entry = mutableMapOf<String, Any>(
+              "taskId" to taskId,
+              "url" to taskInfo.url
+            )
+            taskInfo.itemId?.let { entry["itemId"] = it }
+            taskInfo.destinationPath?.let { entry["destinationPath"] = it }
+            entry
+          }
         }
         promise.resolve(activeDownloads)
       } catch (e: Exception) {
@@ -144,30 +183,33 @@ class BackgroundDownloaderModule : Module() {
     }
   }
 
-  private fun startDownloadInternal(urlString: String, destinationPath: String?): Int {
+  private fun startDownloadLocked(urlString: String, destinationPath: String?, itemId: String?): Int {
     val taskId = taskIdCounter++
-    
+
     if (destinationPath == null) {
       throw IllegalArgumentException("Destination path is required")
     }
-    
+
     downloadTasks[taskId] = DownloadTaskInfo(
       url = urlString,
-      destinationPath = destinationPath
+      destinationPath = destinationPath,
+      itemId = itemId
     )
-    
+
     // Start foreground service if not running
     startDownloadService()
     downloadService?.startDownload()
-    
+
     Log.d(TAG, "Starting download: taskId=$taskId, url=$urlString")
-    
+
     // Send started event
-    sendEvent("onDownloadStarted", mapOf(
+    val payload = mutableMapOf<String, Any>(
       "taskId" to taskId,
       "url" to urlString
-    ))
-    
+    )
+    itemId?.let { payload["itemId"] = it }
+    sendEvent("onDownloadStarted", payload)
+
     // Start the download with OkHttp
     downloadManager.startDownload(
       taskId = taskId,
@@ -183,35 +225,37 @@ class BackgroundDownloaderModule : Module() {
         handleError(taskId, error)
       }
     )
-    
+
     return taskId
   }
 
-  private fun processNextInQueue(): Int {
+  private fun processNextInQueueLocked(): Int {
     // Check if queue has items
     if (downloadQueue.isEmpty()) {
       Log.d(TAG, "Queue is empty")
       return -1
     }
-    
+
     // Check if there are active downloads (one at a time)
     if (downloadTasks.isNotEmpty()) {
       Log.d(TAG, "Active downloads in progress (${downloadTasks.size}), waiting...")
       return -1
     }
-    
+
     // Get next item from queue
-    val (url, destinationPath) = downloadQueue.removeAt(0)
-    Log.d(TAG, "Processing next in queue: $url")
-    
+    val next = downloadQueue.removeAt(0)
+    Log.d(TAG, "Processing next in queue: ${next.url}")
+
     return try {
-      startDownloadInternal(url, destinationPath)
+      startDownloadLocked(next.url, next.destinationPath, next.itemId)
     } catch (e: Exception) {
       Log.e(TAG, "Error processing queue item: ${e.message}", e)
       // Try to process next item
-      processNextInQueue()
+      processNextInQueueLocked()
     }
   }
+
+  // Called from OkHttp dispatcher threads.
 
   private fun handleProgress(taskId: Int, bytesWritten: Long, totalBytes: Long) {
     val progress = if (totalBytes > 0) {
@@ -219,60 +263,71 @@ class BackgroundDownloaderModule : Module() {
     } else {
       0.0
     }
-    
+
+    val taskInfo = synchronized(stateLock) { downloadTasks[taskId] }
+
     // Update notification
-    val taskInfo = downloadTasks[taskId]
     if (taskInfo != null) {
       val progressPercent = (progress * 100).toInt()
       downloadService?.updateProgress("Downloading video", progressPercent)
     }
-    
-    sendEvent("onDownloadProgress", mapOf(
+
+    val payload = mutableMapOf<String, Any>(
       "taskId" to taskId,
       "bytesWritten" to bytesWritten,
       "totalBytes" to totalBytes,
       "progress" to progress
-    ))
+    )
+    taskInfo?.itemId?.let { payload["itemId"] = it }
+    sendEvent("onDownloadProgress", payload)
   }
 
   private fun handleDownloadComplete(taskId: Int, filePath: String) {
-    val taskInfo = downloadTasks[taskId]
-    
+    val taskInfo = synchronized(stateLock) { downloadTasks[taskId] }
+
     if (taskInfo == null) {
       Log.e(TAG, "Download completed but task info not found: taskId=$taskId")
       return
     }
-    
+
     Log.d(TAG, "Download completed: taskId=$taskId, filePath=$filePath")
-    
-    sendEvent("onDownloadComplete", mapOf(
+
+    val payload = mutableMapOf<String, Any>(
       "taskId" to taskId,
       "filePath" to filePath,
       "url" to taskInfo.url
-    ))
-    
-    downloadTasks.remove(taskId)
+    )
+    taskInfo.itemId?.let { payload["itemId"] = it }
+    sendEvent("onDownloadComplete", payload)
+
     downloadService?.stopDownload()
-    
-    // Process next item in queue
-    processNextInQueue()
+
+    synchronized(stateLock) {
+      downloadTasks.remove(taskId)
+      // Process next item in queue
+      processNextInQueueLocked()
+    }
   }
 
   private fun handleError(taskId: Int, error: String) {
-    val taskInfo = downloadTasks[taskId]
-    
+    val taskInfo = synchronized(stateLock) { downloadTasks[taskId] }
+
     Log.e(TAG, "Download error: taskId=$taskId, error=$error")
-    
-    sendEvent("onDownloadError", mapOf(
+
+    val payload = mutableMapOf<String, Any>(
       "taskId" to taskId,
       "error" to error
-    ))
-    
-    downloadTasks.remove(taskId)
+    )
+    taskInfo?.itemId?.let { payload["itemId"] = it }
+    sendEvent("onDownloadError", payload)
+
     downloadService?.stopDownload()
-    
-    // Process next item in queue even on error
-    processNextInQueue()
+
+    synchronized(stateLock) {
+      downloadTasks.remove(taskId)
+      // Process next item in queue even on error
+      processNextInQueueLocked()
+    }
   }
 
   private fun startDownloadService() {
@@ -284,12 +339,13 @@ class BackgroundDownloaderModule : Module() {
   }
 
   private fun stopDownloadService() {
-    if (serviceBound && downloadTasks.isEmpty()) {
+    val idle = synchronized(stateLock) { downloadTasks.isEmpty() }
+    if (serviceBound && idle) {
       try {
         context.unbindService(serviceConnection)
         serviceBound = false
         downloadService = null
-        
+
         val intent = Intent(context, DownloadService::class.java)
         context.stopService(intent)
       } catch (e: Exception) {

--- a/modules/background-downloader/android/src/main/java/expo/modules/backgrounddownloader/BackgroundDownloaderModule.kt
+++ b/modules/background-downloader/android/src/main/java/expo/modules/backgrounddownloader/BackgroundDownloaderModule.kt
@@ -165,18 +165,32 @@ class BackgroundDownloaderModule : Module() {
 
     AsyncFunction("getActiveDownloads") { promise: Promise ->
       try {
-        val activeDownloads = synchronized(stateLock) {
-          downloadTasks.map { (taskId, taskInfo) ->
+        // Running and queued are snapshotted under one lock, so an item mid-transition
+        // (dequeued and started) can never be missing from both lists.
+        val downloads = synchronized(stateLock) {
+          val running = downloadTasks.map { (taskId, taskInfo) ->
             val entry = mutableMapOf<String, Any>(
               "taskId" to taskId,
-              "url" to taskInfo.url
+              "url" to taskInfo.url,
+              "state" to "running"
             )
             taskInfo.itemId?.let { entry["itemId"] = it }
             taskInfo.destinationPath?.let { entry["destinationPath"] = it }
             entry
           }
+          val queued = downloadQueue.map { queuedItem ->
+            val entry = mutableMapOf<String, Any>(
+              "taskId" to -1,
+              "url" to queuedItem.url,
+              "state" to "queued"
+            )
+            queuedItem.itemId?.let { entry["itemId"] = it }
+            queuedItem.destinationPath?.let { entry["destinationPath"] = it }
+            entry
+          }
+          running + queued
         }
-        promise.resolve(activeDownloads)
+        promise.resolve(downloads)
       } catch (e: Exception) {
         promise.reject("ERROR", "Failed to get active downloads: ${e.message}", e)
       }

--- a/modules/background-downloader/android/src/main/java/expo/modules/backgrounddownloader/OkHttpDownloadManager.kt
+++ b/modules/background-downloader/android/src/main/java/expo/modules/backgrounddownloader/OkHttpDownloadManager.kt
@@ -8,18 +8,20 @@ import okhttp3.Request
 import okhttp3.Response
 import java.io.File
 import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 class OkHttpDownloadManager {
   private val TAG = "OkHttpDownloadManager"
-  
+
   private val client = OkHttpClient.Builder()
     .connectTimeout(30, TimeUnit.SECONDS)
     .readTimeout(60, TimeUnit.SECONDS)
     .callTimeout(0, TimeUnit.SECONDS) // No timeout for long transcodes
     .build()
-  
-  private val activeDownloads = mutableMapOf<Int, Call>()
+
+  // Mutated from the JS thread (start/cancel) and OkHttp dispatcher threads (callbacks).
+  private val activeDownloads = ConcurrentHashMap<Int, Call>()
   
   fun startDownload(
     taskId: Int,

--- a/modules/background-downloader/android/src/main/java/expo/modules/backgrounddownloader/OkHttpDownloadManager.kt
+++ b/modules/background-downloader/android/src/main/java/expo/modules/backgrounddownloader/OkHttpDownloadManager.kt
@@ -59,28 +59,33 @@ class OkHttpDownloadManager {
           return
         }
         
+        // Stream into a .part staging file and rename on completion. The destination path must
+        // only ever hold a finished download: a process killed mid-transfer cannot run cleanup,
+        // and JS reconciliation treats an existing destination file as a completed download.
+        val destFile = File(destinationPath)
+        val partFile = File("$destinationPath.part")
+
         try {
           val totalBytes = response.body?.contentLength() ?: -1L
           val inputStream = response.body?.byteStream()
-          
+
           if (inputStream == null) {
             activeDownloads.remove(taskId)
             onError("Failed to get response body")
             return
           }
-          
+
           // Create destination directory if needed
-          val destFile = File(destinationPath)
           val destDir = destFile.parentFile
           if (destDir != null && !destDir.exists()) {
             destDir.mkdirs()
           }
-          
-          val outputStream = destFile.outputStream()
+
+          val outputStream = partFile.outputStream()
           val buffer = ByteArray(8192)
           var bytesWritten = 0L
           var lastProgressUpdate = System.currentTimeMillis()
-          
+
           inputStream.use { input ->
             outputStream.use { output ->
               var bytes = input.read(buffer)
@@ -88,44 +93,55 @@ class OkHttpDownloadManager {
                 // Check if download was cancelled
                 if (call.isCanceled()) {
                   Log.d(TAG, "Download cancelled: taskId=$taskId")
-                  destFile.delete()
+                  partFile.delete()
                   activeDownloads.remove(taskId)
                   return
                 }
-                
+
                 output.write(buffer, 0, bytes)
                 bytesWritten += bytes
-                
+
                 // Throttle progress updates to every 500ms
                 val now = System.currentTimeMillis()
                 if (now - lastProgressUpdate >= 500) {
                   onProgress(bytesWritten, totalBytes)
                   lastProgressUpdate = now
                 }
-                
+
                 bytes = input.read(buffer)
               }
             }
           }
-          
+
           // Send final progress update
           onProgress(bytesWritten, totalBytes)
-          
+
+          if (destFile.exists()) {
+            destFile.delete()
+          }
+          if (!partFile.renameTo(destFile)) {
+            Log.e(TAG, "Failed to move completed file into place: taskId=$taskId")
+            partFile.delete()
+            activeDownloads.remove(taskId)
+            onError("Failed to move completed file into place")
+            return
+          }
+
           Log.d(TAG, "Download completed: taskId=$taskId, bytes=$bytesWritten")
           activeDownloads.remove(taskId)
           onComplete(destinationPath)
-          
+
         } catch (e: Exception) {
           Log.e(TAG, "Error during download: taskId=$taskId, error=${e.message}", e)
           activeDownloads.remove(taskId)
-          
+
           // Clean up partial file
           try {
-            File(destinationPath).delete()
+            partFile.delete()
           } catch (deleteError: Exception) {
             Log.e(TAG, "Failed to delete partial file: ${deleteError.message}")
           }
-          
+
           if (!call.isCanceled()) {
             onError(e.message ?: "Download failed")
           }

--- a/modules/background-downloader/index.ts
+++ b/modules/background-downloader/index.ts
@@ -3,7 +3,6 @@ import { Platform } from "react-native";
 import type {
   ActiveDownload,
   DownloadActivityMetadata,
-  DownloadCancelledEvent,
   DownloadCompleteEvent,
   DownloadErrorEvent,
   DownloadProgressEvent,
@@ -51,11 +50,6 @@ export interface BackgroundDownloader {
 
   addStartedListener(
     listener: (event: DownloadStartedEvent) => void,
-  ): EventSubscription;
-
-  /** iOS only: fires when the user stops downloads from the system task UI. */
-  addCancelledListener(
-    listener: (event: DownloadCancelledEvent) => void,
   ): EventSubscription;
 }
 
@@ -142,15 +136,6 @@ const BackgroundDownloader: BackgroundDownloader = {
       listener,
     );
   },
-
-  addCancelledListener(
-    listener: (event: DownloadCancelledEvent) => void,
-  ): EventSubscription {
-    return BackgroundDownloaderModule.addListener(
-      "onDownloadCancelled",
-      listener,
-    );
-  },
 };
 
 export default BackgroundDownloader;
@@ -158,7 +143,6 @@ export default BackgroundDownloader;
 export type {
   ActiveDownload,
   DownloadActivityMetadata,
-  DownloadCancelledEvent,
   DownloadCompleteEvent,
   DownloadErrorEvent,
   DownloadProgressEvent,

--- a/modules/background-downloader/index.ts
+++ b/modules/background-downloader/index.ts
@@ -1,6 +1,8 @@
 import type { EventSubscription } from "expo-modules-core";
+import { Platform } from "react-native";
 import type {
   ActiveDownload,
+  DownloadActivityMetadata,
   DownloadCompleteEvent,
   DownloadErrorEvent,
   DownloadProgressEvent,
@@ -9,12 +11,30 @@ import type {
 import BackgroundDownloaderModule from "./src/BackgroundDownloaderModule";
 
 export interface BackgroundDownloader {
-  startDownload(url: string, destinationPath?: string): Promise<number>;
-  enqueueDownload(url: string, destinationPath?: string): Promise<number>;
+  startDownload(
+    url: string,
+    destinationPath?: string,
+    metadata?: DownloadActivityMetadata,
+  ): Promise<number>;
+  enqueueDownload(
+    url: string,
+    destinationPath?: string,
+    metadata?: DownloadActivityMetadata,
+  ): Promise<number>;
   cancelDownload(taskId: number): void;
   cancelQueuedDownload(url: string): void;
   cancelAllDownloads(): void;
   getActiveDownloads(): Promise<ActiveDownload[]>;
+
+  /** iOS only; no-op elsewhere. Ends any live activity when turned off. */
+  setLiveActivityEnabled(enabled: boolean): void;
+
+  /**
+   * iOS only. Absolute path of the App Group directory the Live Activity extension can read, or
+   * `null` when unavailable. Poster images must be staged here — the extension has no access to the
+   * app's Documents directory.
+   */
+  getLiveActivityDirectory(): string | null;
 
   addProgressListener(
     listener: (event: DownloadProgressEvent) => void,
@@ -34,18 +54,38 @@ export interface BackgroundDownloader {
 }
 
 const BackgroundDownloader: BackgroundDownloader = {
-  async startDownload(url: string, destinationPath?: string): Promise<number> {
-    return await BackgroundDownloaderModule.startDownload(url, destinationPath);
+  async startDownload(
+    url: string,
+    destinationPath?: string,
+    metadata?: DownloadActivityMetadata,
+  ): Promise<number> {
+    return await BackgroundDownloaderModule.startDownload(
+      url,
+      destinationPath,
+      metadata,
+    );
   },
 
   async enqueueDownload(
     url: string,
     destinationPath?: string,
+    metadata?: DownloadActivityMetadata,
   ): Promise<number> {
     return await BackgroundDownloaderModule.enqueueDownload(
       url,
       destinationPath,
+      metadata,
     );
+  },
+
+  setLiveActivityEnabled(enabled: boolean): void {
+    if (Platform.OS !== "ios") return;
+    BackgroundDownloaderModule.setLiveActivityEnabled?.(enabled);
+  },
+
+  getLiveActivityDirectory(): string | null {
+    if (Platform.OS !== "ios") return null;
+    return BackgroundDownloaderModule.getLiveActivityDirectory?.() ?? null;
   },
 
   cancelDownload(taskId: number): void {
@@ -102,6 +142,7 @@ export default BackgroundDownloader;
 
 export type {
   ActiveDownload,
+  DownloadActivityMetadata,
   DownloadCompleteEvent,
   DownloadErrorEvent,
   DownloadProgressEvent,

--- a/modules/background-downloader/index.ts
+++ b/modules/background-downloader/index.ts
@@ -3,6 +3,7 @@ import { Platform } from "react-native";
 import type {
   ActiveDownload,
   DownloadActivityMetadata,
+  DownloadCancelledEvent,
   DownloadCompleteEvent,
   DownloadErrorEvent,
   DownloadProgressEvent,
@@ -50,6 +51,11 @@ export interface BackgroundDownloader {
 
   addStartedListener(
     listener: (event: DownloadStartedEvent) => void,
+  ): EventSubscription;
+
+  /** iOS only: fires when the user stops downloads from the system task UI. */
+  addCancelledListener(
+    listener: (event: DownloadCancelledEvent) => void,
   ): EventSubscription;
 }
 
@@ -136,6 +142,15 @@ const BackgroundDownloader: BackgroundDownloader = {
       listener,
     );
   },
+
+  addCancelledListener(
+    listener: (event: DownloadCancelledEvent) => void,
+  ): EventSubscription {
+    return BackgroundDownloaderModule.addListener(
+      "onDownloadCancelled",
+      listener,
+    );
+  },
 };
 
 export default BackgroundDownloader;
@@ -143,6 +158,7 @@ export default BackgroundDownloader;
 export type {
   ActiveDownload,
   DownloadActivityMetadata,
+  DownloadCancelledEvent,
   DownloadCompleteEvent,
   DownloadErrorEvent,
   DownloadProgressEvent,

--- a/modules/background-downloader/ios/BackgroundDownloaderAppDelegate.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderAppDelegate.swift
@@ -1,5 +1,6 @@
 import ExpoModulesCore
 import UIKit
+import os
 
 public class BackgroundDownloaderAppDelegate: ExpoAppDelegateSubscriber {
   public func application(
@@ -7,6 +8,9 @@ public class BackgroundDownloaderAppDelegate: ExpoAppDelegateSubscriber {
     handleEventsForBackgroundURLSession identifier: String,
     completionHandler: @escaping () -> Void
   ) {
+    backgroundDownloaderLog.info(
+      "handleEventsForBackgroundURLSession received for \(identifier, privacy: .public)"
+    )
     if identifier == "com.fredrikburmester.streamyfin.backgrounddownloader" {
       BackgroundDownloaderModule.setBackgroundCompletionHandler(completionHandler)
     }

--- a/modules/background-downloader/ios/BackgroundDownloaderAppDelegate.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderAppDelegate.swift
@@ -8,7 +8,7 @@ public class BackgroundDownloaderAppDelegate: ExpoAppDelegateSubscriber {
     handleEventsForBackgroundURLSession identifier: String,
     completionHandler: @escaping () -> Void
   ) {
-    backgroundDownloaderLog.info(
+    backgroundDownloaderLog.notice(
       "handleEventsForBackgroundURLSession received for \(identifier, privacy: .public)"
     )
     if identifier == "com.fredrikburmester.streamyfin.backgrounddownloader" {

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -177,6 +177,14 @@ public class BackgroundDownloaderModule: Module {
           DownloadLiveActivityController.shared.setEnabled(enabled)
         }
       #endif
+      #if os(iOS) && compiler(>=6.2)
+        // Turning the setting off must drop the system pill too, not just the card — finish a
+        // keeper task that is already running. The transfer itself continues in the background
+        // session; the process just suspends and the completion wake handles the rest.
+        if #available(iOS 26.0, *), !enabled {
+          DownloadContinuedProcessingKeeper.shared.finish()
+        }
+      #endif
     }
 
     /// Path of the App Group directory the widget extension can read. JS stages poster images here,

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -123,6 +123,10 @@ public class BackgroundDownloaderModule: Module {
   private var downloadTasks: [Int: DownloadTaskInfo] = [:]
   private var downloadQueue: [QueuedDownloadInfo] = []
   private var lastProgressTime: [Int: Date] = [:]
+  /// Mirrors the JS `showDownloadLiveActivity` setting. Gates both the module's own activity
+  /// (also gated inside the controller) and the continued-processing keeper, whose system UI is
+  /// equally lock-screen download UI the user asked to turn off.
+  private var downloadActivityUIEnabled = true
   /// Heartbeat throttle for the unified log — proves whether progress callbacks are being
   /// delivered while backgrounded without flooding the log.
   private var lastProgressLogTime = Date.distantPast
@@ -146,6 +150,19 @@ public class BackgroundDownloaderModule: Module {
 
     OnCreate {
       self.stateQueue.sync {
+        // When the keeper cannot provide the system progress UI (submission refused or task
+        // expired), fall back to the module's own Live Activity so the lock screen is not empty.
+        #if os(iOS) && compiler(>=6.2)
+          if #available(iOS 26.0, *) {
+            DownloadContinuedProcessingKeeper.shared.onUnavailable = { [weak self] in
+              guard let self else { return }
+              self.stateQueue.async {
+                self.startFallbackLiveActivityLocked()
+              }
+            }
+          }
+        #endif
+
         // Restore tasks left behind by a previous process before reconnecting to the session, so a
         // download that completed while we were dead can still be moved into place.
         self.downloadTasks = self.taskStore.load()
@@ -165,6 +182,9 @@ public class BackgroundDownloaderModule: Module {
     }
 
     Function("setLiveActivityEnabled") { (enabled: Bool) in
+      self.stateQueue.sync {
+        self.downloadActivityUIEnabled = enabled
+      }
       #if os(iOS)
         if #available(iOS 16.2, *) {
           DownloadLiveActivityController.shared.setEnabled(enabled)
@@ -645,11 +665,35 @@ public class BackgroundDownloaderModule: Module {
     #endif
   }
 
+  /// On iOS 26+ the continued-processing keeper's system UI is the single lock-screen element for
+  /// downloads (two progress activities read as a bug), so the module's own activity is skipped
+  /// and only used as the fallback when the keeper is unavailable.
   private func startLiveActivity(taskId: Int, metadata: DownloadActivityMetadata?) {
+    guard !keeperCoversUILocked() else { return }
+    forceStartLiveActivity(taskId: taskId, metadata: metadata)
+  }
+
+  private func forceStartLiveActivity(taskId: Int, metadata: DownloadActivityMetadata?) {
     #if os(iOS)
       guard #available(iOS 16.2, *), let metadata else { return }
       DownloadLiveActivityController.shared.start(taskId: taskId, metadata: metadata)
     #endif
+  }
+
+  private func keeperCoversUILocked() -> Bool {
+    #if os(iOS) && compiler(>=6.2)
+      if #available(iOS 26.0, *) { return downloadActivityUIEnabled }
+    #endif
+    return false
+  }
+
+  /// The keeper refused or died; give the active download the regular activity instead. The
+  /// request only succeeds while the app is foregrounded — after a background expiration this is
+  /// a logged no-op and the lock screen stays empty until the next real event.
+  private func startFallbackLiveActivityLocked() {
+    guard let (taskId, info) = downloadTasks.first, let metadata = info.metadata else { return }
+    backgroundDownloaderLog.notice("Keeper unavailable; falling back to own Live Activity")
+    forceStartLiveActivity(taskId: taskId, metadata: metadata)
   }
 
   private func updateLiveActivity(taskId: Int, bytesWritten: Int64, totalBytes: Int64) {
@@ -692,7 +736,7 @@ public class BackgroundDownloaderModule: Module {
 
   private func startContinuedProcessingLocked(metadata: DownloadActivityMetadata?) {
     #if os(iOS) && compiler(>=6.2)
-      guard #available(iOS 26.0, *) else { return }
+      guard #available(iOS 26.0, *), downloadActivityUIEnabled else { return }
       DownloadContinuedProcessingKeeper.shared.ensureRunning(
         title: metadata?.title ?? "Streamyfin",
         subtitle: metadata?.subtitle ?? ""

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -691,7 +691,7 @@ public class BackgroundDownloaderModule: Module {
   // Wrapped like the Live Activity helpers; a no-op before iOS 26 or on older build toolchains.
 
   private func startContinuedProcessingLocked(metadata: DownloadActivityMetadata?) {
-    #if os(iOS) && swift(>=6.2)
+    #if os(iOS) && compiler(>=6.2)
       guard #available(iOS 26.0, *) else { return }
       DownloadContinuedProcessingKeeper.shared.ensureRunning(
         title: metadata?.title ?? "Streamyfin",
@@ -705,7 +705,7 @@ public class BackgroundDownloaderModule: Module {
     bytesWritten: Int64,
     totalBytes: Int64
   ) {
-    #if os(iOS) && swift(>=6.2)
+    #if os(iOS) && compiler(>=6.2)
       guard #available(iOS 26.0, *) else { return }
       let effectiveTotal =
         totalBytes > 0
@@ -719,7 +719,7 @@ public class BackgroundDownloaderModule: Module {
   }
 
   private func finishContinuedProcessingIfIdleLocked() {
-    #if os(iOS) && swift(>=6.2)
+    #if os(iOS) && compiler(>=6.2)
       guard #available(iOS 26.0, *) else { return }
       guard downloadTasks.isEmpty, downloadQueue.isEmpty else { return }
       DownloadContinuedProcessingKeeper.shared.finish()

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -100,8 +100,7 @@ public class BackgroundDownloaderModule: Module {
   private var session: URLSession?
   private var sessionDelegate: DownloadSessionDelegate?
   private var downloadTasks: [Int: DownloadTaskInfo] = [:]
-  private var downloadQueue:
-    [(url: String, destinationPath: String?, metadata: DownloadActivityMetadata?)] = []
+  private var downloadQueue: [QueuedDownloadInfo] = []
   private var lastProgressTime: [Int: Date] = [:]
   private let taskStore = DownloadTaskStore()
 
@@ -126,8 +125,15 @@ public class BackgroundDownloaderModule: Module {
         // Restore tasks left behind by a previous process before reconnecting to the session, so a
         // download that completed while we were dead can still be moved into place.
         self.downloadTasks = self.taskStore.load()
+        self.downloadQueue = self.taskStore.loadQueue()
         self.initializeSessionLocked()
         self.reconcileLiveActivitiesLocked()
+        self.queueDidChangeLocked()
+        // Re-arm a queue that outlived its process. No-op while a restored task is still
+        // in flight; if that task is actually gone (force-quit cancels transfers), the session
+        // delivers its cancellation error shortly after reconnecting, and handleError advances
+        // the queue from there.
+        self.processNextInQueueSafelyLocked()
       }
     }
 
@@ -170,13 +176,13 @@ public class BackgroundDownloaderModule: Module {
       try self.stateQueue.sync { () throws -> Int in
         let wasEmpty = self.downloadQueue.isEmpty
         self.downloadQueue.append(
-          (
+          QueuedDownloadInfo(
             url: urlString,
             destinationPath: destinationPath,
             metadata: metadata?.toMetadata()
           )
         )
-        self.pushQueuedCountLocked()
+        self.queueDidChangeLocked()
 
         // If queue was empty and no active downloads, start processing immediately
         if wasEmpty {
@@ -208,7 +214,7 @@ public class BackgroundDownloaderModule: Module {
         self.downloadQueue.removeAll { queuedItem in
           queuedItem.url == url
         }
-        self.pushQueuedCountLocked()
+        self.queueDidChangeLocked()
       }
     }
 
@@ -218,7 +224,7 @@ public class BackgroundDownloaderModule: Module {
       // would immediately start the next queued item, resurrecting what was just cancelled.
       let session = self.stateQueue.sync { () -> URLSession? in
         self.downloadQueue.removeAll()
-        self.pushQueuedCountLocked()
+        self.queueDidChangeLocked()
         return self.session
       }
       session?.getAllTasks { tasks in
@@ -234,10 +240,29 @@ public class BackgroundDownloaderModule: Module {
 
     AsyncFunction("getActiveDownloads") { () -> [[String: Any]] in
       return try await withCheckedThrowingContinuation { continuation in
-        let (session, tasksSnapshot) = self.stateQueue.sync { (self.session, self.downloadTasks) }
+        // Running and queued are snapshotted in one stateQueue block, so an item mid-transition
+        // (dequeued and started) can never be missing from both lists.
+        let (session, tasksSnapshot, queueSnapshot) = self.stateQueue.sync {
+          (self.session, self.downloadTasks, self.downloadQueue)
+        }
+
+        let queuedDownloads = queueSnapshot.map { queued -> [String: Any] in
+          var entry: [String: Any] = [
+            "taskId": -1,
+            "url": queued.url,
+            "state": "queued"
+          ]
+          if let itemId = queued.metadata?.itemId {
+            entry["itemId"] = itemId
+          }
+          if let destinationPath = queued.destinationPath {
+            entry["destinationPath"] = destinationPath
+          }
+          return entry
+        }
 
         guard let session else {
-          continuation.resume(returning: [])
+          continuation.resume(returning: queuedDownloads)
           return
         }
 
@@ -250,7 +275,8 @@ public class BackgroundDownloaderModule: Module {
 
             var entry: [String: Any] = [
               "taskId": task.taskIdentifier,
-              "url": info.url
+              "url": info.url,
+              "state": "running"
             ]
             if let itemId = info.metadata?.itemId {
               entry["itemId"] = itemId
@@ -260,7 +286,7 @@ public class BackgroundDownloaderModule: Module {
             }
             return entry
           }
-          continuation.resume(returning: activeDownloads)
+          continuation.resume(returning: activeDownloads + queuedDownloads)
         }
       }
     }
@@ -522,19 +548,19 @@ public class BackgroundDownloaderModule: Module {
       return -1
     }
 
-    let (url, destinationPath, metadata) = downloadQueue.removeFirst()
-    pushQueuedCountLocked()
+    let next = downloadQueue.removeFirst()
+    queueDidChangeLocked()
     print("[BackgroundDownloader] Starting queued download")
 
-    guard URL(string: url) != nil else {
-      print("[BackgroundDownloader] Invalid URL in queue: \(url)")
+    guard URL(string: next.url) != nil else {
+      print("[BackgroundDownloader] Invalid URL in queue: \(next.url)")
       return try processNextInQueueLocked()
     }
 
     return try beginDownloadLocked(
-      urlString: url,
-      destinationPath: destinationPath,
-      metadata: metadata
+      urlString: next.url,
+      destinationPath: next.destinationPath,
+      metadata: next.metadata
     )
   }
 
@@ -556,10 +582,12 @@ public class BackgroundDownloaderModule: Module {
   // checks. All of this compiles away on tvOS, where ActivityKit does not exist. The controller
   // confines its own state to its own queue; calls from here never block.
 
-  /// The controller keeps its own copy of the queued count, updated whenever the queue changes.
-  /// Reading `downloadQueue.count` from the delegate callbacks instead (as `updateLiveActivity`
+  /// Called after every queue mutation: persists the queue (so it survives process death) and
+  /// pushes the count into the Live Activity controller. The controller keeps its own copy of the
+  /// count because reading `downloadQueue.count` from the delegate callbacks (as `updateLiveActivity`
   /// used to) was the hottest cross-thread access in the module.
-  private func pushQueuedCountLocked() {
+  private func queueDidChangeLocked() {
+    taskStore.saveQueue(downloadQueue)
     #if os(iOS)
       guard #available(iOS 16.2, *) else { return }
       DownloadLiveActivityController.shared.setQueuedCount(downloadQueue.count)

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -7,9 +7,27 @@ enum DownloadError: Error {
   case downloadFailed
 }
 
-struct DownloadTaskInfo {
-  let url: String
-  let destinationPath: String?
+/// Live Activity metadata handed down from JS at enqueue time. Entirely optional — a download
+/// without it still works, it just never surfaces on the Lock Screen. All user-visible strings are
+/// resolved in JS so translations stay single-sourced in `translations/*.json`.
+struct DownloadMetadataRecord: Record {
+  @Field var itemId: String = ""
+  @Field var title: String = ""
+  @Field var subtitle: String = ""
+  @Field var posterFileName: String?
+  @Field var estimatedTotalBytes: Double = 0
+  @Field var labels: [String: String] = [:]
+
+  func toMetadata() -> DownloadActivityMetadata {
+    DownloadActivityMetadata(
+      itemId: itemId,
+      title: title,
+      subtitle: subtitle,
+      posterFileName: posterFileName,
+      estimatedTotalBytes: Int64(max(estimatedTotalBytes, 0)),
+      labels: labels
+    )
+  }
 }
 
 // Separate delegate class to handle URLSession callbacks
@@ -73,9 +91,17 @@ public class BackgroundDownloaderModule: Module {
   private var sessionDelegate: DownloadSessionDelegate?
   fileprivate static var backgroundCompletionHandler: (() -> Void)?
   private var downloadTasks: [Int: DownloadTaskInfo] = [:]
-  private var downloadQueue: [(url: String, destinationPath: String?)] = []
+  private var downloadQueue:
+    [(url: String, destinationPath: String?, metadata: DownloadActivityMetadata?)] = []
   private var lastProgressTime: [Int: Date] = [:]
-  
+  private let taskStore = DownloadTaskStore()
+
+  /// Mirrors `downloadTasks` into the App Group so a transfer that finishes after the app is
+  /// terminated can still be resolved when iOS relaunches us.
+  private func persistTasks() {
+    taskStore.save(downloadTasks)
+  }
+
   public func definition() -> ModuleDefinition {
     Name("BackgroundDownloader")
     
@@ -87,10 +113,38 @@ public class BackgroundDownloaderModule: Module {
     )
     
     OnCreate {
+      // Restore tasks left behind by a previous process before reconnecting to the session, so a
+      // download that completed while we were dead can still be moved into place.
+      self.downloadTasks = self.taskStore.load()
       self.initializeSession()
+      self.reconcileLiveActivities()
     }
-    
-    AsyncFunction("startDownload") { (urlString: String, destinationPath: String?) -> Int in
+
+    Function("setLiveActivityEnabled") { (enabled: Bool) in
+      #if os(iOS)
+        if #available(iOS 16.2, *) {
+          DownloadLiveActivityController.shared.setEnabled(enabled)
+        }
+      #endif
+    }
+
+    /// Path of the App Group directory the widget extension can read. JS stages poster images here,
+    /// since the extension has no access to the app's Documents directory.
+    Function("getLiveActivityDirectory") { () -> String? in
+      #if os(iOS)
+        guard let directory = DownloadActivitySharedContainer.directory else { return nil }
+        try? FileManager.default.createDirectory(
+          at: directory,
+          withIntermediateDirectories: true
+        )
+        return directory.path
+      #else
+        return nil
+      #endif
+    }
+
+    AsyncFunction("startDownload") {
+      (urlString: String, destinationPath: String?, metadata: DownloadMetadataRecord?) -> Int in
       guard let url = URL(string: urlString) else {
         throw DownloadError.invalidURL
       }
@@ -111,26 +165,38 @@ public class BackgroundDownloaderModule: Module {
       let task = session.downloadTask(with: request)
       let taskId = task.taskIdentifier
       
+      let resolvedMetadata = metadata?.toMetadata()
       self.downloadTasks[taskId] = DownloadTaskInfo(
         url: urlString,
-        destinationPath: destinationPath
+        destinationPath: destinationPath,
+        metadata: resolvedMetadata
       )
-      
+      self.persistTasks()
+
       task.resume()
-      
+
+      self.startLiveActivity(taskId: taskId, metadata: resolvedMetadata)
+
       self.sendEvent("onDownloadStarted", [
         "taskId": taskId,
         "url": urlString
       ])
-      
+
       return taskId
     }
-    
-    AsyncFunction("enqueueDownload") { (urlString: String, destinationPath: String?) -> Int in
+
+    AsyncFunction("enqueueDownload") {
+      (urlString: String, destinationPath: String?, metadata: DownloadMetadataRecord?) -> Int in
       // Add to queue
       let wasEmpty = self.downloadQueue.isEmpty
-      self.downloadQueue.append((url: urlString, destinationPath: destinationPath))
-      
+      self.downloadQueue.append(
+        (
+          url: urlString,
+          destinationPath: destinationPath,
+          metadata: metadata?.toMetadata()
+        )
+      )
+
       // If queue was empty and no active downloads, start processing immediately
       if wasEmpty {
         return try await self.processNextInQueue()
@@ -141,27 +207,31 @@ public class BackgroundDownloaderModule: Module {
     }
     
     Function("cancelDownload") { (taskId: Int) in
+      self.cancelLiveActivity(taskId: taskId)
       self.session?.getAllTasks { tasks in
         for task in tasks where task.taskIdentifier == taskId {
           task.cancel()
           self.downloadTasks.removeValue(forKey: taskId)
+          self.persistTasks()
         }
       }
     }
-    
+
     Function("cancelQueuedDownload") { (url: String) in
       // Remove from queue by URL
       self.downloadQueue.removeAll { queuedItem in
         queuedItem.url == url
       }
     }
-    
+
     Function("cancelAllDownloads") {
+      self.cancelAllLiveActivities()
       self.session?.getAllTasks { tasks in
         for task in tasks {
           task.cancel()
         }
         self.downloadTasks.removeAll()
+        self.persistTasks()
       }
     }
     
@@ -221,7 +291,11 @@ public class BackgroundDownloaderModule: Module {
     let progress = totalBytes > 0
       ? Double(bytesWritten) / Double(totalBytes)
       : 0.0
-    
+
+    // Fed every callback, not just the throttled ones — the controller does its own rate limiting
+    // and wants the finer samples for its speed average.
+    updateLiveActivity(taskId: taskId, bytesWritten: bytesWritten, totalBytes: totalBytes)
+
     // Throttle progress updates: only send every 500ms
     let lastTime = lastProgressTime[taskId] ?? Date.distantPast
     let now = Date()
@@ -242,13 +316,14 @@ public class BackgroundDownloaderModule: Module {
   
   func handleDownloadComplete(taskId: Int, location: URL, downloadTask: URLSessionDownloadTask) {
     guard let taskInfo = downloadTasks[taskId] else {
+      finishLiveActivity(taskId: taskId, state: .failed)
       self.sendEvent("onDownloadError", [
         "taskId": taskId,
         "error": "Download task info not found"
       ])
       return
     }
-    
+
     let fileManager = FileManager.default
     
     do {
@@ -278,16 +353,19 @@ public class BackgroundDownloaderModule: Module {
       }
       
       try fileManager.moveItem(at: location, to: destinationURL)
-      
+
+      finishLiveActivity(taskId: taskId, state: .completed)
+
       self.sendEvent("onDownloadComplete", [
         "taskId": taskId,
         "filePath": destinationURL.path,
         "url": taskInfo.url
       ])
-      
+
       downloadTasks.removeValue(forKey: taskId)
       lastProgressTime.removeValue(forKey: taskId)
-      
+      persistTasks()
+
       // Process next item in queue
       Task {
         do {
@@ -298,11 +376,17 @@ public class BackgroundDownloaderModule: Module {
       }
       
     } catch {
+      finishLiveActivity(taskId: taskId, state: .failed)
+
       self.sendEvent("onDownloadError", [
         "taskId": taskId,
         "error": "File operation failed: \(error.localizedDescription)"
       ])
-      
+
+      downloadTasks.removeValue(forKey: taskId)
+      lastProgressTime.removeValue(forKey: taskId)
+      persistTasks()
+
       // Process next item in queue even on error
       Task {
         do {
@@ -316,19 +400,26 @@ public class BackgroundDownloaderModule: Module {
   
   func handleError(taskId: Int, error: Error) {
     let isCancelled = (error as NSError).code == NSURLErrorCancelled
-    
-    if !isCancelled {
+
+    if isCancelled {
+      // JS drives cancellation, so it has usually dismissed the activity already; this covers
+      // cancels that originate anywhere else.
+      cancelLiveActivity(taskId: taskId)
+    } else {
       print("[BackgroundDownloader] Task \(taskId) error: \(error.localizedDescription)")
-      
+
+      finishLiveActivity(taskId: taskId, state: .failed)
+
       self.sendEvent("onDownloadError", [
         "taskId": taskId,
         "error": error.localizedDescription
       ])
     }
-    
+
     downloadTasks.removeValue(forKey: taskId)
     lastProgressTime.removeValue(forKey: taskId)
-    
+    persistTasks()
+
     // Process next item in queue (whether cancelled or errored)
     Task {
       do {
@@ -351,7 +442,7 @@ public class BackgroundDownloaderModule: Module {
     }
     
     // Get next item from queue
-    let (url, destinationPath) = downloadQueue.removeFirst()
+    let (url, destinationPath, metadata) = downloadQueue.removeFirst()
     print("[BackgroundDownloader] Starting queued download")
     
     // Start the download using existing startDownload logic
@@ -377,21 +468,93 @@ public class BackgroundDownloaderModule: Module {
     
     downloadTasks[taskId] = DownloadTaskInfo(
       url: url,
-      destinationPath: destinationPath
+      destinationPath: destinationPath,
+      metadata: metadata
     )
-    
+    persistTasks()
+
     task.resume()
-    
+
+    startLiveActivity(taskId: taskId, metadata: metadata)
+
     sendEvent("onDownloadStarted", [
       "taskId": taskId,
       "url": url
     ])
-    
+
     return taskId
   }
-  
+
   static func setBackgroundCompletionHandler(_ handler: @escaping () -> Void) {
     BackgroundDownloaderModule.backgroundCompletionHandler = handler
+  }
+
+  // MARK: - Live Activity
+
+  // Every entry point is wrapped so the rest of the module stays free of availability and platform
+  // checks. All of this compiles away on tvOS, where ActivityKit does not exist.
+
+  private func startLiveActivity(taskId: Int, metadata: DownloadActivityMetadata?) {
+    #if os(iOS)
+      guard #available(iOS 16.2, *), let metadata else { return }
+      DownloadLiveActivityController.shared.start(
+        taskId: taskId,
+        metadata: metadata,
+        queuedCount: downloadQueue.count
+      )
+    #endif
+  }
+
+  private func updateLiveActivity(taskId: Int, bytesWritten: Int64, totalBytes: Int64) {
+    #if os(iOS)
+      guard #available(iOS 16.2, *) else { return }
+      DownloadLiveActivityController.shared.update(
+        taskId: taskId,
+        bytesWritten: bytesWritten,
+        totalBytes: totalBytes,
+        queuedCount: downloadQueue.count
+      )
+    #endif
+  }
+
+  private func finishLiveActivity(taskId: Int, state: DownloadActivityState) {
+    #if os(iOS)
+      guard #available(iOS 16.2, *) else { return }
+      DownloadLiveActivityController.shared.finish(
+        taskId: taskId,
+        state: state,
+        queuedCount: downloadQueue.count
+      )
+    #endif
+  }
+
+  private func cancelLiveActivity(taskId: Int) {
+    #if os(iOS)
+      guard #available(iOS 16.2, *) else { return }
+      DownloadLiveActivityController.shared.cancel(taskId: taskId)
+    #endif
+  }
+
+  private func cancelAllLiveActivities() {
+    #if os(iOS)
+      guard #available(iOS 16.2, *) else { return }
+      DownloadLiveActivityController.shared.cancelAll()
+    #endif
+  }
+
+  /// Clears activities with no live task behind them — otherwise an app killed mid-download leaves
+  /// one stranded on the Lock Screen indefinitely.
+  private func reconcileLiveActivities() {
+    #if os(iOS)
+      guard #available(iOS 16.2, *) else { return }
+      session?.getAllTasks { tasks in
+        let active = Set(
+          tasks.filter { $0.state == .running || $0.state == .suspended }
+            .map(\.taskIdentifier)
+        )
+        DownloadLiveActivityController.shared.reconcile(activeTaskIds: active)
+      }
+    #endif
   }
 }
 

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -67,7 +67,7 @@ class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate {
     downloadTask: URLSessionDownloadTask,
     didFinishDownloadingTo location: URL
   ) {
-    backgroundDownloaderLog.info(
+    backgroundDownloaderLog.notice(
       "didFinishDownloadingTo delivered for task \(downloadTask.taskIdentifier)"
     )
     module?.handleDownloadComplete(
@@ -92,14 +92,14 @@ class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate {
   }
 
   func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
-    backgroundDownloaderLog.info("All background session events delivered")
+    backgroundDownloaderLog.notice("All background session events delivered")
     DispatchQueue.main.async {
       if let completion = BackgroundDownloaderModule.backgroundCompletionHandler {
-        backgroundDownloaderLog.info("Calling stored background completion handler")
+        backgroundDownloaderLog.notice("Calling stored background completion handler")
         completion()
         BackgroundDownloaderModule.backgroundCompletionHandler = nil
       } else {
-        backgroundDownloaderLog.info(
+        backgroundDownloaderLog.notice(
           "No background completion handler stored (foreground delivery)"
         )
       }
@@ -150,7 +150,7 @@ public class BackgroundDownloaderModule: Module {
         // download that completed while we were dead can still be moved into place.
         self.downloadTasks = self.taskStore.load()
         self.downloadQueue = self.taskStore.loadQueue()
-        backgroundDownloaderLog.info(
+        backgroundDownloaderLog.notice(
           "Module created: restored \(self.downloadTasks.count) task(s), \(self.downloadQueue.count) queued"
         )
         self.initializeSessionLocked()
@@ -334,7 +334,7 @@ public class BackgroundDownloaderModule: Module {
       delegateQueue: nil
     )
 
-    backgroundDownloaderLog.info("Background URLSession initialized")
+    backgroundDownloaderLog.notice("Background URLSession initialized")
   }
 
   /// Creates the URLSession task and all bookkeeping for one download. Shared by `startDownload`
@@ -373,7 +373,7 @@ public class BackgroundDownloaderModule: Module {
 
     task.resume()
 
-    backgroundDownloaderLog.info(
+    backgroundDownloaderLog.notice(
       "Started download task \(taskId), \(self.downloadQueue.count) queued behind it"
     )
 
@@ -436,7 +436,7 @@ public class BackgroundDownloaderModule: Module {
     let timeDiff = now.timeIntervalSince(lastTime)
 
     if now.timeIntervalSince(lastProgressLogTime) >= 10 {
-      backgroundDownloaderLog.info(
+      backgroundDownloaderLog.notice(
         "Progress delivering for task \(taskId): \(bytesWritten) / \(totalBytes) bytes"
       )
       lastProgressLogTime = now
@@ -504,7 +504,7 @@ public class BackgroundDownloaderModule: Module {
 
       try fileManager.moveItem(at: location, to: destinationURL)
 
-      backgroundDownloaderLog.info("Task \(taskId) completed; file moved into place")
+      backgroundDownloaderLog.notice("Task \(taskId) completed; file moved into place")
 
       finishLiveActivity(taskId: taskId, state: .completed)
 
@@ -551,7 +551,7 @@ public class BackgroundDownloaderModule: Module {
     let itemId = downloadTasks[taskId]?.metadata?.itemId
 
     if isCancelled {
-      backgroundDownloaderLog.info("Task \(taskId) cancelled")
+      backgroundDownloaderLog.notice("Task \(taskId) cancelled")
       // JS drives cancellation, so it has usually dismissed the activity already; this covers
       // cancels that originate anywhere else.
       cancelLiveActivity(taskId: taskId)

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -145,7 +145,8 @@ public class BackgroundDownloaderModule: Module {
       "onDownloadProgress",
       "onDownloadComplete",
       "onDownloadError",
-      "onDownloadStarted"
+      "onDownloadStarted",
+      "onDownloadCancelled"
     )
 
     OnCreate {
@@ -154,10 +155,10 @@ public class BackgroundDownloaderModule: Module {
         // expired), fall back to the module's own Live Activity so the lock screen is not empty.
         #if os(iOS) && compiler(>=6.2)
           if #available(iOS 26.0, *) {
-            DownloadContinuedProcessingKeeper.shared.onUnavailable = { [weak self] in
+            DownloadContinuedProcessingKeeper.shared.onUnavailable = { [weak self] reason in
               guard let self else { return }
               self.stateQueue.async {
-                self.startFallbackLiveActivityLocked()
+                self.handleKeeperUnavailableLocked(expired: reason == .expired)
               }
             }
           }
@@ -687,6 +688,30 @@ public class BackgroundDownloaderModule: Module {
     return false
   }
 
+  /// A stall expiration requires ~30 seconds of missing progress before the system fires it, so
+  /// an expiration while bytes arrived within this window can only realistically be the user
+  /// tapping stop on the system UI. Kept well under the stall threshold so the two cannot overlap.
+  private static let userStopCancelWindow: TimeInterval = 5
+
+  private func handleKeeperUnavailableLocked(expired: Bool) {
+    // Heuristic user-stop detection (Apple provides no explicit signal yet — see the DTS
+    // acknowledgment on forums thread 805088): expiration with fresh progress means the user
+    // tapped stop, so honor the tap and cancel the work. Everything else — submission failures,
+    // stall expirations — falls back to the module's own activity and lets the transfer finish.
+    if expired,
+      let lastProgress = lastProgressTime.values.max(),
+      Date().timeIntervalSince(lastProgress) <= Self.userStopCancelWindow
+    {
+      backgroundDownloaderLog.notice(
+        "Keeper expired while bytes were flowing; treating as user stop and cancelling downloads"
+      )
+      cancelAllForUserStopLocked()
+      return
+    }
+
+    startFallbackLiveActivityLocked()
+  }
+
   /// The keeper refused or died; give the active download the regular activity instead. The
   /// request only succeeds while the app is foregrounded — after a background expiration this is
   /// a logged no-op and the lock screen stays empty until the next real event.
@@ -694,6 +719,39 @@ public class BackgroundDownloaderModule: Module {
     guard let (taskId, info) = downloadTasks.first, let metadata = info.metadata else { return }
     backgroundDownloaderLog.notice("Keeper unavailable; falling back to own Live Activity")
     forceStartLiveActivity(taskId: taskId, metadata: metadata)
+  }
+
+  /// Cancels the active transfer and the whole queue in response to a system-UI stop tap.
+  private func cancelAllForUserStopLocked() {
+    // Events go out first: the process suspends shortly after the keeper dies and JS needs these
+    // to settle its persisted records. If suspension wins the race anyway, the next launch's
+    // reconciliation re-enqueues the queued items as if native lost them — an accepted residual
+    // of the heuristic, correctable by the user in-app.
+    for (taskId, info) in downloadTasks {
+      var payload: [String: Any] = ["taskId": taskId]
+      if let itemId = info.metadata?.itemId {
+        payload["itemId"] = itemId
+      }
+      sendEvent("onDownloadCancelled", payload)
+    }
+    for queued in downloadQueue {
+      guard let itemId = queued.metadata?.itemId else { continue }
+      sendEvent("onDownloadCancelled", ["taskId": -1, "itemId": itemId])
+    }
+
+    downloadQueue.removeAll()
+    queueDidChangeLocked()
+    downloadTasks.removeAll()
+    lastProgressTime.removeAll()
+    persistTasksLocked()
+
+    cancelAllLiveActivities()
+
+    session?.getAllTasks { tasks in
+      for task in tasks {
+        task.cancel()
+      }
+    }
   }
 
   private func updateLiveActivity(taskId: Int, bytesWritten: Int64, totalBytes: Int64) {

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -1,5 +1,14 @@
 import ExpoModulesCore
 import Foundation
+import os
+
+/// Unified-log diagnostics for the background wake chain. `print` is invisible in release builds;
+/// these lines are readable from Console.app or `log show` on an untethered device — the only way
+/// to see whether iOS actually resumed the app for a background completion.
+let backgroundDownloaderLog = Logger(
+  subsystem: "com.fredrikburmester.streamyfin",
+  category: "BackgroundDownloader"
+)
 
 enum DownloadError: Error {
   case invalidURL
@@ -58,6 +67,9 @@ class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate {
     downloadTask: URLSessionDownloadTask,
     didFinishDownloadingTo location: URL
   ) {
+    backgroundDownloaderLog.info(
+      "didFinishDownloadingTo delivered for task \(downloadTask.taskIdentifier)"
+    )
     module?.handleDownloadComplete(
       taskId: downloadTask.taskIdentifier,
       location: location,
@@ -71,16 +83,25 @@ class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate {
     didCompleteWithError error: Error?
   ) {
     if let error = error {
-      print("[BackgroundDownloader] Task \(task.taskIdentifier) error: \(error.localizedDescription)")
+      let nsError = error as NSError
+      backgroundDownloaderLog.error(
+        "Task \(task.taskIdentifier) failed: \(nsError.domain, privacy: .public) code \(nsError.code)"
+      )
       module?.handleError(taskId: task.taskIdentifier, error: error)
     }
   }
 
   func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+    backgroundDownloaderLog.info("All background session events delivered")
     DispatchQueue.main.async {
       if let completion = BackgroundDownloaderModule.backgroundCompletionHandler {
+        backgroundDownloaderLog.info("Calling stored background completion handler")
         completion()
         BackgroundDownloaderModule.backgroundCompletionHandler = nil
+      } else {
+        backgroundDownloaderLog.info(
+          "No background completion handler stored (foreground delivery)"
+        )
       }
     }
   }
@@ -102,6 +123,9 @@ public class BackgroundDownloaderModule: Module {
   private var downloadTasks: [Int: DownloadTaskInfo] = [:]
   private var downloadQueue: [QueuedDownloadInfo] = []
   private var lastProgressTime: [Int: Date] = [:]
+  /// Heartbeat throttle for the unified log — proves whether progress callbacks are being
+  /// delivered while backgrounded without flooding the log.
+  private var lastProgressLogTime = Date.distantPast
   private let taskStore = DownloadTaskStore()
 
   /// Mirrors `downloadTasks` into the App Group so a transfer that finishes after the app is
@@ -126,6 +150,9 @@ public class BackgroundDownloaderModule: Module {
         // download that completed while we were dead can still be moved into place.
         self.downloadTasks = self.taskStore.load()
         self.downloadQueue = self.taskStore.loadQueue()
+        backgroundDownloaderLog.info(
+          "Module created: restored \(self.downloadTasks.count) task(s), \(self.downloadQueue.count) queued"
+        )
         self.initializeSessionLocked()
         self.reconcileLiveActivitiesLocked()
         self.queueDidChangeLocked()
@@ -293,8 +320,6 @@ public class BackgroundDownloaderModule: Module {
   }
 
   private func initializeSessionLocked() {
-    print("[BackgroundDownloader] Initializing URLSession")
-
     let config = URLSessionConfiguration.background(
       withIdentifier: "com.fredrikburmester.streamyfin.backgrounddownloader"
     )
@@ -309,7 +334,7 @@ public class BackgroundDownloaderModule: Module {
       delegateQueue: nil
     )
 
-    print("[BackgroundDownloader] URLSession initialized with delegate: \(String(describing: self.sessionDelegate))")
+    backgroundDownloaderLog.info("Background URLSession initialized")
   }
 
   /// Creates the URLSession task and all bookkeeping for one download. Shared by `startDownload`
@@ -347,6 +372,10 @@ public class BackgroundDownloaderModule: Module {
     persistTasksLocked()
 
     task.resume()
+
+    backgroundDownloaderLog.info(
+      "Started download task \(taskId), \(self.downloadQueue.count) queued behind it"
+    )
 
     startLiveActivity(taskId: taskId, metadata: metadata)
 
@@ -406,6 +435,13 @@ public class BackgroundDownloaderModule: Module {
     let now = Date()
     let timeDiff = now.timeIntervalSince(lastTime)
 
+    if now.timeIntervalSince(lastProgressLogTime) >= 10 {
+      backgroundDownloaderLog.info(
+        "Progress delivering for task \(taskId): \(bytesWritten) / \(totalBytes) bytes"
+      )
+      lastProgressLogTime = now
+    }
+
     // Send if 500ms passed
     if timeDiff >= 0.5 {
       var payload: [String: Any] = [
@@ -429,6 +465,7 @@ public class BackgroundDownloaderModule: Module {
     downloadTask: URLSessionDownloadTask
   ) {
     guard let taskInfo = downloadTasks[taskId] else {
+      backgroundDownloaderLog.error("Completion for task \(taskId) but no task info was found")
       finishLiveActivity(taskId: taskId, state: .failed)
       self.sendEvent("onDownloadError", [
         "taskId": taskId,
@@ -467,6 +504,8 @@ public class BackgroundDownloaderModule: Module {
 
       try fileManager.moveItem(at: location, to: destinationURL)
 
+      backgroundDownloaderLog.info("Task \(taskId) completed; file moved into place")
+
       finishLiveActivity(taskId: taskId, state: .completed)
 
       var payload: [String: Any] = [
@@ -485,6 +524,9 @@ public class BackgroundDownloaderModule: Module {
 
       processNextInQueueSafelyLocked()
     } catch {
+      backgroundDownloaderLog.error(
+        "Task \(taskId) file operation failed: \(error.localizedDescription, privacy: .public)"
+      )
       finishLiveActivity(taskId: taskId, state: .failed)
 
       var payload: [String: Any] = [
@@ -509,12 +551,11 @@ public class BackgroundDownloaderModule: Module {
     let itemId = downloadTasks[taskId]?.metadata?.itemId
 
     if isCancelled {
+      backgroundDownloaderLog.info("Task \(taskId) cancelled")
       // JS drives cancellation, so it has usually dismissed the activity already; this covers
       // cancels that originate anywhere else.
       cancelLiveActivity(taskId: taskId)
     } else {
-      print("[BackgroundDownloader] Task \(taskId) error: \(error.localizedDescription)")
-
       finishLiveActivity(taskId: taskId, state: .failed)
 
       var payload: [String: Any] = [
@@ -550,10 +591,9 @@ public class BackgroundDownloaderModule: Module {
 
     let next = downloadQueue.removeFirst()
     queueDidChangeLocked()
-    print("[BackgroundDownloader] Starting queued download")
 
     guard URL(string: next.url) != nil else {
-      print("[BackgroundDownloader] Invalid URL in queue: \(next.url)")
+      backgroundDownloaderLog.error("Invalid URL in queue; skipping to next")
       return try processNextInQueueLocked()
     }
 
@@ -568,7 +608,9 @@ public class BackgroundDownloaderModule: Module {
     do {
       _ = try processNextInQueueLocked()
     } catch {
-      print("[BackgroundDownloader] Error processing next: \(error)")
+      backgroundDownloaderLog.error(
+        "Failed to start next queued download: \(error.localizedDescription, privacy: .public)"
+      )
     }
   }
 

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -150,19 +150,6 @@ public class BackgroundDownloaderModule: Module {
 
     OnCreate {
       self.stateQueue.sync {
-        // When the keeper cannot provide the system progress UI (submission refused or task
-        // expired), fall back to the module's own Live Activity so the lock screen is not empty.
-        #if os(iOS) && compiler(>=6.2)
-          if #available(iOS 26.0, *) {
-            DownloadContinuedProcessingKeeper.shared.onUnavailable = { [weak self] in
-              guard let self else { return }
-              self.stateQueue.async {
-                self.startFallbackLiveActivityLocked()
-              }
-            }
-          }
-        #endif
-
         // Restore tasks left behind by a previous process before reconnecting to the session, so a
         // download that completed while we were dead can still be moved into place.
         self.downloadTasks = self.taskStore.load()
@@ -665,35 +652,16 @@ public class BackgroundDownloaderModule: Module {
     #endif
   }
 
-  /// On iOS 26+ the continued-processing keeper's system UI is the single lock-screen element for
-  /// downloads (two progress activities read as a bug), so the module's own activity is skipped
-  /// and only used as the fallback when the keeper is unavailable.
+  /// The module's activity is the primary download UI on every iOS version. On iOS 26+ the
+  /// system's continued-processing pill shows alongside it while the keeper runs — Apple mandates
+  /// that UI for background execution and it cannot be suppressed — but the card is the element
+  /// that survives everything: when the keeper expires (stop tap, stalled progress), the card is
+  /// already live and degrades to the timer projection instead of leaving the lock screen empty.
   private func startLiveActivity(taskId: Int, metadata: DownloadActivityMetadata?) {
-    guard !keeperCoversUILocked() else { return }
-    forceStartLiveActivity(taskId: taskId, metadata: metadata)
-  }
-
-  private func forceStartLiveActivity(taskId: Int, metadata: DownloadActivityMetadata?) {
     #if os(iOS)
       guard #available(iOS 16.2, *), let metadata else { return }
       DownloadLiveActivityController.shared.start(taskId: taskId, metadata: metadata)
     #endif
-  }
-
-  private func keeperCoversUILocked() -> Bool {
-    #if os(iOS) && compiler(>=6.2)
-      if #available(iOS 26.0, *) { return downloadActivityUIEnabled }
-    #endif
-    return false
-  }
-
-  /// The keeper refused or died; give the active download the regular activity instead. The
-  /// request only succeeds while the app is foregrounded — after a background expiration this is
-  /// a logged no-op and the lock screen stays empty until the next real event.
-  private func startFallbackLiveActivityLocked() {
-    guard let (taskId, info) = downloadTasks.first, let metadata = info.metadata else { return }
-    backgroundDownloaderLog.notice("Keeper unavailable; falling back to own Live Activity")
-    forceStartLiveActivity(taskId: taskId, metadata: metadata)
   }
 
   private func updateLiveActivity(taskId: Int, bytesWritten: Int64, totalBytes: Int64) {
@@ -737,9 +705,12 @@ public class BackgroundDownloaderModule: Module {
   private func startContinuedProcessingLocked(metadata: DownloadActivityMetadata?) {
     #if os(iOS) && compiler(>=6.2)
       guard #available(iOS 26.0, *), downloadActivityUIEnabled else { return }
+      // Titled as a status ("Downloading" / item name) rather than repeating the activity card's
+      // title/subtitle — the pill reads as the system's task control, the card as the content,
+      // instead of two identical media cards.
       DownloadContinuedProcessingKeeper.shared.ensureRunning(
-        title: metadata?.title ?? "Streamyfin",
-        subtitle: metadata?.subtitle ?? ""
+        title: metadata?.labels["downloading"] ?? "Downloading",
+        subtitle: metadata?.title ?? ""
       )
     #endif
   }

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -145,8 +145,7 @@ public class BackgroundDownloaderModule: Module {
       "onDownloadProgress",
       "onDownloadComplete",
       "onDownloadError",
-      "onDownloadStarted",
-      "onDownloadCancelled"
+      "onDownloadStarted"
     )
 
     OnCreate {
@@ -155,10 +154,10 @@ public class BackgroundDownloaderModule: Module {
         // expired), fall back to the module's own Live Activity so the lock screen is not empty.
         #if os(iOS) && compiler(>=6.2)
           if #available(iOS 26.0, *) {
-            DownloadContinuedProcessingKeeper.shared.onUnavailable = { [weak self] reason in
+            DownloadContinuedProcessingKeeper.shared.onUnavailable = { [weak self] in
               guard let self else { return }
               self.stateQueue.async {
-                self.handleKeeperUnavailableLocked(expired: reason == .expired)
+                self.startFallbackLiveActivityLocked()
               }
             }
           }
@@ -688,30 +687,6 @@ public class BackgroundDownloaderModule: Module {
     return false
   }
 
-  /// A stall expiration requires ~30 seconds of missing progress before the system fires it, so
-  /// an expiration while bytes arrived within this window can only realistically be the user
-  /// tapping stop on the system UI. Kept well under the stall threshold so the two cannot overlap.
-  private static let userStopCancelWindow: TimeInterval = 5
-
-  private func handleKeeperUnavailableLocked(expired: Bool) {
-    // Heuristic user-stop detection (Apple provides no explicit signal yet — see the DTS
-    // acknowledgment on forums thread 805088): expiration with fresh progress means the user
-    // tapped stop, so honor the tap and cancel the work. Everything else — submission failures,
-    // stall expirations — falls back to the module's own activity and lets the transfer finish.
-    if expired,
-      let lastProgress = lastProgressTime.values.max(),
-      Date().timeIntervalSince(lastProgress) <= Self.userStopCancelWindow
-    {
-      backgroundDownloaderLog.notice(
-        "Keeper expired while bytes were flowing; treating as user stop and cancelling downloads"
-      )
-      cancelAllForUserStopLocked()
-      return
-    }
-
-    startFallbackLiveActivityLocked()
-  }
-
   /// The keeper refused or died; give the active download the regular activity instead. The
   /// request only succeeds while the app is foregrounded — after a background expiration this is
   /// a logged no-op and the lock screen stays empty until the next real event.
@@ -719,39 +694,6 @@ public class BackgroundDownloaderModule: Module {
     guard let (taskId, info) = downloadTasks.first, let metadata = info.metadata else { return }
     backgroundDownloaderLog.notice("Keeper unavailable; falling back to own Live Activity")
     forceStartLiveActivity(taskId: taskId, metadata: metadata)
-  }
-
-  /// Cancels the active transfer and the whole queue in response to a system-UI stop tap.
-  private func cancelAllForUserStopLocked() {
-    // Events go out first: the process suspends shortly after the keeper dies and JS needs these
-    // to settle its persisted records. If suspension wins the race anyway, the next launch's
-    // reconciliation re-enqueues the queued items as if native lost them — an accepted residual
-    // of the heuristic, correctable by the user in-app.
-    for (taskId, info) in downloadTasks {
-      var payload: [String: Any] = ["taskId": taskId]
-      if let itemId = info.metadata?.itemId {
-        payload["itemId"] = itemId
-      }
-      sendEvent("onDownloadCancelled", payload)
-    }
-    for queued in downloadQueue {
-      guard let itemId = queued.metadata?.itemId else { continue }
-      sendEvent("onDownloadCancelled", ["taskId": -1, "itemId": itemId])
-    }
-
-    downloadQueue.removeAll()
-    queueDidChangeLocked()
-    downloadTasks.removeAll()
-    lastProgressTime.removeAll()
-    persistTasksLocked()
-
-    cancelAllLiveActivities()
-
-    session?.getAllTasks { tasks in
-      for task in tasks {
-        task.cancel()
-      }
-    }
   }
 
   private func updateLiveActivity(taskId: Int, bytesWritten: Int64, totalBytes: Int64) {

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -542,18 +542,16 @@ public class BackgroundDownloaderModule: Module {
     #endif
   }
 
-  /// Clears activities with no live task behind them — otherwise an app killed mid-download leaves
-  /// one stranded on the Lock Screen indefinitely.
+  /// Reconnects Live Activities left by a previous process to their restored tasks and clears the
+  /// rest — otherwise an app killed mid-download leaves one stranded on the Lock Screen. Keyed on
+  /// the persisted task store, not `getAllTasks`, so an activity whose transfer finished while the
+  /// app was dead survives long enough for the queued completion callback to flip it.
   private func reconcileLiveActivities() {
     #if os(iOS)
       guard #available(iOS 16.2, *) else { return }
-      session?.getAllTasks { tasks in
-        let active = Set(
-          tasks.filter { $0.state == .running || $0.state == .suspended }
-            .map(\.taskIdentifier)
-        )
-        DownloadLiveActivityController.shared.reconcile(activeTaskIds: active)
-      }
+      DownloadLiveActivityController.shared.reconcile(
+        persistedTasks: downloadTasks.compactMapValues(\.metadata)
+      )
     #endif
   }
 }

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -33,12 +33,12 @@ struct DownloadMetadataRecord: Record {
 // Separate delegate class to handle URLSession callbacks
 class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate {
   weak var module: BackgroundDownloaderModule?
-  
+
   init(module: BackgroundDownloaderModule) {
     self.module = module
     super.init()
   }
-  
+
   func urlSession(
     _ session: URLSession,
     downloadTask: URLSessionDownloadTask,
@@ -52,7 +52,7 @@ class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate {
       totalBytes: totalBytesExpectedToWrite
     )
   }
-  
+
   func urlSession(
     _ session: URLSession,
     downloadTask: URLSessionDownloadTask,
@@ -64,7 +64,7 @@ class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate {
       downloadTask: downloadTask
     )
   }
-  
+
   func urlSession(
     _ session: URLSession,
     task: URLSessionTask,
@@ -75,7 +75,7 @@ class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate {
       module?.handleError(taskId: task.taskIdentifier, error: error)
     }
   }
-  
+
   func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
     DispatchQueue.main.async {
       if let completion = BackgroundDownloaderModule.backgroundCompletionHandler {
@@ -87,9 +87,18 @@ class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate {
 }
 
 public class BackgroundDownloaderModule: Module {
+  fileprivate static var backgroundCompletionHandler: (() -> Void)?
+
+  /// Confines every piece of mutable download state below. The module is entered from several
+  /// unrelated execution contexts — Expo function bodies, the URLSession delegate queue, and
+  /// `getAllTasks` completion handlers — and plain Swift collections must never be touched from two
+  /// of them at once. Methods suffixed `Locked` assume they are already running on this queue and
+  /// must not be called from anywhere else.
+  private let stateQueue = DispatchQueue(
+    label: "com.fredrikburmester.streamyfin.backgrounddownloader.state"
+  )
   private var session: URLSession?
   private var sessionDelegate: DownloadSessionDelegate?
-  fileprivate static var backgroundCompletionHandler: (() -> Void)?
   private var downloadTasks: [Int: DownloadTaskInfo] = [:]
   private var downloadQueue:
     [(url: String, destinationPath: String?, metadata: DownloadActivityMetadata?)] = []
@@ -98,26 +107,28 @@ public class BackgroundDownloaderModule: Module {
 
   /// Mirrors `downloadTasks` into the App Group so a transfer that finishes after the app is
   /// terminated can still be resolved when iOS relaunches us.
-  private func persistTasks() {
+  private func persistTasksLocked() {
     taskStore.save(downloadTasks)
   }
 
   public func definition() -> ModuleDefinition {
     Name("BackgroundDownloader")
-    
+
     Events(
       "onDownloadProgress",
       "onDownloadComplete",
       "onDownloadError",
       "onDownloadStarted"
     )
-    
+
     OnCreate {
-      // Restore tasks left behind by a previous process before reconnecting to the session, so a
-      // download that completed while we were dead can still be moved into place.
-      self.downloadTasks = self.taskStore.load()
-      self.initializeSession()
-      self.reconcileLiveActivities()
+      self.stateQueue.sync {
+        // Restore tasks left behind by a previous process before reconnecting to the session, so a
+        // download that completed while we were dead can still be moved into place.
+        self.downloadTasks = self.taskStore.load()
+        self.initializeSessionLocked()
+        self.reconcileLiveActivitiesLocked()
+      }
     }
 
     Function("setLiveActivityEnabled") { (enabled: Bool) in
@@ -145,149 +156,213 @@ public class BackgroundDownloaderModule: Module {
 
     AsyncFunction("startDownload") {
       (urlString: String, destinationPath: String?, metadata: DownloadMetadataRecord?) -> Int in
-      guard let url = URL(string: urlString) else {
-        throw DownloadError.invalidURL
+      try self.stateQueue.sync {
+        try self.beginDownloadLocked(
+          urlString: urlString,
+          destinationPath: destinationPath,
+          metadata: metadata?.toMetadata()
+        )
       }
-      
-      if self.session == nil {
-        self.initializeSession()
-      }
-      
-      guard let session = self.session else {
-        throw DownloadError.downloadFailed
-      }
-      
-      // Create a URLRequest to ensure proper handling
-      var request = URLRequest(url: url)
-      request.httpMethod = "GET"
-      request.timeoutInterval = 300
-      
-      let task = session.downloadTask(with: request)
-      let taskId = task.taskIdentifier
-      
-      let resolvedMetadata = metadata?.toMetadata()
-      self.downloadTasks[taskId] = DownloadTaskInfo(
-        url: urlString,
-        destinationPath: destinationPath,
-        metadata: resolvedMetadata
-      )
-      self.persistTasks()
-
-      task.resume()
-
-      self.startLiveActivity(taskId: taskId, metadata: resolvedMetadata)
-
-      self.sendEvent("onDownloadStarted", [
-        "taskId": taskId,
-        "url": urlString
-      ])
-
-      return taskId
     }
 
     AsyncFunction("enqueueDownload") {
       (urlString: String, destinationPath: String?, metadata: DownloadMetadataRecord?) -> Int in
-      // Add to queue
-      let wasEmpty = self.downloadQueue.isEmpty
-      self.downloadQueue.append(
-        (
-          url: urlString,
-          destinationPath: destinationPath,
-          metadata: metadata?.toMetadata()
+      try self.stateQueue.sync { () throws -> Int in
+        let wasEmpty = self.downloadQueue.isEmpty
+        self.downloadQueue.append(
+          (
+            url: urlString,
+            destinationPath: destinationPath,
+            metadata: metadata?.toMetadata()
+          )
         )
-      )
+        self.pushQueuedCountLocked()
 
-      // If queue was empty and no active downloads, start processing immediately
-      if wasEmpty {
-        return try await self.processNextInQueue()
+        // If queue was empty and no active downloads, start processing immediately
+        if wasEmpty {
+          return try self.processNextInQueueLocked()
+        }
+
+        // Return placeholder taskId for queued items
+        return -1
       }
-      
-      // Return placeholder taskId for queued items
-      return -1
     }
-    
+
     Function("cancelDownload") { (taskId: Int) in
       self.cancelLiveActivity(taskId: taskId)
-      self.session?.getAllTasks { tasks in
+      let session = self.stateQueue.sync { self.session }
+      session?.getAllTasks { tasks in
         for task in tasks where task.taskIdentifier == taskId {
           task.cancel()
-          self.downloadTasks.removeValue(forKey: taskId)
-          self.persistTasks()
+          self.stateQueue.async {
+            self.downloadTasks.removeValue(forKey: taskId)
+            self.persistTasksLocked()
+          }
         }
       }
     }
 
     Function("cancelQueuedDownload") { (url: String) in
       // Remove from queue by URL
-      self.downloadQueue.removeAll { queuedItem in
-        queuedItem.url == url
+      self.stateQueue.sync {
+        self.downloadQueue.removeAll { queuedItem in
+          queuedItem.url == url
+        }
+        self.pushQueuedCountLocked()
       }
     }
 
     Function("cancelAllDownloads") {
       self.cancelAllLiveActivities()
-      self.session?.getAllTasks { tasks in
+      // Clear the queue as well (Android already does) — otherwise the cancellation callbacks
+      // would immediately start the next queued item, resurrecting what was just cancelled.
+      let session = self.stateQueue.sync { () -> URLSession? in
+        self.downloadQueue.removeAll()
+        self.pushQueuedCountLocked()
+        return self.session
+      }
+      session?.getAllTasks { tasks in
         for task in tasks {
           task.cancel()
         }
-        self.downloadTasks.removeAll()
-        self.persistTasks()
+        self.stateQueue.async {
+          self.downloadTasks.removeAll()
+          self.persistTasksLocked()
+        }
       }
     }
-    
+
     AsyncFunction("getActiveDownloads") { () -> [[String: Any]] in
       return try await withCheckedThrowingContinuation { continuation in
-        let downloadTasks = self.downloadTasks
-        
-        self.session?.getAllTasks { tasks in
+        let (session, tasksSnapshot) = self.stateQueue.sync { (self.session, self.downloadTasks) }
+
+        guard let session else {
+          continuation.resume(returning: [])
+          return
+        }
+
+        session.getAllTasks { tasks in
           let activeDownloads = tasks.compactMap { task -> [String: Any]? in
             guard task is URLSessionDownloadTask,
-                  let info = downloadTasks[task.taskIdentifier] else {
+                  let info = tasksSnapshot[task.taskIdentifier] else {
               return nil
             }
-            
-            return [
+
+            var entry: [String: Any] = [
               "taskId": task.taskIdentifier,
               "url": info.url
             ]
+            if let itemId = info.metadata?.itemId {
+              entry["itemId"] = itemId
+            }
+            if let destinationPath = info.destinationPath {
+              entry["destinationPath"] = destinationPath
+            }
+            return entry
           }
           continuation.resume(returning: activeDownloads)
         }
       }
     }
   }
-  
-  private func initializeSession() {
+
+  private func initializeSessionLocked() {
     print("[BackgroundDownloader] Initializing URLSession")
-    
+
     let config = URLSessionConfiguration.background(
       withIdentifier: "com.fredrikburmester.streamyfin.backgrounddownloader"
     )
     config.allowsCellularAccess = true
     config.sessionSendsLaunchEvents = true
     config.isDiscretionary = false
-    
+
     self.sessionDelegate = DownloadSessionDelegate(module: self)
     self.session = URLSession(
       configuration: config,
       delegate: self.sessionDelegate,
       delegateQueue: nil
     )
-    
+
     print("[BackgroundDownloader] URLSession initialized with delegate: \(String(describing: self.sessionDelegate))")
-    print("[BackgroundDownloader] Session identifier: \(config.identifier ?? "nil")")
-    print("[BackgroundDownloader] Delegate queue: nil (uses default)")
-    
-    // Verify delegate is connected
-    if let session = self.session, session.delegate != nil {
-      print("[BackgroundDownloader] ✅ Delegate successfully attached to session")
-    } else {
-      print("[BackgroundDownloader] ⚠️ DELEGATE NOT ATTACHED!")
+  }
+
+  /// Creates the URLSession task and all bookkeeping for one download. Shared by `startDownload`
+  /// and the queue processor so the two can never drift apart again.
+  private func beginDownloadLocked(
+    urlString: String,
+    destinationPath: String?,
+    metadata: DownloadActivityMetadata?
+  ) throws -> Int {
+    guard let url = URL(string: urlString) else {
+      throw DownloadError.invalidURL
+    }
+
+    if session == nil {
+      initializeSessionLocked()
+    }
+
+    guard let session = self.session else {
+      throw DownloadError.downloadFailed
+    }
+
+    // Create a URLRequest to ensure proper handling
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.timeoutInterval = 300
+
+    let task = session.downloadTask(with: request)
+    let taskId = task.taskIdentifier
+
+    downloadTasks[taskId] = DownloadTaskInfo(
+      url: urlString,
+      destinationPath: destinationPath,
+      metadata: metadata
+    )
+    persistTasksLocked()
+
+    task.resume()
+
+    startLiveActivity(taskId: taskId, metadata: metadata)
+
+    var payload: [String: Any] = [
+      "taskId": taskId,
+      "url": urlString
+    ]
+    if let itemId = metadata?.itemId {
+      payload["itemId"] = itemId
+    }
+    sendEvent("onDownloadStarted", payload)
+
+    return taskId
+  }
+
+  // MARK: - Delegate entry points
+  // Called on the URLSession delegate queue; each hops onto stateQueue before touching state.
+
+  func handleProgress(taskId: Int, bytesWritten: Int64, totalBytes: Int64) {
+    stateQueue.async {
+      self.handleProgressLocked(taskId: taskId, bytesWritten: bytesWritten, totalBytes: totalBytes)
     }
   }
-  
-  // Handler methods called by the delegate
-  func handleProgress(taskId: Int, bytesWritten: Int64, totalBytes: Int64) {
+
+  func handleDownloadComplete(taskId: Int, location: URL, downloadTask: URLSessionDownloadTask) {
+    // The temporary file at `location` is only valid until the delegate callback returns, so this
+    // hop must be synchronous — the file is moved before control goes back to URLSession. Safe
+    // because stateQueue never blocks on the delegate queue in return.
+    stateQueue.sync {
+      self.handleDownloadCompleteLocked(taskId: taskId, location: location, downloadTask: downloadTask)
+    }
+  }
+
+  func handleError(taskId: Int, error: Error) {
+    stateQueue.async {
+      self.handleErrorLocked(taskId: taskId, error: error)
+    }
+  }
+
+  // MARK: - Handlers (stateQueue-confined)
+
+  private func handleProgressLocked(taskId: Int, bytesWritten: Int64, totalBytes: Int64) {
     let progress = totalBytes > 0
       ? Double(bytesWritten) / Double(totalBytes)
       : 0.0
@@ -300,21 +375,29 @@ public class BackgroundDownloaderModule: Module {
     let lastTime = lastProgressTime[taskId] ?? Date.distantPast
     let now = Date()
     let timeDiff = now.timeIntervalSince(lastTime)
-    
+
     // Send if 500ms passed
     if timeDiff >= 0.5 {
-      self.sendEvent("onDownloadProgress", [
+      var payload: [String: Any] = [
         "taskId": taskId,
         "bytesWritten": bytesWritten,
         "totalBytes": totalBytes,
         "progress": progress
-      ])
-      
+      ]
+      if let itemId = downloadTasks[taskId]?.metadata?.itemId {
+        payload["itemId"] = itemId
+      }
+      sendEvent("onDownloadProgress", payload)
+
       lastProgressTime[taskId] = now
     }
   }
-  
-  func handleDownloadComplete(taskId: Int, location: URL, downloadTask: URLSessionDownloadTask) {
+
+  private func handleDownloadCompleteLocked(
+    taskId: Int,
+    location: URL,
+    downloadTask: URLSessionDownloadTask
+  ) {
     guard let taskInfo = downloadTasks[taskId] else {
       finishLiveActivity(taskId: taskId, state: .failed)
       self.sendEvent("onDownloadError", [
@@ -325,10 +408,10 @@ public class BackgroundDownloaderModule: Module {
     }
 
     let fileManager = FileManager.default
-    
+
     do {
       let destinationURL: URL
-      
+
       if let customPath = taskInfo.destinationPath {
         destinationURL = URL(fileURLWithPath: customPath)
       } else {
@@ -338,11 +421,11 @@ public class BackgroundDownloaderModule: Module {
           ?? "download_\(taskId)"
         destinationURL = documentsDir.appendingPathComponent(filename)
       }
-      
+
       if fileManager.fileExists(atPath: destinationURL.path) {
         try fileManager.removeItem(at: destinationURL)
       }
-      
+
       let destinationDirectory = destinationURL.deletingLastPathComponent()
       if !fileManager.fileExists(atPath: destinationDirectory.path) {
         try fileManager.createDirectory(
@@ -351,55 +434,49 @@ public class BackgroundDownloaderModule: Module {
           attributes: nil
         )
       }
-      
+
       try fileManager.moveItem(at: location, to: destinationURL)
 
       finishLiveActivity(taskId: taskId, state: .completed)
 
-      self.sendEvent("onDownloadComplete", [
+      var payload: [String: Any] = [
         "taskId": taskId,
         "filePath": destinationURL.path,
         "url": taskInfo.url
-      ])
+      ]
+      if let itemId = taskInfo.metadata?.itemId {
+        payload["itemId"] = itemId
+      }
+      sendEvent("onDownloadComplete", payload)
 
       downloadTasks.removeValue(forKey: taskId)
       lastProgressTime.removeValue(forKey: taskId)
-      persistTasks()
+      persistTasksLocked()
 
-      // Process next item in queue
-      Task {
-        do {
-          _ = try await self.processNextInQueue()
-        } catch {
-          print("[BackgroundDownloader] Error processing next: \(error)")
-        }
-      }
-      
+      processNextInQueueSafelyLocked()
     } catch {
       finishLiveActivity(taskId: taskId, state: .failed)
 
-      self.sendEvent("onDownloadError", [
+      var payload: [String: Any] = [
         "taskId": taskId,
         "error": "File operation failed: \(error.localizedDescription)"
-      ])
+      ]
+      if let itemId = taskInfo.metadata?.itemId {
+        payload["itemId"] = itemId
+      }
+      sendEvent("onDownloadError", payload)
 
       downloadTasks.removeValue(forKey: taskId)
       lastProgressTime.removeValue(forKey: taskId)
-      persistTasks()
+      persistTasksLocked()
 
-      // Process next item in queue even on error
-      Task {
-        do {
-          _ = try await self.processNextInQueue()
-        } catch {
-          print("[BackgroundDownloader] Error processing next: \(error)")
-        }
-      }
+      processNextInQueueSafelyLocked()
     }
   }
-  
-  func handleError(taskId: Int, error: Error) {
+
+  private func handleErrorLocked(taskId: Int, error: Error) {
     let isCancelled = (error as NSError).code == NSURLErrorCancelled
+    let itemId = downloadTasks[taskId]?.metadata?.itemId
 
     if isCancelled {
       // JS drives cancellation, so it has usually dismissed the activity already; this covers
@@ -410,79 +487,59 @@ public class BackgroundDownloaderModule: Module {
 
       finishLiveActivity(taskId: taskId, state: .failed)
 
-      self.sendEvent("onDownloadError", [
+      var payload: [String: Any] = [
         "taskId": taskId,
         "error": error.localizedDescription
-      ])
+      ]
+      if let itemId {
+        payload["itemId"] = itemId
+      }
+      sendEvent("onDownloadError", payload)
     }
 
     downloadTasks.removeValue(forKey: taskId)
     lastProgressTime.removeValue(forKey: taskId)
-    persistTasks()
+    persistTasksLocked()
 
     // Process next item in queue (whether cancelled or errored)
-    Task {
-      do {
-        _ = try await self.processNextInQueue()
-      } catch {
-        print("[BackgroundDownloader] Error processing next: \(error)")
-      }
-    }
+    processNextInQueueSafelyLocked()
   }
-  
-  private func processNextInQueue() async throws -> Int {
-    // Check if queue has items
+
+  /// Nothing in here is actually asynchronous — the previous `async` shape existed only so the
+  /// completion handlers could spawn it inside detached `Task`s, which added a fourth unsynchronized
+  /// execution context. Now it is a plain function that runs where the state lives.
+  private func processNextInQueueLocked() throws -> Int {
     guard !downloadQueue.isEmpty else {
       return -1
     }
-    
-    // Check if there are active downloads
-    if !downloadTasks.isEmpty {
+
+    // One download at a time
+    guard downloadTasks.isEmpty else {
       return -1
     }
-    
-    // Get next item from queue
+
     let (url, destinationPath, metadata) = downloadQueue.removeFirst()
+    pushQueuedCountLocked()
     print("[BackgroundDownloader] Starting queued download")
-    
-    // Start the download using existing startDownload logic
-    guard let urlObj = URL(string: url) else {
+
+    guard URL(string: url) != nil else {
       print("[BackgroundDownloader] Invalid URL in queue: \(url)")
-      return try await processNextInQueue()
+      return try processNextInQueueLocked()
     }
-    
-    if session == nil {
-      initializeSession()
-    }
-    
-    guard let session = self.session else {
-      throw DownloadError.downloadFailed
-    }
-    
-    var request = URLRequest(url: urlObj)
-    request.httpMethod = "GET"
-    request.timeoutInterval = 300
-    
-    let task = session.downloadTask(with: request)
-    let taskId = task.taskIdentifier
-    
-    downloadTasks[taskId] = DownloadTaskInfo(
-      url: url,
+
+    return try beginDownloadLocked(
+      urlString: url,
       destinationPath: destinationPath,
       metadata: metadata
     )
-    persistTasks()
+  }
 
-    task.resume()
-
-    startLiveActivity(taskId: taskId, metadata: metadata)
-
-    sendEvent("onDownloadStarted", [
-      "taskId": taskId,
-      "url": url
-    ])
-
-    return taskId
+  private func processNextInQueueSafelyLocked() {
+    do {
+      _ = try processNextInQueueLocked()
+    } catch {
+      print("[BackgroundDownloader] Error processing next: \(error)")
+    }
   }
 
   static func setBackgroundCompletionHandler(_ handler: @escaping () -> Void) {
@@ -492,16 +549,23 @@ public class BackgroundDownloaderModule: Module {
   // MARK: - Live Activity
 
   // Every entry point is wrapped so the rest of the module stays free of availability and platform
-  // checks. All of this compiles away on tvOS, where ActivityKit does not exist.
+  // checks. All of this compiles away on tvOS, where ActivityKit does not exist. The controller
+  // confines its own state to its own queue; calls from here never block.
+
+  /// The controller keeps its own copy of the queued count, updated whenever the queue changes.
+  /// Reading `downloadQueue.count` from the delegate callbacks instead (as `updateLiveActivity`
+  /// used to) was the hottest cross-thread access in the module.
+  private func pushQueuedCountLocked() {
+    #if os(iOS)
+      guard #available(iOS 16.2, *) else { return }
+      DownloadLiveActivityController.shared.setQueuedCount(downloadQueue.count)
+    #endif
+  }
 
   private func startLiveActivity(taskId: Int, metadata: DownloadActivityMetadata?) {
     #if os(iOS)
       guard #available(iOS 16.2, *), let metadata else { return }
-      DownloadLiveActivityController.shared.start(
-        taskId: taskId,
-        metadata: metadata,
-        queuedCount: downloadQueue.count
-      )
+      DownloadLiveActivityController.shared.start(taskId: taskId, metadata: metadata)
     #endif
   }
 
@@ -511,8 +575,7 @@ public class BackgroundDownloaderModule: Module {
       DownloadLiveActivityController.shared.update(
         taskId: taskId,
         bytesWritten: bytesWritten,
-        totalBytes: totalBytes,
-        queuedCount: downloadQueue.count
+        totalBytes: totalBytes
       )
     #endif
   }
@@ -520,11 +583,7 @@ public class BackgroundDownloaderModule: Module {
   private func finishLiveActivity(taskId: Int, state: DownloadActivityState) {
     #if os(iOS)
       guard #available(iOS 16.2, *) else { return }
-      DownloadLiveActivityController.shared.finish(
-        taskId: taskId,
-        state: state,
-        queuedCount: downloadQueue.count
-      )
+      DownloadLiveActivityController.shared.finish(taskId: taskId, state: state)
     #endif
   }
 
@@ -546,7 +605,7 @@ public class BackgroundDownloaderModule: Module {
   /// rest — otherwise an app killed mid-download leaves one stranded on the Lock Screen. Keyed on
   /// the persisted task store, not `getAllTasks`, so an activity whose transfer finished while the
   /// app was dead survives long enough for the queued completion callback to flip it.
-  private func reconcileLiveActivities() {
+  private func reconcileLiveActivitiesLocked() {
     #if os(iOS)
       guard #available(iOS 16.2, *) else { return }
       DownloadLiveActivityController.shared.reconcile(
@@ -555,4 +614,3 @@ public class BackgroundDownloaderModule: Module {
     #endif
   }
 }
-

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -261,6 +261,7 @@ public class BackgroundDownloaderModule: Module {
         self.stateQueue.async {
           self.downloadTasks.removeAll()
           self.persistTasksLocked()
+          self.finishContinuedProcessingIfIdleLocked()
         }
       }
     }
@@ -378,6 +379,7 @@ public class BackgroundDownloaderModule: Module {
     )
 
     startLiveActivity(taskId: taskId, metadata: metadata)
+    startContinuedProcessingLocked(metadata: metadata)
 
     var payload: [String: Any] = [
       "taskId": taskId,
@@ -429,6 +431,11 @@ public class BackgroundDownloaderModule: Module {
     // Fed every callback, not just the throttled ones — the controller does its own rate limiting
     // and wants the finer samples for its speed average.
     updateLiveActivity(taskId: taskId, bytesWritten: bytesWritten, totalBytes: totalBytes)
+    updateContinuedProcessingLocked(
+      taskId: taskId,
+      bytesWritten: bytesWritten,
+      totalBytes: totalBytes
+    )
 
     // Throttle progress updates: only send every 500ms
     let lastTime = lastProgressTime[taskId] ?? Date.distantPast
@@ -612,6 +619,8 @@ public class BackgroundDownloaderModule: Module {
         "Failed to start next queued download: \(error.localizedDescription, privacy: .public)"
       )
     }
+    // Reached after every completion/error/cancel; ends the keeper when the session drained.
+    finishContinuedProcessingIfIdleLocked()
   }
 
   static func setBackgroundCompletionHandler(_ handler: @escaping () -> Void) {
@@ -672,6 +681,48 @@ public class BackgroundDownloaderModule: Module {
     #if os(iOS)
       guard #available(iOS 16.2, *) else { return }
       DownloadLiveActivityController.shared.cancelAll()
+    #endif
+  }
+
+  // MARK: - Continued processing (iOS 26+)
+
+  // Keeps the process executing while downloads run, so progress keeps reporting after the user
+  // backgrounds the app and the Live Activity shows measured percent instead of a projection.
+  // Wrapped like the Live Activity helpers; a no-op before iOS 26 or on older build toolchains.
+
+  private func startContinuedProcessingLocked(metadata: DownloadActivityMetadata?) {
+    #if os(iOS) && swift(>=6.2)
+      guard #available(iOS 26.0, *) else { return }
+      DownloadContinuedProcessingKeeper.shared.ensureRunning(
+        title: metadata?.title ?? "Streamyfin",
+        subtitle: metadata?.subtitle ?? ""
+      )
+    #endif
+  }
+
+  private func updateContinuedProcessingLocked(
+    taskId: Int,
+    bytesWritten: Int64,
+    totalBytes: Int64
+  ) {
+    #if os(iOS) && swift(>=6.2)
+      guard #available(iOS 26.0, *) else { return }
+      let effectiveTotal =
+        totalBytes > 0
+        ? totalBytes
+        : downloadTasks[taskId]?.metadata?.estimatedTotalBytes ?? 0
+      DownloadContinuedProcessingKeeper.shared.updateProgress(
+        completedBytes: bytesWritten,
+        totalBytes: effectiveTotal
+      )
+    #endif
+  }
+
+  private func finishContinuedProcessingIfIdleLocked() {
+    #if os(iOS) && swift(>=6.2)
+      guard #available(iOS 26.0, *) else { return }
+      guard downloadTasks.isEmpty, downloadQueue.isEmpty else { return }
+      DownloadContinuedProcessingKeeper.shared.finish()
     #endif
   }
 

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -355,7 +355,11 @@ public class BackgroundDownloaderModule: Module {
   }
 
   func handleError(taskId: Int, error: Error) {
-    stateQueue.async {
+    // Synchronous for the same reason as handleDownloadComplete: when a transfer fails while the
+    // app is backgrounded, the next queued download must be created before the delegate queue
+    // drains and urlSessionDidFinishEvents lets the system re-suspend the process. An async hop
+    // here races that suspension.
+    stateQueue.sync {
       self.handleErrorLocked(taskId: taskId, error: error)
     }
   }

--- a/modules/background-downloader/ios/DownloadActivityAttributes.swift
+++ b/modules/background-downloader/ios/DownloadActivityAttributes.swift
@@ -48,6 +48,15 @@ public enum DownloadActivityState: String, Codable, Hashable {
       public var speedBytesPerSec: Double
       public var queuedCount: Int
       public var state: DownloadActivityState
+      /// Interval start for the system-rendered, self-advancing progress bar — anchored so that
+      /// "now" at push time equals the measured `progress`. `ProgressView(timerInterval:)` and
+      /// `Text(timerInterval:)` are the only primitives iOS animates while the app is suspended;
+      /// everything else freezes at the last pushed value.
+      public var progressBarStartDate: Date?
+      /// Projected completion time, derived from the smoothed speed with a pessimistic haircut so
+      /// the projection under-promises. `nil` until a speed estimate exists — the UI then falls
+      /// back to the static measured bar.
+      public var projectedEndDate: Date?
 
       public init(
         itemId: String,
@@ -59,7 +68,9 @@ public enum DownloadActivityState: String, Codable, Hashable {
         totalBytes: Int64,
         speedBytesPerSec: Double,
         queuedCount: Int,
-        state: DownloadActivityState
+        state: DownloadActivityState,
+        progressBarStartDate: Date? = nil,
+        projectedEndDate: Date? = nil
       ) {
         self.itemId = itemId
         self.title = title
@@ -71,6 +82,8 @@ public enum DownloadActivityState: String, Codable, Hashable {
         self.speedBytesPerSec = speedBytesPerSec
         self.queuedCount = queuedCount
         self.state = state
+        self.progressBarStartDate = progressBarStartDate
+        self.projectedEndDate = projectedEndDate
       }
     }
 

--- a/modules/background-downloader/ios/DownloadActivityAttributes.swift
+++ b/modules/background-downloader/ios/DownloadActivityAttributes.swift
@@ -22,23 +22,38 @@ public enum DownloadActivityState: String, Codable, Hashable {
   ///
   /// ActivityKit matches activities on the *unqualified* type name, so it does not matter that the
   /// two targets compile it into different Swift modules — but the declaration must stay identical.
-  /// Anything mutable belongs in `ContentState`; everything else is fixed at `start` and stays out of
-  /// the 4 KB per-update payload budget.
+  ///
+  /// The per-download fields (title, poster, …) deliberately live in `ContentState`, not in the
+  /// static attributes: iOS only allows `Activity.request` while the app is foregrounded, and
+  /// queued downloads start from background wake-ups. The one activity is therefore created for the
+  /// first download and *rebound* to each subsequent one via `activity.update`, which has no
+  /// foreground restriction — possible only if everything episode-specific is mutable.
   @available(iOS 16.1, *)
   public struct DownloadActivityAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
+      /// Jellyfin item id of the download currently bound to the activity; how a restored process
+      /// re-adopts its activity after a cold relaunch.
+      public var itemId: String
+      public var title: String
+      public var subtitle: String
+      /// File name inside the App Group container. The extension cannot read the app's Documents
+      /// directory, so the poster is staged into the shared container before the download starts.
+      public var posterFileName: String?
       /// Fraction of the transfer that is genuinely done, `0...1`. Frozen while iOS suspends us —
       /// the ETA countdown in the UI is what keeps moving. Never inflate this.
       public var progress: Double
       public var bytesDownloaded: Int64
-      /// `0` when the server sent no `Content-Length` (transcoding), in which case the UI falls back
-      /// to `estimatedTotalBytes` from the attributes.
+      /// `0` when the server sent no `Content-Length` (transcoding) and no estimate exists either.
       public var totalBytes: Int64
       public var speedBytesPerSec: Double
       public var queuedCount: Int
       public var state: DownloadActivityState
 
       public init(
+        itemId: String,
+        title: String,
+        subtitle: String,
+        posterFileName: String?,
         progress: Double,
         bytesDownloaded: Int64,
         totalBytes: Int64,
@@ -46,6 +61,10 @@ public enum DownloadActivityState: String, Codable, Hashable {
         queuedCount: Int,
         state: DownloadActivityState
       ) {
+        self.itemId = itemId
+        self.title = title
+        self.subtitle = subtitle
+        self.posterFileName = posterFileName
         self.progress = progress
         self.bytesDownloaded = bytesDownloaded
         self.totalBytes = totalBytes
@@ -55,31 +74,12 @@ public enum DownloadActivityState: String, Codable, Hashable {
       }
     }
 
-    public var itemId: String
-    public var title: String
-    public var subtitle: String
-    /// File name inside the App Group container. The extension cannot read the app's Documents
-    /// directory, so the poster is staged into the shared container before the activity starts.
-    public var posterFileName: String?
-    /// Used only when the server withholds `Content-Length`.
-    public var estimatedTotalBytes: Int64
     /// Localized strings, resolved in JS so translations stay single-sourced in `translations/*.json`.
-    /// Keyed by `DownloadActivityState.rawValue`, plus `"appName"`.
+    /// Keyed by `DownloadActivityState.rawValue`. Identical for every download, hence the only
+    /// field that may stay immutable.
     public var labels: [String: String]
 
-    public init(
-      itemId: String,
-      title: String,
-      subtitle: String,
-      posterFileName: String?,
-      estimatedTotalBytes: Int64,
-      labels: [String: String]
-    ) {
-      self.itemId = itemId
-      self.title = title
-      self.subtitle = subtitle
-      self.posterFileName = posterFileName
-      self.estimatedTotalBytes = estimatedTotalBytes
+    public init(labels: [String: String]) {
       self.labels = labels
     }
 

--- a/modules/background-downloader/ios/DownloadActivityAttributes.swift
+++ b/modules/background-downloader/ios/DownloadActivityAttributes.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// The state of the download the Live Activity is tracking.
+///
+/// Deliberately outside the `os(iOS)` guard below: `BackgroundDownloaderModule` names this type in
+/// its (unguarded) helper signatures, and that module also compiles for tvOS, where ActivityKit does
+/// not exist. The enum itself has no ActivityKit dependency.
+public enum DownloadActivityState: String, Codable, Hashable {
+  case downloading
+  case completed
+  case failed
+  case queued
+}
+
+#if os(iOS)
+  import ActivityKit
+
+  /// Shared between two targets:
+  ///   • the app, via the `BackgroundDownloader` pod (this whole `ios/` dir is `source_files`)
+  ///   • the `StreamyfinDownloadActivity` widget extension, which `plugins/withDownloadLiveActivity.ts`
+  ///     adds to its Sources build phase by path
+  ///
+  /// ActivityKit matches activities on the *unqualified* type name, so it does not matter that the
+  /// two targets compile it into different Swift modules — but the declaration must stay identical.
+  /// Anything mutable belongs in `ContentState`; everything else is fixed at `start` and stays out of
+  /// the 4 KB per-update payload budget.
+  @available(iOS 16.1, *)
+  public struct DownloadActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+      /// Fraction of the transfer that is genuinely done, `0...1`. Frozen while iOS suspends us —
+      /// the ETA countdown in the UI is what keeps moving. Never inflate this.
+      public var progress: Double
+      public var bytesDownloaded: Int64
+      /// `0` when the server sent no `Content-Length` (transcoding), in which case the UI falls back
+      /// to `estimatedTotalBytes` from the attributes.
+      public var totalBytes: Int64
+      public var speedBytesPerSec: Double
+      public var queuedCount: Int
+      public var state: DownloadActivityState
+
+      public init(
+        progress: Double,
+        bytesDownloaded: Int64,
+        totalBytes: Int64,
+        speedBytesPerSec: Double,
+        queuedCount: Int,
+        state: DownloadActivityState
+      ) {
+        self.progress = progress
+        self.bytesDownloaded = bytesDownloaded
+        self.totalBytes = totalBytes
+        self.speedBytesPerSec = speedBytesPerSec
+        self.queuedCount = queuedCount
+        self.state = state
+      }
+    }
+
+    public var itemId: String
+    public var title: String
+    public var subtitle: String
+    /// File name inside the App Group container. The extension cannot read the app's Documents
+    /// directory, so the poster is staged into the shared container before the activity starts.
+    public var posterFileName: String?
+    /// Used only when the server withholds `Content-Length`.
+    public var estimatedTotalBytes: Int64
+    /// Localized strings, resolved in JS so translations stay single-sourced in `translations/*.json`.
+    /// Keyed by `DownloadActivityState.rawValue`, plus `"appName"`.
+    public var labels: [String: String]
+
+    public init(
+      itemId: String,
+      title: String,
+      subtitle: String,
+      posterFileName: String?,
+      estimatedTotalBytes: Int64,
+      labels: [String: String]
+    ) {
+      self.itemId = itemId
+      self.title = title
+      self.subtitle = subtitle
+      self.posterFileName = posterFileName
+      self.estimatedTotalBytes = estimatedTotalBytes
+      self.labels = labels
+    }
+
+    public func label(for state: DownloadActivityState) -> String {
+      labels[state.rawValue] ?? ""
+    }
+  }
+
+  /// Resolves the App Group container both targets share. The identifier is written into each
+  /// target's Info.plist by `plugins/withDownloadLiveActivity.ts`, mirroring how
+  /// `plugins/withTVOSTopShelf.ts` passes `StreamyfinAppGroupIdentifier` to the Top Shelf extension.
+  public enum DownloadActivitySharedContainer {
+    public static let infoPlistKey = "StreamyfinDownloadsAppGroupIdentifier"
+
+    public static var appGroupIdentifier: String? {
+      Bundle.main.object(forInfoDictionaryKey: infoPlistKey) as? String
+    }
+
+    public static var directory: URL? {
+      guard let appGroupIdentifier else { return nil }
+      return FileManager.default.containerURL(
+        forSecurityApplicationGroupIdentifier: appGroupIdentifier
+      )?.appendingPathComponent("LiveActivity", isDirectory: true)
+    }
+
+    public static func posterURL(fileName: String?) -> URL? {
+      guard let fileName, !fileName.isEmpty, let directory else { return nil }
+      return directory.appendingPathComponent(fileName)
+    }
+  }
+#endif

--- a/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
+++ b/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
@@ -33,19 +33,10 @@
     /// Submitted but the launch handler has not run yet — guards double submission.
     private var isPending = false
 
-    /// Why the keeper stopped covering the download. The distinction matters: an expiration while
-    /// bytes were flowing is almost certainly the user tapping stop on the system UI (a stall
-    /// expiration requires ~30s of silence first), whereas a submission failure happens seconds
-    /// into a healthy, user-wanted download and must never trigger cancellation.
-    enum UnavailableReason {
-      case submissionFailed
-      case expired
-    }
-
     /// The keeper's system UI replaces the module's own Live Activity on iOS 26+, so when the
-    /// keeper cannot run the module needs to know — to fall back to its regular activity, and on
-    /// expiration to apply the user-stop heuristic. Set once by the module at creation.
-    var onUnavailable: ((UnavailableReason) -> Void)?
+    /// keeper cannot run (submission refused, task expired) the module needs to know and put its
+    /// regular activity up instead. Set once by the module at creation.
+    var onUnavailable: (() -> Void)?
 
     /// Submits the keeper task if none is live. Safe to call on every download start; queue
     /// advances reuse the already-running task and retitle its system UI to the episode that is
@@ -73,7 +64,7 @@
           backgroundDownloaderLog.error(
             "Continued processing submit failed: \(error.localizedDescription, privacy: .public)"
           )
-          self.onUnavailable?(.submissionFailed)
+          self.onUnavailable?()
         }
       }
     }
@@ -138,7 +129,7 @@
             )
             self.task?.setTaskCompleted(success: false)
             self.task = nil
-            self.onUnavailable?(.expired)
+            self.onUnavailable?()
           }
         }
 

--- a/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
+++ b/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
@@ -33,10 +33,19 @@
     /// Submitted but the launch handler has not run yet — guards double submission.
     private var isPending = false
 
+    /// Why the keeper stopped covering the download. The distinction matters: an expiration while
+    /// bytes were flowing is almost certainly the user tapping stop on the system UI (a stall
+    /// expiration requires ~30s of silence first), whereas a submission failure happens seconds
+    /// into a healthy, user-wanted download and must never trigger cancellation.
+    enum UnavailableReason {
+      case submissionFailed
+      case expired
+    }
+
     /// The keeper's system UI replaces the module's own Live Activity on iOS 26+, so when the
-    /// keeper cannot run (submission refused, task expired) the module needs to know and put its
-    /// regular activity up instead. Set once by the module at creation.
-    var onUnavailable: (() -> Void)?
+    /// keeper cannot run the module needs to know — to fall back to its regular activity, and on
+    /// expiration to apply the user-stop heuristic. Set once by the module at creation.
+    var onUnavailable: ((UnavailableReason) -> Void)?
 
     /// Submits the keeper task if none is live. Safe to call on every download start; queue
     /// advances reuse the already-running task and retitle its system UI to the episode that is
@@ -64,7 +73,7 @@
           backgroundDownloaderLog.error(
             "Continued processing submit failed: \(error.localizedDescription, privacy: .public)"
           )
-          self.onUnavailable?()
+          self.onUnavailable?(.submissionFailed)
         }
       }
     }
@@ -129,7 +138,7 @@
             )
             self.task?.setTaskCompleted(success: false)
             self.task = nil
-            self.onUnavailable?()
+            self.onUnavailable?(.expired)
           }
         }
 

--- a/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
+++ b/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
@@ -39,11 +39,16 @@
     var onUnavailable: (() -> Void)?
 
     /// Submits the keeper task if none is live. Safe to call on every download start; queue
-    /// advances reuse the already-running task. Submission is refused by the system outside the
-    /// foreground — that is fine, the caller's flow works without it.
+    /// advances reuse the already-running task and retitle its system UI to the episode that is
+    /// now downloading. Submission is refused by the system outside the foreground — that is
+    /// fine, the caller's flow works without it.
     func ensureRunning(title: String, subtitle: String) {
       queue.async {
-        guard self.task == nil, !self.isPending else { return }
+        if let task = self.task {
+          task.updateTitle(title, subtitle: subtitle)
+          return
+        }
+        guard !self.isPending else { return }
         self.registerIfNeededLocked()
 
         let request = BGContinuedProcessingTaskRequest(

--- a/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
+++ b/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
@@ -33,15 +33,11 @@
     /// Submitted but the launch handler has not run yet — guards double submission.
     private var isPending = false
 
-    /// The keeper's system UI replaces the module's own Live Activity on iOS 26+, so when the
-    /// keeper cannot run (submission refused, task expired) the module needs to know and put its
-    /// regular activity up instead. Set once by the module at creation.
-    var onUnavailable: (() -> Void)?
-
     /// Submits the keeper task if none is live. Safe to call on every download start; queue
     /// advances reuse the already-running task and retitle its system UI to the episode that is
     /// now downloading. Submission is refused by the system outside the foreground — that is
-    /// fine, the caller's flow works without it.
+    /// fine, the caller's flow works without it: the module's own activity is live regardless and
+    /// simply degrades to projected progress once the process suspends.
     func ensureRunning(title: String, subtitle: String) {
       queue.async {
         if let task = self.task {
@@ -64,7 +60,6 @@
           backgroundDownloaderLog.error(
             "Continued processing submit failed: \(error.localizedDescription, privacy: .public)"
           )
-          self.onUnavailable?()
         }
       }
     }
@@ -129,7 +124,6 @@
             )
             self.task?.setTaskCompleted(success: false)
             self.task = nil
-            self.onUnavailable?()
           }
         }
 

--- a/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
+++ b/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
@@ -1,0 +1,118 @@
+// swift(>=6.2) ≈ Xcode 26 / iOS 26 SDK. On older toolchains this whole file compiles away and the
+// module degrades to the pre-26 behavior (suspension + timer-projection Live Activity).
+#if os(iOS) && swift(>=6.2)
+  import BackgroundTasks
+  import Foundation
+
+  /// Keeps the app process executing while user-started downloads run.
+  ///
+  /// iOS 26's continued processing tasks are the sanctioned way to keep running after the user
+  /// backgrounds the app, for work they explicitly started. While one is live the process is NOT
+  /// suspended — the URLSession delegate keeps delivering `didWriteData` and the Live Activity
+  /// shows *measured* percent all the way through. The widget's timer projection then only covers
+  /// what this cannot: pre-iOS 26 devices, a submit refusal, or the system expiring the task,
+  /// after which the process suspends and the pre-26 behavior takes over seamlessly.
+  ///
+  /// One task spans the whole queue session: submitted when a download is started from the
+  /// foreground (submission requires it), completed when both the active transfer and the queue
+  /// drain, so chained episodes stay covered without re-submitting from the background.
+  @available(iOS 26.0, *)
+  final class DownloadContinuedProcessingKeeper {
+    static let shared = DownloadContinuedProcessingKeeper()
+
+    /// Must be declared in BGTaskSchedulerPermittedIdentifiers (see withDownloadLiveActivity.ts).
+    private static let taskIdentifier = "com.fredrikburmester.streamyfin.downloads"
+
+    private let queue = DispatchQueue(
+      label: "com.fredrikburmester.streamyfin.downloadkeeper"
+    )
+    private var task: BGContinuedProcessingTask?
+    private var isRegistered = false
+    /// Submitted but the launch handler has not run yet — guards double submission.
+    private var isPending = false
+
+    /// Submits the keeper task if none is live. Safe to call on every download start; queue
+    /// advances reuse the already-running task. Submission is refused by the system outside the
+    /// foreground — that is fine, the caller's flow works without it.
+    func ensureRunning(title: String, subtitle: String) {
+      queue.async {
+        guard self.task == nil, !self.isPending else { return }
+        self.registerIfNeededLocked()
+
+        let request = BGContinuedProcessingTaskRequest(
+          identifier: Self.taskIdentifier,
+          title: title,
+          subtitle: subtitle
+        )
+        do {
+          try BGTaskScheduler.shared.submit(request)
+          self.isPending = true
+          backgroundDownloaderLog.notice("Continued processing task submitted")
+        } catch {
+          backgroundDownloaderLog.error(
+            "Continued processing submit failed: \(error.localizedDescription, privacy: .public)"
+          )
+        }
+      }
+    }
+
+    /// Feeds real transfer progress into the system task UI. Progress must keep advancing or the
+    /// system may end the task.
+    func updateProgress(completedBytes: Int64, totalBytes: Int64) {
+      queue.async {
+        guard let task = self.task, totalBytes > 0 else { return }
+        task.progress.totalUnitCount = totalBytes
+        task.progress.completedUnitCount = min(completedBytes, totalBytes)
+      }
+    }
+
+    /// Ends the task once the whole queue session is done (or cancelled).
+    func finish() {
+      queue.async {
+        self.isPending = false
+        guard let task = self.task else { return }
+        task.progress.completedUnitCount = task.progress.totalUnitCount
+        task.setTaskCompleted(success: true)
+        self.task = nil
+        backgroundDownloaderLog.notice("Continued processing task completed")
+      }
+    }
+
+    private func registerIfNeededLocked() {
+      guard !isRegistered else { return }
+      isRegistered = true
+
+      BGTaskScheduler.shared.register(
+        forTaskWithIdentifier: Self.taskIdentifier,
+        using: queue
+      ) { task in
+        guard let continued = task as? BGContinuedProcessingTask else {
+          task.setTaskCompleted(success: false)
+          return
+        }
+
+        // Event-driven, not a work loop: the task is held open while the download queue drains.
+        // Progress arrives from the URLSession delegate via updateProgress; completion via
+        // finish(). The launch handler runs on `queue`, so state access here is confined.
+        continued.progress.totalUnitCount = 100
+        continued.progress.completedUnitCount = 0
+        continued.expirationHandler = { [weak self] in
+          guard let self else { return }
+          self.queue.async {
+            backgroundDownloaderLog.notice(
+              "Continued processing task expired; process may suspend until the next wake"
+            )
+            self.task?.setTaskCompleted(success: false)
+            self.task = nil
+          }
+        }
+
+        self.task = continued
+        self.isPending = false
+        backgroundDownloaderLog.notice(
+          "Continued processing task running; downloads keep reporting while backgrounded"
+        )
+      }
+    }
+  }
+#endif

--- a/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
+++ b/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
@@ -104,11 +104,23 @@
         // finish(). The launch handler runs on `queue`, so state access here is confined.
         continued.progress.totalUnitCount = 100
         continued.progress.completedUnitCount = 0
+
+        // Instrumentation for the stop-button experiment: a user tap on the system UI's stop
+        // control may surface as Progress cancellation, as task expiration, or both — the
+        // distinction decides whether stop can safely cancel the download itself (a system
+        // expiration must NOT).
+        continued.progress.cancellationHandler = { [weak self] in
+          guard let self else { return }
+          self.queue.async {
+            backgroundDownloaderLog.notice("Continued processing progress CANCELLED (user tapped stop?)")
+          }
+        }
         continued.expirationHandler = { [weak self] in
           guard let self else { return }
           self.queue.async {
+            let userCancelled = self.task?.progress.isCancelled ?? false
             backgroundDownloaderLog.notice(
-              "Continued processing task expired; process may suspend until the next wake"
+              "Continued processing task expired (progress.isCancelled: \(userCancelled))"
             )
             self.task?.setTaskCompleted(success: false)
             self.task = nil

--- a/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
+++ b/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
@@ -33,6 +33,11 @@
     /// Submitted but the launch handler has not run yet — guards double submission.
     private var isPending = false
 
+    /// The keeper's system UI replaces the module's own Live Activity on iOS 26+, so when the
+    /// keeper cannot run (submission refused, task expired) the module needs to know and put its
+    /// regular activity up instead. Set once by the module at creation.
+    var onUnavailable: (() -> Void)?
+
     /// Submits the keeper task if none is live. Safe to call on every download start; queue
     /// advances reuse the already-running task. Submission is refused by the system outside the
     /// foreground — that is fine, the caller's flow works without it.
@@ -54,6 +59,7 @@
           backgroundDownloaderLog.error(
             "Continued processing submit failed: \(error.localizedDescription, privacy: .public)"
           )
+          self.onUnavailable?()
         }
       }
     }
@@ -106,6 +112,7 @@
             )
             self.task?.setTaskCompleted(success: false)
             self.task = nil
+            self.onUnavailable?()
           }
         }
 

--- a/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
+++ b/modules/background-downloader/ios/DownloadContinuedProcessingKeeper.swift
@@ -1,6 +1,8 @@
-// swift(>=6.2) ≈ Xcode 26 / iOS 26 SDK. On older toolchains this whole file compiles away and the
-// module degrades to the pre-26 behavior (suspension + timer-projection Live Activity).
-#if os(iOS) && swift(>=6.2)
+// compiler(>=6.2) ≈ Xcode 26 / iOS 26 SDK. On older toolchains this whole file compiles away and
+// the module degrades to the pre-26 behavior (suspension + timer-projection Live Activity).
+// NOT swift(>=…): that checks the language *mode*, and CocoaPods targets build in Swift 5 mode —
+// it silently compiled this feature out even under Xcode 26.
+#if os(iOS) && compiler(>=6.2)
   import BackgroundTasks
   import Foundation
 

--- a/modules/background-downloader/ios/DownloadLiveActivityController.swift
+++ b/modules/background-downloader/ios/DownloadLiveActivityController.swift
@@ -123,12 +123,12 @@
             state: state,
             staleDate: now.addingTimeInterval(Self.staleInterval)
           )
-          liveActivityLog.info("Rebound existing activity to task \(taskId)")
+          liveActivityLog.notice("Rebound existing activity to task \(taskId)")
           return
         }
 
         guard self.activitiesAvailable else {
-          liveActivityLog.info("Activities unavailable; not starting one for task \(taskId)")
+          liveActivityLog.notice("Activities unavailable; not starting one for task \(taskId)")
           return
         }
 
@@ -150,7 +150,7 @@
             lastBytes: 0,
             emaSpeed: 0
           )
-          liveActivityLog.info("Requested new activity for task \(taskId)")
+          liveActivityLog.notice("Requested new activity for task \(taskId)")
         } catch {
           // Most commonly ActivityKit refusing a request from the background with no existing
           // activity to rebind (e.g. the queue was armed while the Lock Screen showed nothing).
@@ -232,7 +232,7 @@
           // More downloads are queued and the app may be backgrounded, where a replacement
           // activity could not be requested. Keep this one alive showing the result; the next
           // download's start() rebinds it moments later.
-          liveActivityLog.info(
+          liveActivityLog.notice(
             "Task \(taskId) finished (\(finalState.rawValue, privacy: .public)); keeping activity for \(self.queuedCount) queued download(s)"
           )
           self.push(
@@ -241,7 +241,7 @@
             staleDate: Date().addingTimeInterval(Self.staleInterval)
           )
         } else {
-          liveActivityLog.info(
+          liveActivityLog.notice(
             "Task \(taskId) finished (\(finalState.rawValue, privacy: .public)); ending activity"
           )
           self.tracker = nil
@@ -307,9 +307,9 @@
               lastBytes: activity.content.state.bytesDownloaded,
               emaSpeed: 0
             )
-            liveActivityLog.info("Adopted surviving activity for restored task")
+            liveActivityLog.notice("Adopted surviving activity for restored task")
           } else if self.tracker?.activityId != activity.id {
-            liveActivityLog.info("Ending orphaned activity from a previous process")
+            liveActivityLog.notice("Ending orphaned activity from a previous process")
             Task { await activity.end(nil, dismissalPolicy: .immediate) }
           }
         }

--- a/modules/background-downloader/ios/DownloadLiveActivityController.swift
+++ b/modules/background-downloader/ios/DownloadLiveActivityController.swift
@@ -198,19 +198,48 @@
       }
     }
 
-    /// Ends any activity with no live task behind it. Covers the app being killed mid-download and
-    /// relaunched later, which would otherwise leave an activity stuck on the Lock Screen forever.
-    func reconcile(activeTaskIds: Set<Int>) {
+    /// Re-adopts activities that survived a process restart and ends the rest.
+    ///
+    /// `trackers` lives only in memory, so after a cold relaunch every surviving activity is
+    /// unknown here — and iOS relaunches the app precisely because a background transfer is still
+    /// progressing or just finished. Ending those activities would destroy the Live Activity for
+    /// the remainder of the download and make every later `update`/`finish` a silent no-op.
+    /// Instead each activity is matched back to its restored task via the persisted metadata and
+    /// tracked again; only activities matching no known task are ended.
+    ///
+    /// Matching deliberately ignores whether the task is still present in the `URLSession`: a
+    /// task that completed while the app was dead is already absent from `getAllTasks`, yet its
+    /// `didFinishDownloadingTo` arrives moments later and must find a tracker to flip the
+    /// activity to "Downloaded" (the same race `DownloadTaskStore` documents). Adopted activities
+    /// whose task truly died are ended by the delegate's failure/cancellation callbacks.
+    func reconcile(persistedTasks: [Int: DownloadActivityMetadata]) {
       queue.async {
-        for (taskId, tracker) in self.trackers where !activeTaskIds.contains(taskId) {
-          self.trackers.removeValue(forKey: taskId)
-          self.end(activityId: tracker.activityId, state: nil, dismissalPolicy: .immediate)
-        }
-
+        var unclaimed = persistedTasks.filter { taskId, _ in self.trackers[taskId] == nil }
         let known = Set(self.trackers.values.map(\.activityId))
+
         for activity in Activity<DownloadActivityAttributes>.activities
         where !known.contains(activity.id) {
-          Task { await activity.end(nil, dismissalPolicy: .immediate) }
+          guard self.isEnabled,
+            let taskId = unclaimed.first(where: {
+              $0.value.itemId == activity.attributes.itemId
+            })?.key
+          else {
+            Task { await activity.end(nil, dismissalPolicy: .immediate) }
+            continue
+          }
+          unclaimed.removeValue(forKey: taskId)
+          self.trackers[taskId] = Tracker(
+            activityId: activity.id,
+            attributes: activity.attributes,
+            // Backdated so the first post-relaunch progress tick pushes immediately instead of
+            // waiting out the update throttle.
+            lastPushedAt: .distantPast,
+            lastSampleAt: Date(),
+            // Seeded from the activity's last rendered state so the first speed sample measures
+            // the delta since relaunch, not the whole download so far.
+            lastBytes: activity.content.state.bytesDownloaded,
+            emaSpeed: 0
+          )
         }
       }
     }

--- a/modules/background-downloader/ios/DownloadLiveActivityController.swift
+++ b/modules/background-downloader/ios/DownloadLiveActivityController.swift
@@ -1,0 +1,265 @@
+#if os(iOS)
+  import ActivityKit
+  import Foundation
+
+  /// Owns the download Live Activity end to end.
+  ///
+  /// Deliberately driven from the `URLSession` delegate rather than from JS. iOS wakes the app in the
+  /// background to deliver `didWriteData` batches and always relaunches it for
+  /// `handleEventsForBackgroundURLSession` on completion, but the React Native runtime is usually
+  /// gone by then — so the terminal "Downloaded" flip is only reliable from native.
+  ///
+  /// It cannot beat suspension: while iOS has the process suspended no code runs at all and the
+  /// transfer continues out-of-process in `nsurlsessiond`. That is why every update carries a
+  /// `staleDate`, so the system visibly de-emphasizes numbers that have gone old.
+  @available(iOS 16.2, *)
+  final class DownloadLiveActivityController {
+    static let shared = DownloadLiveActivityController()
+
+    /// ActivityKit budgets updates; the URLSession delegate fires far more often than this.
+    private static let minUpdateInterval: TimeInterval = 1.0
+    /// Sample window for the speed average. `didWriteData` fires many times a second and the
+    /// per-callback byte deltas are far too jittery to divide by — averaging over a full second
+    /// keeps the displayed rate readable.
+    private static let minSpeedSampleInterval: TimeInterval = 1.0
+    /// Low alpha: heavily favour history over the newest sample. Download throughput is spiky, and
+    /// a responsive average just renders as a number that will not sit still.
+    private static let speedSmoothingAlpha = 0.15
+    /// How long a pushed update stays "current". Long enough that ordinary background wake-up gaps
+    /// do not constantly dim the activity, short enough that a dead transfer stops looking live.
+    private static let staleInterval: TimeInterval = 5 * 60
+
+    private struct Tracker {
+      var activityId: String
+      var attributes: DownloadActivityAttributes
+      var lastPushedAt: Date
+      var lastSampleAt: Date
+      var lastBytes: Int64
+      var emaSpeed: Double
+    }
+
+    private let queue = DispatchQueue(
+      label: "com.fredrikburmester.streamyfin.downloadliveactivity"
+    )
+    private var trackers: [Int: Tracker] = [:]
+    private var isEnabled = true
+
+    private var activitiesAvailable: Bool {
+      ActivityAuthorizationInfo().areActivitiesEnabled
+    }
+
+    // MARK: - Configuration
+
+    func setEnabled(_ enabled: Bool) {
+      queue.async {
+        guard self.isEnabled != enabled else { return }
+        self.isEnabled = enabled
+        if !enabled {
+          self.endAllLocked(state: .completed, dismissImmediately: true)
+        }
+      }
+    }
+
+    // MARK: - Lifecycle
+
+    func start(taskId: Int, metadata: DownloadActivityMetadata, queuedCount: Int) {
+      queue.async {
+        guard self.isEnabled, self.activitiesAvailable else { return }
+        guard self.trackers[taskId] == nil else { return }
+
+        // Only one download runs at a time, so anything still live belongs to a previous task.
+        self.endAllLocked(state: .completed, dismissImmediately: true)
+
+        let attributes = DownloadActivityAttributes(
+          itemId: metadata.itemId,
+          title: metadata.title,
+          subtitle: metadata.subtitle,
+          posterFileName: metadata.posterFileName,
+          estimatedTotalBytes: metadata.estimatedTotalBytes,
+          labels: metadata.labels
+        )
+        let now = Date()
+        let state = DownloadActivityAttributes.ContentState(
+          progress: 0,
+          bytesDownloaded: 0,
+          totalBytes: 0,
+          speedBytesPerSec: 0,
+          queuedCount: queuedCount,
+          state: .downloading
+        )
+
+        do {
+          let activity = try Activity.request(
+            attributes: attributes,
+            content: ActivityContent(
+              state: state,
+              staleDate: now.addingTimeInterval(Self.staleInterval)
+            ),
+            pushType: nil
+          )
+          self.trackers[taskId] = Tracker(
+            activityId: activity.id,
+            attributes: attributes,
+            lastPushedAt: now,
+            lastSampleAt: now,
+            lastBytes: 0,
+            emaSpeed: 0
+          )
+        } catch {
+          print("[LiveActivity] Failed to start: \(error.localizedDescription)")
+        }
+      }
+    }
+
+    func update(taskId: Int, bytesWritten: Int64, totalBytes: Int64, queuedCount: Int) {
+      queue.async {
+        guard self.isEnabled, var tracker = self.trackers[taskId] else { return }
+
+        let now = Date()
+        let sampleInterval = now.timeIntervalSince(tracker.lastSampleAt)
+
+        // Speed is computed here rather than reusing the JS calculator in
+        // providers/Downloads/hooks/useDownloadSpeedCalculator.ts, because that one only runs while
+        // the JS runtime is alive — exactly when we do not need it.
+        if sampleInterval >= Self.minSpeedSampleInterval, bytesWritten >= tracker.lastBytes {
+          let instantaneous = Double(bytesWritten - tracker.lastBytes) / sampleInterval
+          tracker.emaSpeed =
+            tracker.emaSpeed == 0
+            ? instantaneous
+            : Self.speedSmoothingAlpha * instantaneous
+              + (1 - Self.speedSmoothingAlpha) * tracker.emaSpeed
+          tracker.lastBytes = bytesWritten
+          tracker.lastSampleAt = now
+        }
+
+        let effectiveTotal =
+          totalBytes > 0 ? totalBytes : tracker.attributes.estimatedTotalBytes
+        let progress =
+          effectiveTotal > 0
+          ? min(max(Double(bytesWritten) / Double(effectiveTotal), 0), 1)
+          : 0
+
+        self.trackers[taskId] = tracker
+
+        guard now.timeIntervalSince(tracker.lastPushedAt) >= Self.minUpdateInterval else { return }
+        tracker.lastPushedAt = now
+        self.trackers[taskId] = tracker
+
+        let state = DownloadActivityAttributes.ContentState(
+          progress: progress,
+          bytesDownloaded: bytesWritten,
+          totalBytes: effectiveTotal,
+          speedBytesPerSec: tracker.emaSpeed,
+          queuedCount: queuedCount,
+          state: .downloading
+        )
+
+        // The bar cannot advance while we are suspended, so this is what stops a transfer that died
+        // mid-flight from sitting there looking like a confident, current 62%.
+        self.push(
+          activityId: tracker.activityId,
+          state: state,
+          staleDate: now.addingTimeInterval(Self.staleInterval)
+        )
+      }
+    }
+
+    func finish(taskId: Int, state finalState: DownloadActivityState, queuedCount: Int) {
+      queue.async {
+        guard let tracker = self.trackers.removeValue(forKey: taskId) else { return }
+
+        let content = DownloadActivityAttributes.ContentState(
+          progress: finalState == .completed ? 1 : 0,
+          bytesDownloaded: tracker.lastBytes,
+          totalBytes: tracker.attributes.estimatedTotalBytes,
+          speedBytesPerSec: 0,
+          queuedCount: queuedCount,
+          state: finalState
+        )
+        // Leave the result on the Lock Screen briefly; the next queued download replaces it anyway.
+        self.end(
+          activityId: tracker.activityId,
+          state: content,
+          dismissalPolicy: .after(Date().addingTimeInterval(finalState == .failed ? 30 : 15))
+        )
+      }
+    }
+
+    func cancel(taskId: Int) {
+      queue.async {
+        guard let tracker = self.trackers.removeValue(forKey: taskId) else { return }
+        self.end(activityId: tracker.activityId, state: nil, dismissalPolicy: .immediate)
+      }
+    }
+
+    func cancelAll() {
+      queue.async {
+        self.endAllLocked(state: .completed, dismissImmediately: true)
+      }
+    }
+
+    /// Ends any activity with no live task behind it. Covers the app being killed mid-download and
+    /// relaunched later, which would otherwise leave an activity stuck on the Lock Screen forever.
+    func reconcile(activeTaskIds: Set<Int>) {
+      queue.async {
+        for (taskId, tracker) in self.trackers where !activeTaskIds.contains(taskId) {
+          self.trackers.removeValue(forKey: taskId)
+          self.end(activityId: tracker.activityId, state: nil, dismissalPolicy: .immediate)
+        }
+
+        let known = Set(self.trackers.values.map(\.activityId))
+        for activity in Activity<DownloadActivityAttributes>.activities
+        where !known.contains(activity.id) {
+          Task { await activity.end(nil, dismissalPolicy: .immediate) }
+        }
+      }
+    }
+
+    // MARK: - ActivityKit plumbing
+
+    private func endAllLocked(state: DownloadActivityState, dismissImmediately: Bool) {
+      let current = trackers
+      trackers.removeAll()
+      for (_, tracker) in current {
+        end(
+          activityId: tracker.activityId,
+          state: nil,
+          dismissalPolicy: dismissImmediately ? .immediate : .default
+        )
+      }
+    }
+
+    private func push(
+      activityId: String,
+      state: DownloadActivityAttributes.ContentState,
+      staleDate: Date
+    ) {
+      guard
+        let activity = Activity<DownloadActivityAttributes>.activities.first(where: {
+          $0.id == activityId
+        })
+      else { return }
+
+      Task {
+        await activity.update(ActivityContent(state: state, staleDate: staleDate))
+      }
+    }
+
+    private func end(
+      activityId: String,
+      state: DownloadActivityAttributes.ContentState?,
+      dismissalPolicy: ActivityUIDismissalPolicy
+    ) {
+      guard
+        let activity = Activity<DownloadActivityAttributes>.activities.first(where: {
+          $0.id == activityId
+        })
+      else { return }
+
+      let content = state.map { ActivityContent(state: $0, staleDate: nil) }
+      Task {
+        await activity.end(content, dismissalPolicy: dismissalPolicy)
+      }
+    }
+  }
+#endif

--- a/modules/background-downloader/ios/DownloadLiveActivityController.swift
+++ b/modules/background-downloader/ios/DownloadLiveActivityController.swift
@@ -38,9 +38,15 @@
     /// Low alpha: heavily favour history over the newest sample. Download throughput is spiky, and
     /// a responsive average just renders as a number that will not sit still.
     private static let speedSmoothingAlpha = 0.15
-    /// How long a pushed update stays "current". Long enough that ordinary background wake-up gaps
-    /// do not constantly dim the activity, short enough that a dead transfer stops looking live.
+    /// How long a pushed update stays "current" when there is no completion projection yet.
     private static let staleInterval: TimeInterval = 5 * 60
+    /// Pessimistic haircut on the smoothed speed when projecting the completion time. The
+    /// projection drives a bar that advances on its own while the app is suspended, so it must
+    /// under-promise: finishing late looks like a slow network, finishing early looks like a lie.
+    private static let projectionSpeedFactor = 0.85
+    /// Grace past the projected completion before the activity is marked stale — enough for the
+    /// completion wake-up to land and flip the state for real.
+    private static let projectionStaleGrace: TimeInterval = 60
 
     /// The one live activity and the download currently bound to it.
     private struct Tracker {
@@ -196,21 +202,51 @@
         tracker.lastPushedAt = now
         self.tracker = tracker
 
+        // Project the completion time so the widget can render a bar and countdown that keep
+        // advancing while the app is suspended (the timer-interval primitives are the only ones
+        // iOS animates without the app running). Anchored so "now" equals the measured progress;
+        // every real update re-anchors, correcting the projection.
+        var progressBarStartDate: Date?
+        var projectedEndDate: Date?
+        let remainingBytes = effectiveTotal - bytesWritten
+        if tracker.emaSpeed > 0, effectiveTotal > 0, remainingBytes > 0, progress < 1 {
+          let remainingSeconds =
+            Double(remainingBytes) / (tracker.emaSpeed * Self.projectionSpeedFactor)
+          if remainingSeconds.isFinite, remainingSeconds > 0 {
+            let end = now.addingTimeInterval(remainingSeconds)
+            let anchoredProgress = min(progress, 0.99)
+            let totalSeconds = remainingSeconds / (1 - anchoredProgress)
+            progressBarStartDate = end.addingTimeInterval(-totalSeconds)
+            projectedEndDate = end
+          }
+        }
+
         let state = self.contentState(
           for: tracker.metadata,
           progress: progress,
           bytesDownloaded: bytesWritten,
           totalBytes: effectiveTotal,
           speed: tracker.emaSpeed,
-          state: .downloading
+          state: .downloading,
+          progressBarStartDate: progressBarStartDate,
+          projectedEndDate: projectedEndDate
         )
 
-        // The bar cannot advance while we are suspended, so this is what stops a transfer that died
-        // mid-flight from sitting there looking like a confident, current 62%.
+        // With a projection the content stays "current" until the promise expires (plus grace for
+        // the completion wake-up); past that, the stale treatment stops a parked bar and a 0:00
+        // countdown from looking confident. Without one, fall back to the fixed window.
+        let staleDate =
+          projectedEndDate.map {
+            max(
+              $0.addingTimeInterval(Self.projectionStaleGrace),
+              now.addingTimeInterval(2 * 60)
+            )
+          } ?? now.addingTimeInterval(Self.staleInterval)
+
         self.push(
           activityId: tracker.activityId,
           state: state,
-          staleDate: now.addingTimeInterval(Self.staleInterval)
+          staleDate: staleDate
         )
       }
     }
@@ -324,7 +360,9 @@
       bytesDownloaded: Int64,
       totalBytes: Int64,
       speed: Double,
-      state: DownloadActivityState
+      state: DownloadActivityState,
+      progressBarStartDate: Date? = nil,
+      projectedEndDate: Date? = nil
     ) -> DownloadActivityAttributes.ContentState {
       DownloadActivityAttributes.ContentState(
         itemId: metadata.itemId,
@@ -336,7 +374,9 @@
         totalBytes: totalBytes,
         speedBytesPerSec: speed,
         queuedCount: queuedCount,
-        state: state
+        state: state,
+        progressBarStartDate: progressBarStartDate,
+        projectedEndDate: projectedEndDate
       )
     }
 

--- a/modules/background-downloader/ios/DownloadLiveActivityController.swift
+++ b/modules/background-downloader/ios/DownloadLiveActivityController.swift
@@ -9,6 +9,13 @@
   /// `handleEventsForBackgroundURLSession` on completion, but the React Native runtime is usually
   /// gone by then — so the terminal "Downloaded" flip is only reliable from native.
   ///
+  /// There is at most ONE activity, reused across the whole download queue. iOS only allows
+  /// `Activity.request` while the app is foregrounded, and queued downloads start from background
+  /// wake-ups — so the activity is created for the first download and then *rebound* to each
+  /// subsequent one through `activity.update`, which has no foreground restriction. Ending it and
+  /// requesting a fresh one per download would leave every episode after the first without an
+  /// activity whenever the app is backgrounded.
+  ///
   /// It cannot beat suspension: while iOS has the process suspended no code runs at all and the
   /// transfer continues out-of-process in `nsurlsessiond`. That is why every update carries a
   /// `staleDate`, so the system visibly de-emphasizes numbers that have gone old.
@@ -29,9 +36,11 @@
     /// do not constantly dim the activity, short enough that a dead transfer stops looking live.
     private static let staleInterval: TimeInterval = 5 * 60
 
+    /// The one live activity and the download currently bound to it.
     private struct Tracker {
       var activityId: String
-      var attributes: DownloadActivityAttributes
+      var taskId: Int
+      var metadata: DownloadActivityMetadata
       var lastPushedAt: Date
       var lastSampleAt: Date
       var lastBytes: Int64
@@ -41,7 +50,7 @@
     private let queue = DispatchQueue(
       label: "com.fredrikburmester.streamyfin.downloadliveactivity"
     )
-    private var trackers: [Int: Tracker] = [:]
+    private var tracker: Tracker?
     private var isEnabled = true
     /// Pushed in by the module whenever its queue changes, instead of being read out of the
     /// module's collections on every progress callback — that read was an unsynchronized
@@ -59,7 +68,7 @@
         guard self.isEnabled != enabled else { return }
         self.isEnabled = enabled
         if !enabled {
-          self.endAllLocked(state: .completed, dismissImmediately: true)
+          self.endAllLocked(dismissImmediately: true)
         }
       }
     }
@@ -74,48 +83,67 @@
 
     func start(taskId: Int, metadata: DownloadActivityMetadata) {
       queue.async {
-        guard self.isEnabled, self.activitiesAvailable else { return }
-        guard self.trackers[taskId] == nil else { return }
+        guard self.isEnabled else { return }
+        guard self.tracker?.taskId != taskId else { return }
 
-        // Only one download runs at a time, so anything still live belongs to a previous task.
-        self.endAllLocked(state: .completed, dismissImmediately: true)
-
-        let attributes = DownloadActivityAttributes(
-          itemId: metadata.itemId,
-          title: metadata.title,
-          subtitle: metadata.subtitle,
-          posterFileName: metadata.posterFileName,
-          estimatedTotalBytes: metadata.estimatedTotalBytes,
-          labels: metadata.labels
-        )
         let now = Date()
-        let state = DownloadActivityAttributes.ContentState(
+        let state = self.contentState(
+          for: metadata,
           progress: 0,
           bytesDownloaded: 0,
           totalBytes: 0,
-          speedBytesPerSec: 0,
-          queuedCount: self.queuedCount,
+          speed: 0,
           state: .downloading
         )
 
+        // Rebind a live activity if there is one — ours, or any orphan of our type. This is the
+        // only path that works from the background, which is where queued downloads start.
+        let candidateId = self.tracker?.activityId
+          ?? Activity<DownloadActivityAttributes>.activities.first?.id
+        if let activityId = candidateId,
+          Activity<DownloadActivityAttributes>.activities.contains(where: { $0.id == activityId })
+        {
+          self.tracker = Tracker(
+            activityId: activityId,
+            taskId: taskId,
+            metadata: metadata,
+            lastPushedAt: now,
+            lastSampleAt: now,
+            lastBytes: 0,
+            emaSpeed: 0
+          )
+          self.push(
+            activityId: activityId,
+            state: state,
+            staleDate: now.addingTimeInterval(Self.staleInterval)
+          )
+          return
+        }
+
+        guard self.activitiesAvailable else { return }
+
         do {
           let activity = try Activity.request(
-            attributes: attributes,
+            attributes: DownloadActivityAttributes(labels: metadata.labels),
             content: ActivityContent(
               state: state,
               staleDate: now.addingTimeInterval(Self.staleInterval)
             ),
             pushType: nil
           )
-          self.trackers[taskId] = Tracker(
+          self.tracker = Tracker(
             activityId: activity.id,
-            attributes: attributes,
+            taskId: taskId,
+            metadata: metadata,
             lastPushedAt: now,
             lastSampleAt: now,
             lastBytes: 0,
             emaSpeed: 0
           )
         } catch {
+          // Most commonly ActivityKit refusing a request from the background with no existing
+          // activity to rebind (e.g. the queue was armed while the Lock Screen showed nothing).
+          self.tracker = nil
           print("[LiveActivity] Failed to start: \(error.localizedDescription)")
         }
       }
@@ -123,7 +151,7 @@
 
     func update(taskId: Int, bytesWritten: Int64, totalBytes: Int64) {
       queue.async {
-        guard self.isEnabled, var tracker = self.trackers[taskId] else { return }
+        guard self.isEnabled, var tracker = self.tracker, tracker.taskId == taskId else { return }
 
         let now = Date()
         let sampleInterval = now.timeIntervalSince(tracker.lastSampleAt)
@@ -143,24 +171,24 @@
         }
 
         let effectiveTotal =
-          totalBytes > 0 ? totalBytes : tracker.attributes.estimatedTotalBytes
+          totalBytes > 0 ? totalBytes : tracker.metadata.estimatedTotalBytes
         let progress =
           effectiveTotal > 0
           ? min(max(Double(bytesWritten) / Double(effectiveTotal), 0), 1)
           : 0
 
-        self.trackers[taskId] = tracker
+        self.tracker = tracker
 
         guard now.timeIntervalSince(tracker.lastPushedAt) >= Self.minUpdateInterval else { return }
         tracker.lastPushedAt = now
-        self.trackers[taskId] = tracker
+        self.tracker = tracker
 
-        let state = DownloadActivityAttributes.ContentState(
+        let state = self.contentState(
+          for: tracker.metadata,
           progress: progress,
           bytesDownloaded: bytesWritten,
           totalBytes: effectiveTotal,
-          speedBytesPerSec: tracker.emaSpeed,
-          queuedCount: self.queuedCount,
+          speed: tracker.emaSpeed,
           state: .downloading
         )
 
@@ -176,95 +204,131 @@
 
     func finish(taskId: Int, state finalState: DownloadActivityState) {
       queue.async {
-        guard let tracker = self.trackers.removeValue(forKey: taskId) else { return }
+        guard let tracker = self.tracker, tracker.taskId == taskId else { return }
 
-        let content = DownloadActivityAttributes.ContentState(
+        let content = self.contentState(
+          for: tracker.metadata,
           progress: finalState == .completed ? 1 : 0,
           bytesDownloaded: tracker.lastBytes,
-          totalBytes: tracker.attributes.estimatedTotalBytes,
-          speedBytesPerSec: 0,
-          queuedCount: self.queuedCount,
+          totalBytes: tracker.metadata.estimatedTotalBytes,
+          speed: 0,
           state: finalState
         )
-        // Leave the result on the Lock Screen briefly; the next queued download replaces it anyway.
-        self.end(
-          activityId: tracker.activityId,
-          state: content,
-          dismissalPolicy: .after(Date().addingTimeInterval(finalState == .failed ? 30 : 15))
-        )
+
+        if self.queuedCount > 0 {
+          // More downloads are queued and the app may be backgrounded, where a replacement
+          // activity could not be requested. Keep this one alive showing the result; the next
+          // download's start() rebinds it moments later.
+          self.push(
+            activityId: tracker.activityId,
+            state: content,
+            staleDate: Date().addingTimeInterval(Self.staleInterval)
+          )
+        } else {
+          self.tracker = nil
+          // Leave the result on the Lock Screen briefly before dismissing.
+          self.end(
+            activityId: tracker.activityId,
+            state: content,
+            dismissalPolicy: .after(Date().addingTimeInterval(finalState == .failed ? 30 : 15))
+          )
+        }
       }
     }
 
     func cancel(taskId: Int) {
       queue.async {
-        guard let tracker = self.trackers.removeValue(forKey: taskId) else { return }
+        guard let tracker = self.tracker, tracker.taskId == taskId else { return }
+        // With downloads still queued the activity is kept for rebinding, same as finish().
+        guard self.queuedCount == 0 else { return }
+        self.tracker = nil
         self.end(activityId: tracker.activityId, state: nil, dismissalPolicy: .immediate)
       }
     }
 
     func cancelAll() {
       queue.async {
-        self.endAllLocked(state: .completed, dismissImmediately: true)
+        self.endAllLocked(dismissImmediately: true)
       }
     }
 
-    /// Re-adopts activities that survived a process restart and ends the rest.
+    /// Re-adopts an activity that survived a process restart and ends any others.
     ///
-    /// `trackers` lives only in memory, so after a cold relaunch every surviving activity is
-    /// unknown here — and iOS relaunches the app precisely because a background transfer is still
-    /// progressing or just finished. Ending those activities would destroy the Live Activity for
-    /// the remainder of the download and make every later `update`/`finish` a silent no-op.
-    /// Instead each activity is matched back to its restored task via the persisted metadata and
-    /// tracked again; only activities matching no known task are ended.
+    /// `tracker` lives only in memory, so after a cold relaunch a surviving activity is unknown
+    /// here — and iOS relaunches the app precisely because a background transfer is still
+    /// progressing or just finished. Ending it would destroy the Live Activity for the remainder
+    /// of the download and, because new activities cannot be requested from the background, for
+    /// every queued download after it. The activity is matched back to its restored task via the
+    /// itemId it is currently rendering.
     ///
     /// Matching deliberately ignores whether the task is still present in the `URLSession`: a
     /// task that completed while the app was dead is already absent from `getAllTasks`, yet its
-    /// `didFinishDownloadingTo` arrives moments later and must find a tracker to flip the
-    /// activity to "Downloaded" (the same race `DownloadTaskStore` documents). Adopted activities
-    /// whose task truly died are ended by the delegate's failure/cancellation callbacks.
+    /// `didFinishDownloadingTo` arrives moments later and must find the tracker to flip the
+    /// activity to "Downloaded" (the same race `DownloadTaskStore` documents). An adopted activity
+    /// whose task truly died is ended by the delegate's failure/cancellation callbacks.
     func reconcile(persistedTasks: [Int: DownloadActivityMetadata]) {
       queue.async {
-        var unclaimed = persistedTasks.filter { taskId, _ in self.trackers[taskId] == nil }
-        let known = Set(self.trackers.values.map(\.activityId))
-
-        for activity in Activity<DownloadActivityAttributes>.activities
-        where !known.contains(activity.id) {
-          guard self.isEnabled,
-            let taskId = unclaimed.first(where: {
-              $0.value.itemId == activity.attributes.itemId
-            })?.key
-          else {
+        for activity in Activity<DownloadActivityAttributes>.activities {
+          if self.tracker == nil,
+            self.isEnabled,
+            let match = persistedTasks.first(where: {
+              $0.value.itemId == activity.content.state.itemId
+            })
+          {
+            self.tracker = Tracker(
+              activityId: activity.id,
+              taskId: match.key,
+              metadata: match.value,
+              // Backdated so the first post-relaunch progress tick pushes immediately instead of
+              // waiting out the update throttle.
+              lastPushedAt: .distantPast,
+              lastSampleAt: Date(),
+              // Seeded from the activity's last rendered state so the first speed sample measures
+              // the delta since relaunch, not the whole download so far.
+              lastBytes: activity.content.state.bytesDownloaded,
+              emaSpeed: 0
+            )
+          } else if self.tracker?.activityId != activity.id {
             Task { await activity.end(nil, dismissalPolicy: .immediate) }
-            continue
           }
-          unclaimed.removeValue(forKey: taskId)
-          self.trackers[taskId] = Tracker(
-            activityId: activity.id,
-            attributes: activity.attributes,
-            // Backdated so the first post-relaunch progress tick pushes immediately instead of
-            // waiting out the update throttle.
-            lastPushedAt: .distantPast,
-            lastSampleAt: Date(),
-            // Seeded from the activity's last rendered state so the first speed sample measures
-            // the delta since relaunch, not the whole download so far.
-            lastBytes: activity.content.state.bytesDownloaded,
-            emaSpeed: 0
-          )
         }
       }
     }
 
     // MARK: - ActivityKit plumbing
 
-    private func endAllLocked(state: DownloadActivityState, dismissImmediately: Bool) {
-      let current = trackers
-      trackers.removeAll()
-      for (_, tracker) in current {
-        end(
-          activityId: tracker.activityId,
-          state: nil,
-          dismissalPolicy: dismissImmediately ? .immediate : .default
-        )
+    private func contentState(
+      for metadata: DownloadActivityMetadata,
+      progress: Double,
+      bytesDownloaded: Int64,
+      totalBytes: Int64,
+      speed: Double,
+      state: DownloadActivityState
+    ) -> DownloadActivityAttributes.ContentState {
+      DownloadActivityAttributes.ContentState(
+        itemId: metadata.itemId,
+        title: metadata.title,
+        subtitle: metadata.subtitle,
+        posterFileName: metadata.posterFileName,
+        progress: progress,
+        bytesDownloaded: bytesDownloaded,
+        totalBytes: totalBytes,
+        speedBytesPerSec: speed,
+        queuedCount: queuedCount,
+        state: state
+      )
+    }
+
+    private func endAllLocked(dismissImmediately: Bool) {
+      tracker = nil
+      // Ends every live activity of our type, orphans included.
+      for activity in Activity<DownloadActivityAttributes>.activities {
+        Task {
+          await activity.end(
+            nil,
+            dismissalPolicy: dismissImmediately ? .immediate : .default
+          )
+        }
       }
     }
 

--- a/modules/background-downloader/ios/DownloadLiveActivityController.swift
+++ b/modules/background-downloader/ios/DownloadLiveActivityController.swift
@@ -1,6 +1,12 @@
 #if os(iOS)
   import ActivityKit
   import Foundation
+  import os
+
+  private let liveActivityLog = Logger(
+    subsystem: "com.fredrikburmester.streamyfin",
+    category: "LiveActivity"
+  )
 
   /// Owns the download Live Activity end to end.
   ///
@@ -117,10 +123,14 @@
             state: state,
             staleDate: now.addingTimeInterval(Self.staleInterval)
           )
+          liveActivityLog.info("Rebound existing activity to task \(taskId)")
           return
         }
 
-        guard self.activitiesAvailable else { return }
+        guard self.activitiesAvailable else {
+          liveActivityLog.info("Activities unavailable; not starting one for task \(taskId)")
+          return
+        }
 
         do {
           let activity = try Activity.request(
@@ -140,11 +150,14 @@
             lastBytes: 0,
             emaSpeed: 0
           )
+          liveActivityLog.info("Requested new activity for task \(taskId)")
         } catch {
           // Most commonly ActivityKit refusing a request from the background with no existing
           // activity to rebind (e.g. the queue was armed while the Lock Screen showed nothing).
           self.tracker = nil
-          print("[LiveActivity] Failed to start: \(error.localizedDescription)")
+          liveActivityLog.error(
+            "Failed to start activity for task \(taskId): \(error.localizedDescription, privacy: .public)"
+          )
         }
       }
     }
@@ -219,12 +232,18 @@
           // More downloads are queued and the app may be backgrounded, where a replacement
           // activity could not be requested. Keep this one alive showing the result; the next
           // download's start() rebinds it moments later.
+          liveActivityLog.info(
+            "Task \(taskId) finished (\(finalState.rawValue, privacy: .public)); keeping activity for \(self.queuedCount) queued download(s)"
+          )
           self.push(
             activityId: tracker.activityId,
             state: content,
             staleDate: Date().addingTimeInterval(Self.staleInterval)
           )
         } else {
+          liveActivityLog.info(
+            "Task \(taskId) finished (\(finalState.rawValue, privacy: .public)); ending activity"
+          )
           self.tracker = nil
           // Leave the result on the Lock Screen briefly before dismissing.
           self.end(
@@ -288,7 +307,9 @@
               lastBytes: activity.content.state.bytesDownloaded,
               emaSpeed: 0
             )
+            liveActivityLog.info("Adopted surviving activity for restored task")
           } else if self.tracker?.activityId != activity.id {
+            liveActivityLog.info("Ending orphaned activity from a previous process")
             Task { await activity.end(nil, dismissalPolicy: .immediate) }
           }
         }

--- a/modules/background-downloader/ios/DownloadLiveActivityController.swift
+++ b/modules/background-downloader/ios/DownloadLiveActivityController.swift
@@ -43,6 +43,10 @@
     )
     private var trackers: [Int: Tracker] = [:]
     private var isEnabled = true
+    /// Pushed in by the module whenever its queue changes, instead of being read out of the
+    /// module's collections on every progress callback — that read was an unsynchronized
+    /// cross-thread access to state owned by another queue.
+    private var queuedCount = 0
 
     private var activitiesAvailable: Bool {
       ActivityAuthorizationInfo().areActivitiesEnabled
@@ -60,9 +64,15 @@
       }
     }
 
+    func setQueuedCount(_ count: Int) {
+      queue.async {
+        self.queuedCount = count
+      }
+    }
+
     // MARK: - Lifecycle
 
-    func start(taskId: Int, metadata: DownloadActivityMetadata, queuedCount: Int) {
+    func start(taskId: Int, metadata: DownloadActivityMetadata) {
       queue.async {
         guard self.isEnabled, self.activitiesAvailable else { return }
         guard self.trackers[taskId] == nil else { return }
@@ -84,7 +94,7 @@
           bytesDownloaded: 0,
           totalBytes: 0,
           speedBytesPerSec: 0,
-          queuedCount: queuedCount,
+          queuedCount: self.queuedCount,
           state: .downloading
         )
 
@@ -111,7 +121,7 @@
       }
     }
 
-    func update(taskId: Int, bytesWritten: Int64, totalBytes: Int64, queuedCount: Int) {
+    func update(taskId: Int, bytesWritten: Int64, totalBytes: Int64) {
       queue.async {
         guard self.isEnabled, var tracker = self.trackers[taskId] else { return }
 
@@ -150,7 +160,7 @@
           bytesDownloaded: bytesWritten,
           totalBytes: effectiveTotal,
           speedBytesPerSec: tracker.emaSpeed,
-          queuedCount: queuedCount,
+          queuedCount: self.queuedCount,
           state: .downloading
         )
 
@@ -164,7 +174,7 @@
       }
     }
 
-    func finish(taskId: Int, state finalState: DownloadActivityState, queuedCount: Int) {
+    func finish(taskId: Int, state finalState: DownloadActivityState) {
       queue.async {
         guard let tracker = self.trackers.removeValue(forKey: taskId) else { return }
 
@@ -173,7 +183,7 @@
           bytesDownloaded: tracker.lastBytes,
           totalBytes: tracker.attributes.estimatedTotalBytes,
           speedBytesPerSec: 0,
-          queuedCount: queuedCount,
+          queuedCount: self.queuedCount,
           state: finalState
         )
         // Leave the result on the Lock Screen briefly; the next queued download replaces it anyway.

--- a/modules/background-downloader/ios/DownloadTaskStore.swift
+++ b/modules/background-downloader/ios/DownloadTaskStore.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Metadata JS attaches to a download so the Live Activity can render without a JS runtime.
+/// All user-visible strings are resolved in JS, so Swift never needs its own translations.
+struct DownloadActivityMetadata: Codable {
+  var itemId: String
+  var title: String
+  var subtitle: String
+  var posterFileName: String?
+  var estimatedTotalBytes: Int64
+  var labels: [String: String]
+}
+
+struct DownloadTaskInfo: Codable {
+  let url: String
+  let destinationPath: String?
+  var metadata: DownloadActivityMetadata?
+  var createdAt: Date = Date()
+}
+
+/// Persists in-flight task info so it survives the app being terminated mid-download.
+///
+/// This is load-bearing, not an optimization. A background `URLSession` keeps transferring after the
+/// app dies; when the transfer finishes iOS relaunches the app and delivers
+/// `didFinishDownloadingTo`. With the task map held only in memory that lookup fails, the file is
+/// never moved out of its temporary location, and the download is silently lost. Background-session
+/// task identifiers are stable across relaunches, so they are safe to key on.
+final class DownloadTaskStore {
+  private static let storageKey = "com.fredrikburmester.streamyfin.backgrounddownloader.tasks"
+
+  private let defaults: UserDefaults
+  private let queue = DispatchQueue(
+    label: "com.fredrikburmester.streamyfin.downloadtaskstore"
+  )
+
+  init() {
+    #if os(iOS)
+      if let appGroupIdentifier = DownloadActivitySharedContainer.appGroupIdentifier,
+        let suite = UserDefaults(suiteName: appGroupIdentifier)
+      {
+        defaults = suite
+      } else {
+        defaults = .standard
+      }
+    #else
+      defaults = .standard
+    #endif
+  }
+
+  /// Entries are never pruned against the live task list on launch: iOS can deliver a queued
+  /// `didFinishDownloadingTo` moments after the session is recreated, and such a task is already
+  /// absent from `getAllTasks`. Dropping it there would lose the download. An age cap bounds growth
+  /// without that race.
+  private static let maxEntryAge: TimeInterval = 7 * 24 * 60 * 60
+
+  func load() -> [Int: DownloadTaskInfo] {
+    queue.sync {
+      guard let data = defaults.data(forKey: Self.storageKey),
+        let decoded = try? JSONDecoder().decode([String: DownloadTaskInfo].self, from: data)
+      else {
+        return [:]
+      }
+      let cutoff = Date().addingTimeInterval(-Self.maxEntryAge)
+      return decoded.reduce(into: [Int: DownloadTaskInfo]()) { result, entry in
+        if let taskId = Int(entry.key), entry.value.createdAt > cutoff {
+          result[taskId] = entry.value
+        }
+      }
+    }
+  }
+
+  func save(_ tasks: [Int: DownloadTaskInfo]) {
+    queue.sync {
+      let encodable = tasks.reduce(into: [String: DownloadTaskInfo]()) { result, entry in
+        result[String(entry.key)] = entry.value
+      }
+      guard let data = try? JSONEncoder().encode(encodable) else { return }
+      defaults.set(data, forKey: Self.storageKey)
+    }
+  }
+}

--- a/modules/background-downloader/ios/DownloadTaskStore.swift
+++ b/modules/background-downloader/ios/DownloadTaskStore.swift
@@ -18,6 +18,16 @@ struct DownloadTaskInfo: Codable {
   var createdAt: Date = Date()
 }
 
+/// A download waiting behind the active one. Persisted alongside the in-flight tasks so a season
+/// queued up and then lost to a process death resumes natively on the next launch, without needing
+/// the JS runtime at all.
+struct QueuedDownloadInfo: Codable {
+  let url: String
+  let destinationPath: String?
+  var metadata: DownloadActivityMetadata?
+  var createdAt: Date = Date()
+}
+
 /// Persists in-flight task info so it survives the app being terminated mid-download.
 ///
 /// This is load-bearing, not an optimization. A background `URLSession` keeps transferring after the
@@ -30,6 +40,7 @@ struct DownloadTaskInfo: Codable {
 /// queue, which is the single place allowed to touch download state.
 final class DownloadTaskStore {
   private static let storageKey = "com.fredrikburmester.streamyfin.backgrounddownloader.tasks"
+  private static let queueStorageKey = "com.fredrikburmester.streamyfin.backgrounddownloader.queue"
 
   private let defaults: UserDefaults
 
@@ -73,5 +84,20 @@ final class DownloadTaskStore {
     }
     guard let data = try? JSONEncoder().encode(encodable) else { return }
     defaults.set(data, forKey: Self.storageKey)
+  }
+
+  func loadQueue() -> [QueuedDownloadInfo] {
+    guard let data = defaults.data(forKey: Self.queueStorageKey),
+      let decoded = try? JSONDecoder().decode([QueuedDownloadInfo].self, from: data)
+    else {
+      return []
+    }
+    let cutoff = Date().addingTimeInterval(-Self.maxEntryAge)
+    return decoded.filter { $0.createdAt > cutoff }
+  }
+
+  func saveQueue(_ queue: [QueuedDownloadInfo]) {
+    guard let data = try? JSONEncoder().encode(queue) else { return }
+    defaults.set(data, forKey: Self.queueStorageKey)
   }
 }

--- a/modules/background-downloader/ios/DownloadTaskStore.swift
+++ b/modules/background-downloader/ios/DownloadTaskStore.swift
@@ -25,13 +25,13 @@ struct DownloadTaskInfo: Codable {
 /// `didFinishDownloadingTo`. With the task map held only in memory that lookup fails, the file is
 /// never moved out of its temporary location, and the download is silently lost. Background-session
 /// task identifiers are stable across relaunches, so they are safe to key on.
+///
+/// Not internally synchronized: `BackgroundDownloaderModule` confines every call to its state
+/// queue, which is the single place allowed to touch download state.
 final class DownloadTaskStore {
   private static let storageKey = "com.fredrikburmester.streamyfin.backgrounddownloader.tasks"
 
   private let defaults: UserDefaults
-  private let queue = DispatchQueue(
-    label: "com.fredrikburmester.streamyfin.downloadtaskstore"
-  )
 
   init() {
     #if os(iOS)
@@ -54,28 +54,24 @@ final class DownloadTaskStore {
   private static let maxEntryAge: TimeInterval = 7 * 24 * 60 * 60
 
   func load() -> [Int: DownloadTaskInfo] {
-    queue.sync {
-      guard let data = defaults.data(forKey: Self.storageKey),
-        let decoded = try? JSONDecoder().decode([String: DownloadTaskInfo].self, from: data)
-      else {
-        return [:]
-      }
-      let cutoff = Date().addingTimeInterval(-Self.maxEntryAge)
-      return decoded.reduce(into: [Int: DownloadTaskInfo]()) { result, entry in
-        if let taskId = Int(entry.key), entry.value.createdAt > cutoff {
-          result[taskId] = entry.value
-        }
+    guard let data = defaults.data(forKey: Self.storageKey),
+      let decoded = try? JSONDecoder().decode([String: DownloadTaskInfo].self, from: data)
+    else {
+      return [:]
+    }
+    let cutoff = Date().addingTimeInterval(-Self.maxEntryAge)
+    return decoded.reduce(into: [Int: DownloadTaskInfo]()) { result, entry in
+      if let taskId = Int(entry.key), entry.value.createdAt > cutoff {
+        result[taskId] = entry.value
       }
     }
   }
 
   func save(_ tasks: [Int: DownloadTaskInfo]) {
-    queue.sync {
-      let encodable = tasks.reduce(into: [String: DownloadTaskInfo]()) { result, entry in
-        result[String(entry.key)] = entry.value
-      }
-      guard let data = try? JSONEncoder().encode(encodable) else { return }
-      defaults.set(data, forKey: Self.storageKey)
+    let encodable = tasks.reduce(into: [String: DownloadTaskInfo]()) { result, entry in
+      result[String(entry.key)] = entry.value
     }
+    guard let data = try? JSONEncoder().encode(encodable) else { return }
+    defaults.set(data, forKey: Self.storageKey)
   }
 }

--- a/modules/background-downloader/src/BackgroundDownloader.types.ts
+++ b/modules/background-downloader/src/BackgroundDownloader.types.ts
@@ -29,13 +29,46 @@ export interface ActiveDownload {
   state: "running" | "suspended" | "canceling" | "completed" | "unknown";
 }
 
+/**
+ * Everything the iOS Live Activity needs in order to render without a JS runtime.
+ *
+ * The activity is driven from the native URLSession delegate, which keeps working when iOS has torn
+ * down the JS runtime — so nothing here can be resolved lazily later. In particular `labels` carries
+ * pre-translated strings, keeping i18n in `translations/*.json` instead of duplicating it in Swift.
+ *
+ * iOS only; ignored on Android.
+ */
+export interface DownloadActivityMetadata {
+  itemId: string;
+  title: string;
+  subtitle: string;
+  /** File name inside the directory returned by `getLiveActivityDirectory()`. */
+  posterFileName?: string;
+  /** Fallback total used when the server sends no Content-Length (transcoded downloads). */
+  estimatedTotalBytes?: number;
+  /** Localized labels keyed by state: `downloading` | `completed` | `failed` | `queued`. */
+  labels: Record<string, string>;
+}
+
 export interface BackgroundDownloaderModuleType {
-  startDownload(url: string, destinationPath?: string): Promise<number>;
-  enqueueDownload(url: string, destinationPath?: string): Promise<number>;
+  startDownload(
+    url: string,
+    destinationPath?: string,
+    metadata?: DownloadActivityMetadata,
+  ): Promise<number>;
+  enqueueDownload(
+    url: string,
+    destinationPath?: string,
+    metadata?: DownloadActivityMetadata,
+  ): Promise<number>;
   cancelDownload(taskId: number): void;
   cancelQueuedDownload(url: string): void;
   cancelAllDownloads(): void;
   getActiveDownloads(): Promise<ActiveDownload[]>;
+  /** iOS only — absent from the Android module. */
+  setLiveActivityEnabled?(enabled: boolean): void;
+  /** iOS only — absent from the Android module. */
+  getLiveActivityDirectory?(): string | null;
   addListener(
     eventName: string,
     listener: (event: any) => void,

--- a/modules/background-downloader/src/BackgroundDownloader.types.ts
+++ b/modules/background-downloader/src/BackgroundDownloader.types.ts
@@ -31,6 +31,16 @@ export interface DownloadStartedEvent {
   itemId?: string;
 }
 
+/**
+ * iOS only: the user stopped the downloads from the system task UI (heuristically detected — see
+ * the keeper's user-stop window). One event per cancelled download, active and queued alike.
+ */
+export interface DownloadCancelledEvent {
+  /** `-1` for downloads that were still queued. */
+  taskId: number;
+  itemId?: string;
+}
+
 export interface ActiveDownload {
   /** Native task id; `-1` for queued entries, which have no task yet. */
   taskId: number;

--- a/modules/background-downloader/src/BackgroundDownloader.types.ts
+++ b/modules/background-downloader/src/BackgroundDownloader.types.ts
@@ -31,16 +31,6 @@ export interface DownloadStartedEvent {
   itemId?: string;
 }
 
-/**
- * iOS only: the user stopped the downloads from the system task UI (heuristically detected — see
- * the keeper's user-stop window). One event per cancelled download, active and queued alike.
- */
-export interface DownloadCancelledEvent {
-  /** `-1` for downloads that were still queued. */
-  taskId: number;
-  itemId?: string;
-}
-
 export interface ActiveDownload {
   /** Native task id; `-1` for queued entries, which have no task yet. */
   taskId: number;

--- a/modules/background-downloader/src/BackgroundDownloader.types.ts
+++ b/modules/background-downloader/src/BackgroundDownloader.types.ts
@@ -5,28 +5,38 @@ export interface DownloadProgressEvent {
   bytesWritten: number;
   totalBytes: number;
   progress: number;
+  /** Jellyfin item id, echoed from the metadata passed at enqueue time (absent without metadata). */
+  itemId?: string;
 }
 
 export interface DownloadCompleteEvent {
   taskId: number;
   filePath: string;
   url: string;
+  /** Jellyfin item id, echoed from the metadata passed at enqueue time (absent without metadata). */
+  itemId?: string;
 }
 
 export interface DownloadErrorEvent {
   taskId: number;
   error: string;
+  /** Jellyfin item id, echoed from the metadata passed at enqueue time (absent without metadata). */
+  itemId?: string;
 }
 
 export interface DownloadStartedEvent {
   taskId: number;
   url: string;
+  /** Jellyfin item id, echoed from the metadata passed at enqueue time (absent without metadata). */
+  itemId?: string;
 }
 
 export interface ActiveDownload {
   taskId: number;
   url: string;
-  state: "running" | "suspended" | "canceling" | "completed" | "unknown";
+  /** Jellyfin item id, echoed from the metadata passed at enqueue time (absent without metadata). */
+  itemId?: string;
+  destinationPath?: string;
 }
 
 /**

--- a/modules/background-downloader/src/BackgroundDownloader.types.ts
+++ b/modules/background-downloader/src/BackgroundDownloader.types.ts
@@ -32,11 +32,14 @@ export interface DownloadStartedEvent {
 }
 
 export interface ActiveDownload {
+  /** Native task id; `-1` for queued entries, which have no task yet. */
   taskId: number;
   url: string;
   /** Jellyfin item id, echoed from the metadata passed at enqueue time (absent without metadata). */
   itemId?: string;
   destinationPath?: string;
+  /** `running` for the transfer in flight, `queued` for entries waiting behind it. */
+  state?: "running" | "queued";
 }
 
 /**

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -1,7 +1,6 @@
 // Background Downloader
 export type {
   ActiveDownload,
-  DownloadCancelledEvent,
   DownloadCompleteEvent,
   DownloadErrorEvent,
   DownloadProgressEvent,

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -1,6 +1,7 @@
 // Background Downloader
 export type {
   ActiveDownload,
+  DownloadCancelledEvent,
   DownloadCompleteEvent,
   DownloadErrorEvent,
   DownloadProgressEvent,

--- a/plugins/withDownloadLiveActivity.ts
+++ b/plugins/withDownloadLiveActivity.ts
@@ -1,0 +1,206 @@
+import type { ExpoConfig } from "expo/config";
+import {
+  type ConfigPlugin,
+  withEntitlementsPlist,
+  withInfoPlist,
+  withXcodeProject,
+} from "expo/config-plugins";
+
+const EXTENSION_TARGET_NAME = "StreamyfinDownloadActivity";
+const TARGET_SOURCE_DIR = "../targets/StreamyfinDownloadActivity";
+// The ActivityAttributes declaration is shared with the app, where it is compiled into the
+// BackgroundDownloader pod. ActivityKit matches on the unqualified type name, so both targets
+// compiling the same file into different Swift modules is fine — and is Apple's documented approach.
+const SHARED_ATTRIBUTES_SOURCE =
+  "../modules/background-downloader/ios/DownloadActivityAttributes.swift";
+const APP_GROUP_INFO_PLIST_KEY = "StreamyfinDownloadsAppGroupIdentifier";
+
+interface AppExtensionConfig {
+  targetName: string;
+  bundleIdentifier: string;
+  entitlements: {
+    "com.apple.security.application-groups": string[];
+  };
+}
+
+function getBundleIdentifier(config: ExpoConfig): string {
+  return config.ios?.bundleIdentifier || "com.fredrikburmester.streamyfin";
+}
+
+function getAppGroupIdentifier(config: ExpoConfig): string {
+  return `group.${getBundleIdentifier(config)}.downloads`;
+}
+
+// The xcode project object has no usable typings — keep `any` here.
+function getBuildConfigurations(project: any, configurationListId: string) {
+  const configurationList =
+    project.hash.project.objects.XCConfigurationList[configurationListId];
+
+  if (!configurationList?.buildConfigurations) return [];
+
+  const buildConfigurations = project.pbxXCBuildConfigurationSection();
+  return configurationList.buildConfigurations
+    .map((config: { value: string }) => buildConfigurations[config.value])
+    .filter(Boolean);
+}
+
+function ensureAppGroup(value: unknown, appGroupIdentifier: string): string[] {
+  const groups = Array.isArray(value) ? value : [];
+  return groups.includes(appGroupIdentifier)
+    ? groups
+    : [...groups, appGroupIdentifier];
+}
+
+function ensureAppExtension(
+  appExtensions: unknown,
+  targetName: string,
+  bundleIdentifier: string,
+  appGroupIdentifier: string,
+): AppExtensionConfig[] {
+  const extensionConfig: AppExtensionConfig = {
+    targetName,
+    bundleIdentifier,
+    entitlements: {
+      "com.apple.security.application-groups": [appGroupIdentifier],
+    },
+  };
+  const extensions: AppExtensionConfig[] = Array.isArray(appExtensions)
+    ? appExtensions
+    : [];
+  // Keep plugin runs idempotent and preserve unrelated app extension entries.
+  const existingIndex = extensions.findIndex(
+    (appExtension) => appExtension?.targetName === targetName,
+  );
+
+  if (existingIndex === -1) {
+    return [...extensions, extensionConfig];
+  }
+
+  return extensions.map((appExtension, index) =>
+    index === existingIndex ? extensionConfig : appExtension,
+  );
+}
+
+/**
+ * Adds the WidgetKit extension that renders the download Live Activity.
+ *
+ * Phone-only: tvOS has no ActivityKit, and the whole downloads feature is disabled there anyway
+ * (see the TV no-op branch in providers/DownloadProvider.tsx). This mirrors withTVUserManagement.ts
+ * and withTVOSTopShelf.ts, which gate the other way on the same env var.
+ */
+const withDownloadLiveActivity: ConfigPlugin = (config) => {
+  if (process.env.EXPO_TV === "1") {
+    return config;
+  }
+
+  const appGroupIdentifier = getAppGroupIdentifier(config);
+  const bundleIdentifier = getBundleIdentifier(config);
+  const extensionBundleIdentifier = `${bundleIdentifier}.downloadactivity`;
+
+  config.extra = {
+    ...config.extra,
+    eas: {
+      ...config.extra?.eas,
+      build: {
+        ...config.extra?.eas?.build,
+        experimental: {
+          ...config.extra?.eas?.build?.experimental,
+          ios: {
+            ...config.extra?.eas?.build?.experimental?.ios,
+            appExtensions: ensureAppExtension(
+              config.extra?.eas?.build?.experimental?.ios?.appExtensions,
+              EXTENSION_TARGET_NAME,
+              extensionBundleIdentifier,
+              appGroupIdentifier,
+            ),
+          },
+        },
+      },
+    },
+  };
+
+  config = withInfoPlist(config, (config) => {
+    config.modResults[APP_GROUP_INFO_PLIST_KEY] = appGroupIdentifier;
+    return config;
+  });
+
+  config = withEntitlementsPlist(config, (config) => {
+    config.modResults["com.apple.security.application-groups"] = ensureAppGroup(
+      config.modResults["com.apple.security.application-groups"],
+      appGroupIdentifier,
+    );
+    return config;
+  });
+
+  return withXcodeProject(config, (config) => {
+    const project = config.modResults;
+
+    if (project.pbxTargetByName(EXTENSION_TARGET_NAME)) {
+      return config;
+    }
+
+    const mainTargetUuid = project.getFirstTarget().uuid;
+
+    // `addTarget` with "app_extension" also creates the Copy Files phase on the app target and adds
+    // the .appex product to it, so the extension is embedded without extra work here.
+    const target = project.addTarget(
+      EXTENSION_TARGET_NAME,
+      "app_extension",
+      EXTENSION_TARGET_NAME,
+      extensionBundleIdentifier,
+    );
+
+    project.addBuildPhase(
+      [
+        `${TARGET_SOURCE_DIR}/StreamyfinDownloadActivityBundle.swift`,
+        `${TARGET_SOURCE_DIR}/DownloadActivityWidget.swift`,
+        SHARED_ATTRIBUTES_SOURCE,
+      ],
+      "PBXSourcesBuildPhase",
+      "Sources",
+      target.uuid,
+    );
+    project.addBuildPhase(
+      ["WidgetKit.framework", "SwiftUI.framework", "ActivityKit.framework"],
+      "PBXFrameworksBuildPhase",
+      "Frameworks",
+      target.uuid,
+    );
+
+    // Embedding alone leaves ordering to implicit dependency resolution; make it explicit so the
+    // .appex is always built before the app tries to copy it.
+    project.addTargetDependency(mainTargetUuid, [target.uuid]);
+
+    const buildConfigurations = getBuildConfigurations(
+      project,
+      target.pbxNativeTarget.buildConfigurationList,
+    );
+
+    for (const buildConfig of buildConfigurations) {
+      buildConfig.buildSettings = {
+        ...buildConfig.buildSettings,
+        CODE_SIGN_ENTITLEMENTS: `${TARGET_SOURCE_DIR}/${EXTENSION_TARGET_NAME}.entitlements`,
+        APPLICATION_EXTENSION_API_ONLY: "YES",
+        CURRENT_PROJECT_VERSION: config.ios?.buildNumber || "1",
+        GENERATE_INFOPLIST_FILE: "NO",
+        INFOPLIST_FILE: `${TARGET_SOURCE_DIR}/Info.plist`,
+        // Live Activities need 16.2; the app already targets 16.4 via expo-build-properties.
+        IPHONEOS_DEPLOYMENT_TARGET:
+          buildConfig.buildSettings.IPHONEOS_DEPLOYMENT_TARGET || "16.4",
+        MARKETING_VERSION: config.version || "1.0",
+        PRODUCT_BUNDLE_IDENTIFIER: extensionBundleIdentifier,
+        PRODUCT_NAME: `"${EXTENSION_TARGET_NAME}"`,
+        SDKROOT: "iphoneos",
+        SKIP_INSTALL: "YES",
+        SWIFT_VERSION: "5.9",
+        DOWNLOADS_APP_GROUP_IDENTIFIER: appGroupIdentifier,
+        SUPPORTED_PLATFORMS: '"iphoneos iphonesimulator"',
+        TARGETED_DEVICE_FAMILY: '"1,2"',
+      };
+    }
+
+    return config;
+  });
+};
+
+export default withDownloadLiveActivity;

--- a/plugins/withDownloadLiveActivity.ts
+++ b/plugins/withDownloadLiveActivity.ts
@@ -121,6 +121,29 @@ const withDownloadLiveActivity: ConfigPlugin = (config) => {
 
   config = withInfoPlist(config, (config) => {
     config.modResults[APP_GROUP_INFO_PLIST_KEY] = appGroupIdentifier;
+
+    // iOS 26 continued processing task: keeps the app executing while a user-started download
+    // runs, so the Live Activity can show measured progress instead of a projection. The
+    // identifier must be declared here and prefixed with the bundle id.
+    const taskIdentifier = `${bundleIdentifier}.downloads`;
+    const permitted = Array.isArray(
+      config.modResults.BGTaskSchedulerPermittedIdentifiers,
+    )
+      ? (config.modResults.BGTaskSchedulerPermittedIdentifiers as string[])
+      : [];
+    if (!permitted.includes(taskIdentifier)) {
+      permitted.push(taskIdentifier);
+    }
+    config.modResults.BGTaskSchedulerPermittedIdentifiers = permitted;
+
+    const backgroundModes = Array.isArray(config.modResults.UIBackgroundModes)
+      ? (config.modResults.UIBackgroundModes as string[])
+      : [];
+    if (!backgroundModes.includes("processing")) {
+      backgroundModes.push("processing");
+    }
+    config.modResults.UIBackgroundModes = backgroundModes;
+
     return config;
   });
 

--- a/providers/DownloadProvider.tsx
+++ b/providers/DownloadProvider.tsx
@@ -7,7 +7,6 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useRef,
 } from "react";
 import { Platform } from "react-native";
 import { useHaptic } from "@/hooks/useHaptic";
@@ -21,6 +20,7 @@ import {
 import { getDownloadedItemSize } from "./Downloads/fileOperations";
 import { useDownloadEventHandlers } from "./Downloads/hooks/useDownloadEventHandlers";
 import { useDownloadOperations } from "./Downloads/hooks/useDownloadOperations";
+import { useDownloadReconciliation } from "./Downloads/hooks/useDownloadReconciliation";
 import { setDownloadLiveActivityEnabled } from "./Downloads/liveActivity";
 import type { JobStatus } from "./Downloads/types";
 import { apiAtom } from "./JellyfinProvider";
@@ -45,9 +45,6 @@ function useDownloadProvider() {
   useEffect(() => {
     setDownloadLiveActivityEnabled(liveActivityEnabled);
   }, [liveActivityEnabled]);
-
-  // Track task ID to process ID mapping
-  const taskMapRef = useRef<Map<number | string, string>>(new Map());
 
   // Reactive downloaded items that updates when refreshKey changes
   const downloadedItems = useMemo(() => {
@@ -103,13 +100,6 @@ function useDownloadProvider() {
       // Use setTimeout to defer removal and avoid race conditions during rendering
       setTimeout(() => {
         setProcesses((prev) => prev.filter((process) => process.id !== id));
-
-        // Find and remove from task map
-        taskMapRef.current.forEach((processId, taskId) => {
-          if (processId === id) {
-            taskMapRef.current.delete(taskId);
-          }
-        });
       }, 0);
     },
     [setProcesses],
@@ -117,13 +107,18 @@ function useDownloadProvider() {
 
   // Set up download event handlers
   useDownloadEventHandlers({
-    taskMapRef,
     processes,
     updateProcess,
     removeProcess,
     onSuccess: successHapticFeedback,
     onDataChange: triggerRefresh,
-    api: api || undefined,
+  });
+
+  // Settle downloads left over from a previous app session (finished while JS was dead,
+  // still transferring natively, or queued and lost with the process).
+  useDownloadReconciliation({
+    setProcesses,
+    onDataChange: triggerRefresh,
   });
 
   // Get download operation functions
@@ -136,7 +131,6 @@ function useDownloadProvider() {
     deleteFileByType,
     appSizeUsage,
   } = useDownloadOperations({
-    taskMapRef,
     processes,
     setProcesses,
     removeProcess,

--- a/providers/DownloadProvider.tsx
+++ b/providers/DownloadProvider.tsx
@@ -1,9 +1,17 @@
 import * as Application from "expo-application";
 import { Directory, Paths } from "expo-file-system";
 import { atom, useAtom } from "jotai";
-import { createContext, useCallback, useContext, useMemo, useRef } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { Platform } from "react-native";
 import { useHaptic } from "@/hooks/useHaptic";
+import { useSettings } from "@/utils/atoms/settings";
 import {
   getAllDownloadedItems,
   getDownloadedItemById,
@@ -13,6 +21,7 @@ import {
 import { getDownloadedItemSize } from "./Downloads/fileOperations";
 import { useDownloadEventHandlers } from "./Downloads/hooks/useDownloadEventHandlers";
 import { useDownloadOperations } from "./Downloads/hooks/useDownloadOperations";
+import { setDownloadLiveActivityEnabled } from "./Downloads/liveActivity";
 import type { JobStatus } from "./Downloads/types";
 import { apiAtom } from "./JellyfinProvider";
 
@@ -28,6 +37,14 @@ function useDownloadProvider() {
   const [processes, setProcesses] = useAtom<JobStatus[]>(processesAtom);
   const [refreshKey, setRefreshKey] = useAtom(downloadsRefreshAtom);
   const successHapticFeedback = useHaptic("success");
+  const { settings } = useSettings();
+
+  // Native owns the Live Activity, so the preference has to be pushed across rather than read at
+  // the point of use — the URLSession delegate runs when JS does not.
+  const liveActivityEnabled = settings?.showDownloadLiveActivity ?? true;
+  useEffect(() => {
+    setDownloadLiveActivityEnabled(liveActivityEnabled);
+  }, [liveActivityEnabled]);
 
   // Track task ID to process ID mapping
   const taskMapRef = useRef<Map<number | string, string>>(new Map());

--- a/providers/Downloads/hooks/useDownloadEventHandlers.ts
+++ b/providers/Downloads/hooks/useDownloadEventHandlers.ts
@@ -2,6 +2,7 @@ import { File } from "expo-file-system";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type {
+  DownloadCancelledEvent,
   DownloadCompleteEvent,
   DownloadErrorEvent,
   DownloadProgressEvent,
@@ -279,4 +280,23 @@ export function useDownloadEventHandlers({
 
     return () => errorSub.remove();
   }, [updateProcess, removeProcess, t]);
+
+  // Handle system-UI stop taps (iOS only): the user cancelled from the continued-processing task
+  // pill. Native has already cancelled the transfers and cleared its queue; settle our records
+  // quietly — no error notification, this was an intentional user action.
+  useEffect(() => {
+    const cancelledSub = BackgroundDownloader.addCancelledListener(
+      (event: DownloadCancelledEvent) => {
+        const itemId = event.itemId;
+        if (!itemId || !getPendingDownload(itemId)) return;
+
+        console.log(`[DPL] Cancelled from system UI: ${itemId.slice(0, 8)}...`);
+        removePendingDownload(itemId);
+        clearSpeedData(itemId);
+        removeProcess(itemId);
+      },
+    );
+
+    return () => cancelledSub.remove();
+  }, [removeProcess]);
 }

--- a/providers/Downloads/hooks/useDownloadEventHandlers.ts
+++ b/providers/Downloads/hooks/useDownloadEventHandlers.ts
@@ -2,7 +2,6 @@ import { File } from "expo-file-system";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type {
-  DownloadCancelledEvent,
   DownloadCompleteEvent,
   DownloadErrorEvent,
   DownloadProgressEvent,
@@ -280,23 +279,4 @@ export function useDownloadEventHandlers({
 
     return () => errorSub.remove();
   }, [updateProcess, removeProcess, t]);
-
-  // Handle system-UI stop taps (iOS only): the user cancelled from the continued-processing task
-  // pill. Native has already cancelled the transfers and cleared its queue; settle our records
-  // quietly — no error notification, this was an intentional user action.
-  useEffect(() => {
-    const cancelledSub = BackgroundDownloader.addCancelledListener(
-      (event: DownloadCancelledEvent) => {
-        const itemId = event.itemId;
-        if (!itemId || !getPendingDownload(itemId)) return;
-
-        console.log(`[DPL] Cancelled from system UI: ${itemId.slice(0, 8)}...`);
-        removePendingDownload(itemId);
-        clearSpeedData(itemId);
-        removeProcess(itemId);
-      },
-    );
-
-    return () => cancelledSub.remove();
-  }, [removeProcess]);
 }

--- a/providers/Downloads/hooks/useDownloadEventHandlers.ts
+++ b/providers/Downloads/hooks/useDownloadEventHandlers.ts
@@ -1,6 +1,4 @@
-import type { Api } from "@jellyfin/sdk";
 import { File } from "expo-file-system";
-import type { MutableRefObject } from "react";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type {
@@ -10,13 +8,18 @@ import type {
   DownloadStartedEvent,
 } from "@/modules";
 import { BackgroundDownloader } from "@/modules";
-import { addDownloadedItem } from "../database";
 import {
   getNotificationContent,
   sendDownloadNotification,
 } from "../notifications";
-import type { DownloadedItem, JobStatus } from "../types";
-import { filePathToUri, generateFilename } from "../utils";
+import {
+  finalizePendingDownload,
+  getPendingDownload,
+  removePendingDownload,
+  updatePendingDownload,
+} from "../pendingDownloads";
+import type { JobStatus } from "../types";
+import { filePathToUri } from "../utils";
 import {
   addSpeedDataPoint,
   calculateWeightedSpeed,
@@ -24,7 +27,6 @@ import {
 } from "./useDownloadSpeedCalculator";
 
 interface UseDownloadEventHandlersProps {
-  taskMapRef: MutableRefObject<Map<number | string, string>>;
   processes: JobStatus[];
   updateProcess: (
     processId: string,
@@ -33,20 +35,23 @@ interface UseDownloadEventHandlersProps {
   removeProcess: (id: string) => void;
   onSuccess?: () => void;
   onDataChange?: () => void;
-  api?: Api;
 }
 
 /**
- * Hook to set up download event listeners (progress, complete, error, started)
+ * Hook to set up download event listeners (progress, complete, error, started).
+ *
+ * Events are correlated by the `itemId` native echoes back from the metadata passed at enqueue
+ * time — no taskId bookkeeping in JS. Events without an `itemId` are not ours (e.g. AudioStorage
+ * downloads, which keep their own taskId map) and are ignored. Completion is finalized from the
+ * persisted pending record rather than in-memory state, so it also works when the download was
+ * enqueued by a previous app session.
  */
 export function useDownloadEventHandlers({
-  taskMapRef,
   processes,
   updateProcess,
   removeProcess,
   onSuccess,
   onDataChange,
-  api,
 }: UseDownloadEventHandlersProps) {
   const { t } = useTranslation();
 
@@ -54,46 +59,19 @@ export function useDownloadEventHandlers({
   useEffect(() => {
     const startedSub = BackgroundDownloader.addStartedListener(
       (event: DownloadStartedEvent) => {
-        let processId = taskMapRef.current.get(event.taskId);
+        const itemId = event.itemId;
+        if (!itemId || !getPendingDownload(itemId)) return;
 
-        // If no mapping exists, find by URL (for queued downloads)
-        if (!processId && event.url) {
-          // Check if we have a URL mapping (queued download)
-          const urlKey = event.url;
-          processId = taskMapRef.current.get(urlKey);
-
-          if (!processId) {
-            // Fallback: search by matching URL in processes
-            const matchingProcess = processes.find(
-              (p) => p.inputUrl === event.url,
-            );
-            if (matchingProcess) {
-              processId = matchingProcess.id;
-            }
-          }
-
-          if (processId) {
-            // Create taskId mapping and remove URL mapping
-            taskMapRef.current.set(event.taskId, processId);
-            taskMapRef.current.delete(urlKey);
-            console.log(
-              `[DPL] Mapped queued download: taskId=${event.taskId} to processId=${processId.slice(0, 8)}...`,
-            );
-          }
-        }
-
-        if (processId) {
-          updateProcess(processId, { startTime: new Date() });
-        } else {
-          console.warn(
-            `[DPL] Started event for unknown download: taskId=${event.taskId}, url=${event.url}`,
-          );
-        }
+        updatePendingDownload(itemId, {
+          status: "downloading",
+          taskId: event.taskId,
+        });
+        updateProcess(itemId, { status: "downloading", startTime: new Date() });
       },
     );
 
     return () => startedSub.remove();
-  }, [taskMapRef, updateProcess, processes]);
+  }, [updateProcess]);
 
   // Track last logged progress per process to avoid spam
   const lastLoggedProgress = useRef<Map<string, number>>(new Map());
@@ -102,7 +80,7 @@ export function useDownloadEventHandlers({
   useEffect(() => {
     const progressSub = BackgroundDownloader.addProgressListener(
       (event: DownloadProgressEvent) => {
-        const processId = taskMapRef.current.get(event.taskId);
+        const processId = event.itemId;
         if (!processId) {
           return;
         }
@@ -197,65 +175,45 @@ export function useDownloadEventHandlers({
     );
 
     return () => progressSub.remove();
-  }, [taskMapRef, updateProcess, processes]);
+  }, [updateProcess, processes]);
 
   // Handle download completion events
   useEffect(() => {
     const completeSub = BackgroundDownloader.addCompleteListener(
       async (event: DownloadCompleteEvent) => {
-        const processId = taskMapRef.current.get(event.taskId);
-        if (!processId) return;
+        const itemId = event.itemId;
+        if (!itemId) return;
 
-        const process = processes.find((p) => p.id === processId);
-        if (!process) return;
+        const record = getPendingDownload(itemId);
+        if (!record) return;
 
         try {
-          const {
-            item,
-            mediaSource,
-            trickPlayData,
-            introSegments,
-            creditSegments,
-            audioStreamIndex,
-            subtitleStreamIndex,
-            isTranscoding,
-          } = process;
           const videoFile = new File(filePathToUri(event.filePath));
-          const fileInfo = videoFile.info();
-          const videoFileSize = fileInfo.size || 0;
-          const filename = generateFilename(item);
+          const videoFileSize = videoFile.info().size || 0;
 
           console.log(
-            `[COMPLETE] Video download complete (${videoFileSize} bytes) for ${item.Name}`,
-          );
-          console.log(
-            `[COMPLETE] Using pre-downloaded assets: trickplay=${!!trickPlayData}, intro=${!!introSegments}, credits=${!!creditSegments}`,
+            `[COMPLETE] Video download complete (${videoFileSize} bytes) for ${record.item.Name}`,
           );
 
-          const downloadedItem: DownloadedItem = {
-            item,
-            mediaSource,
-            videoFilePath: filePathToUri(event.filePath),
+          // In-memory process may carry a live isTranscoding signal derived from progress events;
+          // finalize falls back to the media source when it is gone (e.g. after a relaunch).
+          const process = processes.find((p) => p.id === itemId);
+          finalizePendingDownload(
+            record,
             videoFileSize,
-            videoFileName: `${filename}.mp4`,
-            trickPlayData,
-            introSegments,
-            creditSegments,
-            userData: {
-              audioStreamIndex: audioStreamIndex ?? 0,
-              subtitleStreamIndex: subtitleStreamIndex ?? -1,
-              isTranscoded: isTranscoding ?? false,
-            },
-          };
+            process?.isTranscoding,
+          );
 
-          addDownloadedItem(downloadedItem);
-
-          updateProcess(processId, {
+          updateProcess(itemId, {
             status: "completed",
             progress: 100,
           });
 
-          const notificationContent = getNotificationContent(item, true, t);
+          const notificationContent = getNotificationContent(
+            record.item,
+            true,
+            t,
+          );
           await sendDownloadNotification(
             notificationContent.title,
             notificationContent.body,
@@ -265,52 +223,45 @@ export function useDownloadEventHandlers({
           onDataChange?.();
 
           // Clean up speed data when download completes
-          clearSpeedData(processId);
+          clearSpeedData(itemId);
 
           // Remove process after short delay
           setTimeout(() => {
-            removeProcess(processId);
+            removeProcess(itemId);
           }, 2000);
         } catch (error) {
           console.error("Error handling download completion:", error);
-          updateProcess(processId, { status: "error" });
-          clearSpeedData(processId);
-          removeProcess(processId);
+          removePendingDownload(itemId);
+          updateProcess(itemId, { status: "error" });
+          clearSpeedData(itemId);
+          removeProcess(itemId);
         }
       },
     );
 
     return () => completeSub.remove();
-  }, [
-    taskMapRef,
-    processes,
-    updateProcess,
-    removeProcess,
-    onSuccess,
-    onDataChange,
-    api,
-    t,
-  ]);
+  }, [processes, updateProcess, removeProcess, onSuccess, onDataChange, t]);
 
   // Handle download error events
   useEffect(() => {
     const errorSub = BackgroundDownloader.addErrorListener(
       async (event: DownloadErrorEvent) => {
-        const processId = taskMapRef.current.get(event.taskId);
-        if (!processId) return;
+        const itemId = event.itemId;
+        if (!itemId) return;
 
-        const process = processes.find((p) => p.id === processId);
-        if (!process) return;
+        const record = getPendingDownload(itemId);
+        if (!record) return;
 
-        console.error(`Download error for ${processId}:`, event.error);
+        console.error(`Download error for ${itemId}:`, event.error);
 
-        updateProcess(processId, { status: "error" });
+        removePendingDownload(itemId);
+        updateProcess(itemId, { status: "error" });
 
         // Clean up speed data
-        clearSpeedData(processId);
+        clearSpeedData(itemId);
 
         const notificationContent = getNotificationContent(
-          process.item,
+          record.item,
           false,
           t,
         );
@@ -321,11 +272,11 @@ export function useDownloadEventHandlers({
 
         // Remove process after short delay
         setTimeout(() => {
-          removeProcess(processId);
+          removeProcess(itemId);
         }, 3000);
       },
     );
 
     return () => errorSub.remove();
-  }, [taskMapRef, processes, updateProcess, removeProcess, t]);
+  }, [updateProcess, removeProcess, t]);
 }

--- a/providers/Downloads/hooks/useDownloadOperations.ts
+++ b/providers/Downloads/hooks/useDownloadOperations.ts
@@ -3,7 +3,6 @@ import type {
   MediaSourceInfo,
 } from "@jellyfin/sdk/lib/generated-client/models";
 import { File, Paths } from "expo-file-system";
-import type { MutableRefObject } from "react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import DeviceInfo from "react-native-device-info";
@@ -24,11 +23,16 @@ import {
   deleteAllAssociatedFiles,
 } from "../fileOperations";
 import { buildDownloadActivityMetadata } from "../liveActivity";
+import {
+  getPendingDownload,
+  removePendingDownload,
+  savePendingDownload,
+  updatePendingDownload,
+} from "../pendingDownloads";
 import type { JobStatus } from "../types";
 import { generateFilename, uriToFilePath } from "../utils";
 
 interface UseDownloadOperationsProps {
-  taskMapRef: MutableRefObject<Map<number | string, string>>;
   processes: JobStatus[];
   setProcesses: (updater: (prev: JobStatus[]) => JobStatus[]) => void;
   removeProcess: (id: string) => void;
@@ -41,7 +45,6 @@ interface UseDownloadOperationsProps {
  * Hook providing download operation functions (start, cancel, delete)
  */
 export function useDownloadOperations({
-  taskMapRef,
   processes,
   setProcesses,
   removeProcess,
@@ -71,9 +74,9 @@ export function useDownloadOperations({
         const deviceId = getOrSetDeviceId();
         const processId = item.Id;
 
-        // Check if already downloading
+        // Check if already downloading — in-memory process or persisted pending record
         const existingProcess = processes.find((p) => p.id === processId);
-        if (existingProcess) {
+        if (existingProcess || getPendingDownload(processId)) {
           toast.info(
             t("home.downloads.toasts.item_already_downloading", {
               item: item.Name,
@@ -126,15 +129,17 @@ export function useDownloadOperations({
 
         // Generate destination path
         const filename = generateFilename(item);
-        const videoFile = new File(Paths.document, `${filename}.mp4`);
+        const videoFileName = `${filename}.mp4`;
+        const videoFile = new File(Paths.document, videoFileName);
         const destinationPath = uriToFilePath(videoFile.uri);
 
         console.log(`[DOWNLOAD] Starting video: ${item.Name}`);
         console.log(`[DOWNLOAD] Download URL: ${downloadUrl}`);
 
-        // iOS Live Activity payload. Native drives the activity from the URLSession delegate, so
-        // everything it renders — including the poster file — has to be resolved before we enqueue.
-        // Never let this block the download itself.
+        // Download metadata for native: drives the iOS Live Activity, and its itemId is echoed
+        // back in every download event on both platforms — it is how events find their way back
+        // here without any taskId bookkeeping. Poster staging can fail; itemId must not, so a
+        // minimal payload is always produced.
         let activityMetadata: Awaited<
           ReturnType<typeof buildDownloadActivityMetadata>
         >;
@@ -150,6 +155,32 @@ export function useDownloadOperations({
         } catch (error) {
           console.warn("[DOWNLOAD] Live Activity metadata failed:", error);
         }
+        activityMetadata ??= {
+          itemId: item.Id,
+          title: item.Name ?? "",
+          subtitle: "",
+          labels: {},
+        };
+
+        // Persist the pending record BEFORE handing the download to native, so there is no window
+        // where a transfer exists that a later app session cannot account for.
+        savePendingDownload({
+          itemId: processId,
+          status: "queued",
+          enqueuedAt: new Date().toISOString(),
+          inputUrl: downloadUrl,
+          videoFileName,
+          item,
+          mediaSource: additionalAssets.updatedMediaSource,
+          maxBitrate,
+          deviceId,
+          trickPlayData: additionalAssets.trickPlayData,
+          introSegments: additionalAssets.introSegments,
+          creditSegments: additionalAssets.creditSegments,
+          audioStreamIndex,
+          subtitleStreamIndex,
+          activityMetadata,
+        });
 
         // Start the download using enqueueDownload for sequential processing
         const taskId = await BackgroundDownloader.enqueueDownload(
@@ -158,13 +189,11 @@ export function useDownloadOperations({
           activityMetadata,
         );
 
-        // Map task ID or URL for later cancellation
         if (taskId !== -1) {
-          taskMapRef.current.set(taskId, processId);
-        } else {
-          // For queued downloads, store a negative mapping using URL hash
-          // This allows us to cancel queued downloads by URL
-          taskMapRef.current.set(downloadUrl, processId);
+          updatePendingDownload(processId, {
+            status: "downloading",
+            taskId,
+          });
         }
 
         toast.success(
@@ -174,45 +203,36 @@ export function useDownloadOperations({
         );
       } catch (error) {
         console.error("Failed to start download:", error);
+        if (item.Id) {
+          removePendingDownload(item.Id);
+          removeProcess(item.Id);
+        }
         toast.error(t("home.downloads.toasts.failed_to_start_download"), {
           description: error instanceof Error ? error.message : "Unknown error",
         });
         throw error;
       }
     },
-    [api, authHeader, processes, setProcesses, taskMapRef, t],
+    [api, authHeader, processes, setProcesses, removeProcess, t],
   );
 
   const cancelDownload = useCallback(
     async (id: string) => {
-      // Find the task ID or URL for this process
-      let taskId: number | undefined;
-      let downloadUrl: string | undefined;
+      const record = getPendingDownload(id);
 
-      taskMapRef.current.forEach((pId, key) => {
-        if (pId === id) {
-          if (typeof key === "number") {
-            taskId = key;
-          } else {
-            downloadUrl = key as string;
-          }
-        }
-      });
-
-      if (taskId !== undefined) {
+      if (record?.status === "downloading" && record.taskId !== undefined) {
         // Cancel active download by taskId
-        BackgroundDownloader.cancelDownload(taskId);
-        taskMapRef.current.delete(taskId);
-      } else if (downloadUrl !== undefined) {
-        // Cancel queued download by URL
-        BackgroundDownloader.cancelQueuedDownload(downloadUrl);
-        taskMapRef.current.delete(downloadUrl);
+        BackgroundDownloader.cancelDownload(record.taskId);
+      } else if (record) {
+        // Still queued natively — cancel by URL
+        BackgroundDownloader.cancelQueuedDownload(record.inputUrl);
       }
 
+      removePendingDownload(id);
       removeProcess(id);
       toast.info(t("home.downloads.toasts.download_cancelled"));
     },
-    [taskMapRef, removeProcess, t],
+    [removeProcess, t],
   );
 
   const deleteFile = useCallback(

--- a/providers/Downloads/hooks/useDownloadOperations.ts
+++ b/providers/Downloads/hooks/useDownloadOperations.ts
@@ -12,7 +12,7 @@ import type { Bitrate } from "@/components/BitrateSelector";
 import useImageStorage from "@/hooks/useImageStorage";
 import { BackgroundDownloader } from "@/modules";
 import { getOrSetDeviceId } from "@/utils/device";
-import useDownloadHelper from "@/utils/download";
+import useDownloadHelper, { estimateDownloadSize } from "@/utils/download";
 import { downloadAdditionalAssets } from "../additionalDownloads";
 import {
   clearAllDownloadedItems,
@@ -23,6 +23,7 @@ import {
   calculateTotalDownloadedSize,
   deleteAllAssociatedFiles,
 } from "../fileOperations";
+import { buildDownloadActivityMetadata } from "../liveActivity";
 import type { JobStatus } from "../types";
 import { generateFilename, uriToFilePath } from "../utils";
 
@@ -131,10 +132,30 @@ export function useDownloadOperations({
         console.log(`[DOWNLOAD] Starting video: ${item.Name}`);
         console.log(`[DOWNLOAD] Download URL: ${downloadUrl}`);
 
+        // iOS Live Activity payload. Native drives the activity from the URLSession delegate, so
+        // everything it renders — including the poster file — has to be resolved before we enqueue.
+        // Never let this block the download itself.
+        let activityMetadata: Awaited<
+          ReturnType<typeof buildDownloadActivityMetadata>
+        >;
+        try {
+          activityMetadata = await buildDownloadActivityMetadata({
+            item,
+            api,
+            t,
+            estimatedTotalBytes: maxBitrate.value
+              ? estimateDownloadSize(maxBitrate.value, item.RunTimeTicks)
+              : undefined,
+          });
+        } catch (error) {
+          console.warn("[DOWNLOAD] Live Activity metadata failed:", error);
+        }
+
         // Start the download using enqueueDownload for sequential processing
         const taskId = await BackgroundDownloader.enqueueDownload(
           downloadUrl,
           destinationPath,
+          activityMetadata,
         );
 
         // Map task ID or URL for later cancellation

--- a/providers/Downloads/hooks/useDownloadReconciliation.ts
+++ b/providers/Downloads/hooks/useDownloadReconciliation.ts
@@ -1,0 +1,159 @@
+import { File, Paths } from "expo-file-system";
+import { useEffect } from "react";
+import { Platform } from "react-native";
+import type { ActiveDownload } from "@/modules";
+import { BackgroundDownloader } from "@/modules";
+import {
+  finalizePendingDownload,
+  getPendingDownload,
+  getPendingDownloads,
+  type PendingDownload,
+  removePendingDownload,
+  updatePendingDownload,
+} from "../pendingDownloads";
+import type { JobStatus } from "../types";
+import { uriToFilePath } from "../utils";
+
+interface UseDownloadReconciliationProps {
+  setProcesses: (updater: (prev: JobStatus[]) => JobStatus[]) => void;
+  onDataChange?: () => void;
+}
+
+// Once per JS runtime, not per provider mount — remounts must not re-enqueue anything.
+let hasReconciled = false;
+
+function jobFromRecord(
+  record: PendingDownload,
+  status: "queued" | "downloading",
+): JobStatus {
+  return {
+    id: record.itemId,
+    inputUrl: record.inputUrl,
+    item: record.item,
+    itemId: record.itemId,
+    deviceId: record.deviceId,
+    progress: 0,
+    status,
+    timestamp: new Date(),
+    mediaSource: record.mediaSource,
+    maxBitrate: record.maxBitrate,
+    bytesDownloaded: 0,
+    trickPlayData: record.trickPlayData,
+    introSegments: record.introSegments,
+    creditSegments: record.creditSegments,
+    audioStreamIndex: record.audioStreamIndex,
+    subtitleStreamIndex: record.subtitleStreamIndex,
+  };
+}
+
+/**
+ * Settles pending download records left behind by a previous JS runtime.
+ *
+ * The native layer keeps transferring after the app dies and moves the finished file into place on
+ * relaunch — but it cannot write the downloads database. On startup each persisted record is
+ * matched against reality:
+ *
+ * - task still running natively → resurrect the UI process; progress events flow again
+ * - video file exists → the download finished while JS was dead; finalize it into the database
+ * - never started (`queued`) → the native in-memory queue died with the process; re-enqueue it
+ * - started but no task and no file → genuinely lost (e.g. force-quit cancels background
+ *   transfers); drop the record
+ */
+export function useDownloadReconciliation({
+  setProcesses,
+  onDataChange,
+}: UseDownloadReconciliationProps) {
+  useEffect(() => {
+    if (Platform.isTV || hasReconciled) return;
+    hasReconciled = true;
+
+    (async () => {
+      const pending = getPendingDownloads();
+      if (pending.length === 0) return;
+
+      let active: ActiveDownload[] = [];
+      try {
+        active = await BackgroundDownloader.getActiveDownloads();
+      } catch (error) {
+        console.warn("[RECONCILE] Failed to query native downloads:", error);
+      }
+      const activeByItemId = new Map(
+        active
+          .filter((download) => download.itemId)
+          .map((download) => [download.itemId as string, download]),
+      );
+
+      const restored: JobStatus[] = [];
+
+      for (const record of pending) {
+        const nativeTask = activeByItemId.get(record.itemId);
+
+        if (nativeTask) {
+          console.log(`[RECONCILE] Still downloading: ${record.item.Name}`);
+          updatePendingDownload(record.itemId, {
+            status: "downloading",
+            taskId: nativeTask.taskId,
+          });
+          restored.push(jobFromRecord(record, "downloading"));
+          continue;
+        }
+
+        const file = new File(Paths.document, record.videoFileName);
+        if (file.exists && (file.size ?? 0) > 0) {
+          console.log(
+            `[RECONCILE] Completed while app was dead: ${record.item.Name}`,
+          );
+          finalizePendingDownload(record, file.size ?? 0);
+          onDataChange?.();
+          continue;
+        }
+
+        if (record.status === "queued") {
+          console.log(`[RECONCILE] Re-enqueueing: ${record.item.Name}`);
+          try {
+            const destinationPath = uriToFilePath(
+              new File(Paths.document, record.videoFileName).uri,
+            );
+            const taskId = await BackgroundDownloader.enqueueDownload(
+              record.inputUrl,
+              destinationPath,
+              record.activityMetadata,
+            );
+            if (taskId !== -1) {
+              updatePendingDownload(record.itemId, {
+                status: "downloading",
+                taskId,
+              });
+            }
+            restored.push(jobFromRecord(record, "queued"));
+          } catch (error) {
+            console.warn(
+              `[RECONCILE] Re-enqueue failed for ${record.item.Name}:`,
+              error,
+            );
+            removePendingDownload(record.itemId);
+          }
+          continue;
+        }
+
+        console.log(`[RECONCILE] Lost download dropped: ${record.item.Name}`);
+        removePendingDownload(record.itemId);
+      }
+
+      if (restored.length > 0) {
+        setProcesses((prev) => {
+          const known = new Set(prev.map((process) => process.id));
+          return [
+            ...prev,
+            // A completion event may have finalized (and removed) a record while the native query
+            // above was in flight — only restore processes whose record still exists.
+            ...restored.filter(
+              (process) =>
+                !known.has(process.id) && getPendingDownload(process.id),
+            ),
+          ];
+        });
+      }
+    })();
+  }, [setProcesses, onDataChange]);
+}

--- a/providers/Downloads/hooks/useDownloadReconciliation.ts
+++ b/providers/Downloads/hooks/useDownloadReconciliation.ts
@@ -54,8 +54,10 @@ function jobFromRecord(
  * matched against reality:
  *
  * - task still running natively → resurrect the UI process; progress events flow again
+ * - still queued natively (iOS persists its queue and re-arms it on launch) → resurrect the UI
+ *   process as queued; native starts it when its turn comes
  * - video file exists → the download finished while JS was dead; finalize it into the database
- * - never started (`queued`) → the native in-memory queue died with the process; re-enqueue it
+ * - never started (`queued`) and native lost it (Android process death) → re-enqueue as a backstop
  * - started but no task and no file → genuinely lost (e.g. force-quit cancels background
  *   transfers); drop the record
  */
@@ -77,7 +79,7 @@ export function useDownloadReconciliation({
       } catch (error) {
         console.warn("[RECONCILE] Failed to query native downloads:", error);
       }
-      const activeByItemId = new Map(
+      const nativeByItemId = new Map(
         active
           .filter((download) => download.itemId)
           .map((download) => [download.itemId as string, download]),
@@ -86,7 +88,13 @@ export function useDownloadReconciliation({
       const restored: JobStatus[] = [];
 
       for (const record of pending) {
-        const nativeTask = activeByItemId.get(record.itemId);
+        const nativeTask = nativeByItemId.get(record.itemId);
+
+        if (nativeTask?.state === "queued") {
+          console.log(`[RECONCILE] Still queued natively: ${record.item.Name}`);
+          restored.push(jobFromRecord(record, "queued"));
+          continue;
+        }
 
         if (nativeTask) {
           console.log(`[RECONCILE] Still downloading: ${record.item.Name}`);
@@ -109,6 +117,8 @@ export function useDownloadReconciliation({
         }
 
         if (record.status === "queued") {
+          // Backstop: native lost the queued item (Android queue dies with the process; on iOS
+          // this only fires if the persisted queue failed to restore).
           console.log(`[RECONCILE] Re-enqueueing: ${record.item.Name}`);
           try {
             const destinationPath = uriToFilePath(

--- a/providers/Downloads/index.ts
+++ b/providers/Downloads/index.ts
@@ -28,11 +28,22 @@ export {
 // Hooks
 export { useDownloadEventHandlers } from "./hooks/useDownloadEventHandlers";
 export { useDownloadOperations } from "./hooks/useDownloadOperations";
+export { useDownloadReconciliation } from "./hooks/useDownloadReconciliation";
 // Notification helpers
 export {
   getNotificationContent,
   sendDownloadNotification,
 } from "./notifications";
+// Pending download records (persisted while a download is in flight)
+export {
+  finalizePendingDownload,
+  getPendingDownload,
+  getPendingDownloads,
+  type PendingDownload,
+  removePendingDownload,
+  savePendingDownload,
+  updatePendingDownload,
+} from "./pendingDownloads";
 // Types (re-export from existing types.ts)
 export type {
   DownloadedItem,

--- a/providers/Downloads/liveActivity.ts
+++ b/providers/Downloads/liveActivity.ts
@@ -1,0 +1,141 @@
+import type { Api } from "@jellyfin/sdk";
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+import { Directory, File } from "expo-file-system";
+import type { TFunction } from "i18next";
+import { Platform } from "react-native";
+import { BackgroundDownloader } from "@/modules";
+import type { DownloadActivityMetadata } from "@/modules/background-downloader";
+import { getItemImage } from "@/utils/getItemImage";
+
+/**
+ * Builds the payload for the iOS download Live Activity.
+ *
+ * The activity is driven natively from the URLSession delegate, which keeps running after iOS has
+ * torn down the JS runtime. Nothing here can therefore be resolved later — every string and the
+ * poster file must be in place before the download starts.
+ *
+ * iOS-only. Android already shows download progress through the foreground service in
+ * `modules/background-downloader/android/.../DownloadService.kt`.
+ */
+
+const isSupported = Platform.OS === "ios" && !Platform.isTV;
+
+/**
+ * Title/subtitle for the activity, matching the phrasing `getNotificationContent` uses for the
+ * completion notification so the two never disagree.
+ */
+function getActivityText(item: BaseItemDto): {
+  title: string;
+  subtitle: string;
+} {
+  if (item.Type === "Episode") {
+    const season = item.ParentIndexNumber
+      ? String(item.ParentIndexNumber).padStart(2, "0")
+      : "??";
+    const episode = item.IndexNumber
+      ? String(item.IndexNumber).padStart(2, "0")
+      : "??";
+
+    return {
+      title: item.SeriesName || item.Name || "",
+      subtitle: `S${season}E${episode}${item.Name ? ` · ${item.Name}` : ""}`,
+    };
+  }
+
+  if (item.Type === "Movie") {
+    return {
+      title: item.Name || "",
+      subtitle: item.ProductionYear ? String(item.ProductionYear) : "",
+    };
+  }
+
+  return { title: item.Name || "", subtitle: "" };
+}
+
+/**
+ * Copies the item's poster into the App Group container. The widget extension runs in its own
+ * process and cannot read the app's Documents directory, so the image has to be staged somewhere
+ * both can reach.
+ *
+ * Only one download runs at a time, so the directory is cleared first and never accumulates.
+ * Returns `undefined` on any failure — the activity falls back to an SF Symbol.
+ */
+async function stagePoster(
+  item: BaseItemDto,
+  api: Api,
+): Promise<string | undefined> {
+  const directoryPath = BackgroundDownloader.getLiveActivityDirectory();
+  if (!directoryPath || !item.Id) return undefined;
+
+  try {
+    const image = getItemImage({
+      item,
+      api,
+      variant: item.Type === "Episode" ? "SeriesPrimary" : "Primary",
+      quality: 90,
+      width: 300,
+    });
+    if (!image?.uri) return undefined;
+
+    const directory = new Directory(`file://${directoryPath}`);
+    if (!directory.exists) {
+      directory.create({ intermediates: true });
+    }
+    for (const entry of directory.list()) {
+      try {
+        entry.delete();
+      } catch {
+        // A stale poster we cannot remove is harmless; the new one still overwrites by name.
+      }
+    }
+
+    const fileName = `${item.Id}.jpg`;
+    await File.downloadFileAsync(
+      image.uri as string,
+      new File(directory, fileName),
+      { idempotent: true },
+    );
+
+    return fileName;
+  } catch (error) {
+    console.warn("[LiveActivity] Failed to stage poster:", error);
+    return undefined;
+  }
+}
+
+export async function buildDownloadActivityMetadata({
+  item,
+  api,
+  t,
+  estimatedTotalBytes,
+}: {
+  item: BaseItemDto;
+  api: Api;
+  t: TFunction;
+  estimatedTotalBytes?: number;
+}): Promise<DownloadActivityMetadata | undefined> {
+  if (!isSupported || !item.Id) return undefined;
+
+  const { title, subtitle } = getActivityText(item);
+  const posterFileName = await stagePoster(item, api);
+
+  return {
+    itemId: item.Id,
+    title,
+    subtitle,
+    posterFileName,
+    estimatedTotalBytes: estimatedTotalBytes ?? 0,
+    // Resolved here rather than in Swift so translations stay in translations/*.json only.
+    labels: {
+      downloading: t("home.downloads.live_activity.downloading"),
+      completed: t("home.downloads.live_activity.completed"),
+      failed: t("home.downloads.live_activity.failed"),
+      queued: t("home.downloads.live_activity.queued"),
+    },
+  };
+}
+
+export function setDownloadLiveActivityEnabled(enabled: boolean): void {
+  if (!isSupported) return;
+  BackgroundDownloader.setLiveActivityEnabled(enabled);
+}

--- a/providers/Downloads/liveActivity.ts
+++ b/providers/Downloads/liveActivity.ts
@@ -52,12 +52,17 @@ function getActivityText(item: BaseItemDto): {
   return { title: item.Name || "", subtitle: "" };
 }
 
+/** Posters staged longer ago than this are from a previous download session and safe to remove. */
+const POSTER_RETENTION_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Copies the item's poster into the App Group container. The widget extension runs in its own
  * process and cannot read the app's Documents directory, so the image has to be staged somewhere
  * both can reach.
  *
- * Only one download runs at a time, so the directory is cleared first and never accumulates.
+ * Only stale files are pruned — never the whole directory. When several episodes are queued, each
+ * one stages its poster at enqueue time, and the Live Activity still renders the *first* episode's
+ * poster while the rest are staged; wiping the directory here deleted it mid-display.
  * Returns `undefined` on any failure — the activity falls back to an SF Symbol.
  */
 async function stagePoster(
@@ -83,9 +88,16 @@ async function stagePoster(
     }
     for (const entry of directory.list()) {
       try {
-        entry.delete();
+        if (!(entry instanceof File)) continue;
+        const modified = entry.info().modificationTime ?? 0;
+        // modificationTime has historically been reported in seconds by some backends; treat
+        // small values as seconds so a unit change can never mass-delete fresh posters.
+        const modifiedMs = modified < 1e12 ? modified * 1000 : modified;
+        if (Date.now() - modifiedMs > POSTER_RETENTION_MS) {
+          entry.delete();
+        }
       } catch {
-        // A stale poster we cannot remove is harmless; the new one still overwrites by name.
+        // A stale poster we cannot remove is harmless; same-name posters still overwrite.
       }
     }
 

--- a/providers/Downloads/pendingDownloads.ts
+++ b/providers/Downloads/pendingDownloads.ts
@@ -1,0 +1,136 @@
+import type {
+  BaseItemDto,
+  MediaSourceInfo,
+} from "@jellyfin/sdk/lib/generated-client/models";
+import { File, Paths } from "expo-file-system";
+import type { Bitrate } from "@/components/BitrateSelector";
+import type { DownloadActivityMetadata } from "@/modules/background-downloader";
+import { storage } from "@/utils/mmkv";
+import { addDownloadedItem } from "./database";
+import type { DownloadedItem, MediaTimeSegment, TrickPlayData } from "./types";
+
+/**
+ * Persisted record of an in-flight download, written at enqueue time and removed on completion.
+ *
+ * This is what lets a download survive the death of the JS runtime. The native layer keeps
+ * transferring after the app is killed and moves the file into place on relaunch, but the
+ * downloads database entry used to be assembled from in-memory React state — so a download that
+ * finished while JS was dead produced a file on disk the app never learned about. Everything the
+ * final `DownloadedItem` needs is known at enqueue time except the file size, which is read from
+ * the file itself; persisting it here makes completion bookkeeping possible at any later point,
+ * including a cold start (see `useDownloadReconciliation`).
+ */
+export interface PendingDownload {
+  /** Jellyfin item id; the record key, and how native events are correlated back. */
+  itemId: string;
+  /** `queued` until the native started event fires, then `downloading`. */
+  status: "queued" | "downloading";
+  enqueuedAt: string;
+  /** Native task id, known once the download actually starts. */
+  taskId?: number;
+  inputUrl: string;
+  /**
+   * File name inside the app Documents directory. Deliberately never an absolute path — the iOS
+   * container path changes between app updates, so absolute paths go stale.
+   */
+  videoFileName: string;
+  item: BaseItemDto;
+  mediaSource: MediaSourceInfo;
+  maxBitrate: Bitrate;
+  deviceId: string;
+  trickPlayData?: TrickPlayData;
+  introSegments?: MediaTimeSegment[];
+  creditSegments?: MediaTimeSegment[];
+  audioStreamIndex?: number;
+  subtitleStreamIndex?: number;
+  /** Metadata originally handed to native; reused when re-enqueueing after a relaunch. */
+  activityMetadata?: DownloadActivityMetadata;
+}
+
+const PENDING_DOWNLOADS_KEY = "downloads.pending.v1.json";
+
+function readAll(): Record<string, PendingDownload> {
+  const raw = storage.getString(PENDING_DOWNLOADS_KEY);
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Record<string, PendingDownload>;
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(records: Record<string, PendingDownload>): void {
+  storage.set(PENDING_DOWNLOADS_KEY, JSON.stringify(records));
+}
+
+export function getPendingDownloads(): PendingDownload[] {
+  return Object.values(readAll());
+}
+
+export function getPendingDownload(
+  itemId: string,
+): PendingDownload | undefined {
+  return readAll()[itemId];
+}
+
+export function savePendingDownload(record: PendingDownload): void {
+  const records = readAll();
+  records[record.itemId] = record;
+  writeAll(records);
+}
+
+export function updatePendingDownload(
+  itemId: string,
+  patch: Partial<PendingDownload>,
+): void {
+  const records = readAll();
+  const existing = records[itemId];
+  if (!existing) return;
+  records[itemId] = { ...existing, ...patch };
+  writeAll(records);
+}
+
+export function removePendingDownload(itemId: string): void {
+  const records = readAll();
+  if (!(itemId in records)) return;
+  delete records[itemId];
+  writeAll(records);
+}
+
+/** URI of the video file a pending download writes to (derived, never stored). */
+export function pendingDownloadFileUri(record: PendingDownload): string {
+  return new File(Paths.document, record.videoFileName).uri;
+}
+
+/**
+ * Turns a pending record into a permanent downloads-database entry and removes the record.
+ *
+ * `isTranscoded` can be passed when the live progress events already told us (no Content-Length);
+ * after a relaunch that signal is gone and the presence of a TranscodingUrl is the fallback.
+ */
+export function finalizePendingDownload(
+  record: PendingDownload,
+  videoFileSize: number,
+  isTranscoded?: boolean,
+): DownloadedItem {
+  const downloadedItem: DownloadedItem = {
+    item: record.item,
+    mediaSource: record.mediaSource,
+    videoFilePath: pendingDownloadFileUri(record),
+    videoFileSize,
+    videoFileName: record.videoFileName,
+    trickPlayData: record.trickPlayData,
+    introSegments: record.introSegments,
+    creditSegments: record.creditSegments,
+    userData: {
+      audioStreamIndex: record.audioStreamIndex ?? 0,
+      subtitleStreamIndex: record.subtitleStreamIndex ?? -1,
+      isTranscoded: isTranscoded ?? !!record.mediaSource.TranscodingUrl,
+    },
+  };
+
+  addDownloadedItem(downloadedItem);
+  removePendingDownload(record.itemId);
+
+  return downloadedItem;
+}

--- a/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
+++ b/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
@@ -44,13 +44,13 @@ struct DownloadActivityWidget: Widget {
           ProgressBar(context: context)
         }
       } compactLeading: {
-        Image(systemName: compactSymbol(for: context.state.state))
-          .foregroundStyle(brandTint)
+        Image(systemName: leadingSymbol(for: context))
+          .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
       } compactTrailing: {
         CompactTrailing(context: context)
       } minimal: {
-        Image(systemName: compactSymbol(for: context.state.state))
-          .foregroundStyle(brandTint)
+        Image(systemName: leadingSymbol(for: context))
+          .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
       }
       .keylineTint(brandTint)
     }
@@ -107,10 +107,10 @@ private struct ProgressBar: View {
 
   var body: some View {
     // Honest, value-driven progress. It stops advancing while the app is suspended rather than
-    // guessing forward — the ETA beside it is what conveys that the transfer is still alive.
+    // guessing forward — the stale treatment is what conveys that the numbers are frozen.
     ProgressView(value: displayProgress(for: context))
       .progressViewStyle(.linear)
-      .tint(context.state.state == .failed ? .red : brandTint)
+      .tint(progressTint(for: context))
   }
 }
 
@@ -119,10 +119,17 @@ private struct PercentLabel: View {
 
   var body: some View {
     if context.state.state == .downloading {
-      Text(percentText(for: context))
-        .font(.caption.weight(.semibold))
-        .monospacedDigit()
-        .foregroundStyle(brandTint)
+      HStack(spacing: 3) {
+        if isProgressStale(context) {
+          Image(systemName: "clock.arrow.circlepath")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        Text(percentText(for: context))
+          .font(.caption.weight(.semibold))
+          .monospacedDigit()
+          .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
+      }
     }
   }
 }
@@ -135,6 +142,7 @@ private struct TrailingStatus: View {
       Text(percentText(for: context))
         .font(.body.weight(.semibold))
         .monospacedDigit()
+        .foregroundStyle(isProgressStale(context) ? .secondary : .primary)
       if context.state.queuedCount > 0 {
         Text("+\(context.state.queuedCount)")
           .font(.caption2)
@@ -150,7 +158,7 @@ private struct CompactTrailing: View {
   var body: some View {
     Text(percentText(for: context))
       .monospacedDigit()
-      .foregroundStyle(brandTint)
+      .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
   }
 }
 
@@ -189,6 +197,24 @@ private struct PosterView: View {
 
 // MARK: - Formatting
 
+/// True when the last pushed update has passed its stale date while still claiming to download —
+/// i.e. the app has been suspended and the numbers are frozen, not current. The transfer itself
+/// usually continues out-of-process; this treatment just stops a frozen 16% from looking live.
+private func isProgressStale(_ context: ActivityViewContext<DownloadActivityAttributes>) -> Bool {
+  context.isStale && context.state.state == .downloading
+}
+
+private func progressTint(for context: ActivityViewContext<DownloadActivityAttributes>) -> Color {
+  if context.state.state == .failed { return .red }
+  return isProgressStale(context) ? brandTint.opacity(0.4) : brandTint
+}
+
+private func leadingSymbol(for context: ActivityViewContext<DownloadActivityAttributes>) -> String {
+  isProgressStale(context)
+    ? "clock.arrow.circlepath"
+    : compactSymbol(for: context.state.state)
+}
+
 private func displayProgress(for context: ActivityViewContext<DownloadActivityAttributes>) -> Double
 {
   switch context.state.state {
@@ -221,7 +247,8 @@ private func transferredText(for context: ActivityViewContext<DownloadActivityAt
   } else {
     parts.append(downloaded)
   }
-  if context.state.speedBytesPerSec > 0 {
+  // A speed frozen at its pre-suspension value is a lie; drop it once the update has gone stale.
+  if !isProgressStale(context), context.state.speedBytesPerSec > 0 {
     let speed = formatter.string(fromByteCount: Int64(context.state.speedBytesPerSec))
     parts.append("\(speed)/s")
   }

--- a/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
+++ b/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
@@ -22,12 +22,12 @@ struct DownloadActivityWidget: Widget {
     } dynamicIsland: { context in
       DynamicIsland {
         DynamicIslandExpandedRegion(.leading) {
-          PosterView(fileName: context.attributes.posterFileName, size: 46)
+          PosterView(fileName: context.state.posterFileName, size: 46)
             .padding(.leading, 4)
         }
         DynamicIslandExpandedRegion(.center) {
           VStack(alignment: .leading, spacing: 2) {
-            Text(context.attributes.title)
+            Text(context.state.title)
               .font(.headline)
               .lineLimit(1)
             Text(subtitleText(for: context))
@@ -64,11 +64,11 @@ private struct LockScreenView: View {
 
   var body: some View {
     HStack(alignment: .top, spacing: 12) {
-      PosterView(fileName: context.attributes.posterFileName, size: 60)
+      PosterView(fileName: context.state.posterFileName, size: 60)
 
       VStack(alignment: .leading, spacing: 5) {
         HStack(alignment: .firstTextBaseline) {
-          Text(context.attributes.title)
+          Text(context.state.title)
             .font(.headline)
             .lineLimit(1)
           Spacer(minLength: 8)
@@ -203,7 +203,7 @@ private func percentText(for context: ActivityViewContext<DownloadActivityAttrib
 }
 
 private func subtitleText(for context: ActivityViewContext<DownloadActivityAttributes>) -> String {
-  let subtitle = context.attributes.subtitle
+  let subtitle = context.state.subtitle
   guard context.state.queuedCount > 0, context.state.state == .downloading else { return subtitle }
   let queued = "+\(context.state.queuedCount)"
   return subtitle.isEmpty ? queued : "\(subtitle) · \(queued)"

--- a/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
+++ b/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
@@ -87,9 +87,13 @@ private struct LockScreenView: View {
 
         HStack {
           if context.state.state == .downloading {
+            // Instant swap instead of the default fade — this line changes on every 1s update,
+            // and a fade per second reads as flicker. numericText is wrong here: the string mixes
+            // units and separators, not a single rolling number.
             Text(transferredText(for: context))
               .font(.caption2)
               .foregroundStyle(.secondary)
+              .contentTransition(.identity)
           }
           Spacer(minLength: 8)
           PercentLabel(context: context)
@@ -139,9 +143,11 @@ private struct PercentLabel: View {
         // Measured percent, not a countdown — the owner's call. It freezes while the app is
         // suspended (no self-updating percent primitive exists); the timer-driven bar beside it
         // is what keeps advancing, and the stale treatment covers a projection that expires.
+        // numericText rolls the digits in place instead of fading the whole label every update.
         Text(percentText(for: context))
           .font(.caption.weight(.semibold))
           .monospacedDigit()
+          .contentTransition(.numericText())
           .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
       }
     }
@@ -156,10 +162,12 @@ private struct TrailingStatus: View {
       Text(percentText(for: context))
         .font(.body.weight(.semibold))
         .monospacedDigit()
+        .contentTransition(.numericText())
         .foregroundStyle(isProgressStale(context) ? .secondary : .primary)
       if context.state.queuedCount > 0 {
         Text("+\(context.state.queuedCount)")
           .font(.caption2)
+          .contentTransition(.numericText())
           .foregroundStyle(.secondary)
       }
     }
@@ -172,6 +180,7 @@ private struct CompactTrailing: View {
   var body: some View {
     Text(percentText(for: context))
       .monospacedDigit()
+      .contentTransition(.numericText())
       .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
   }
 }

--- a/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
+++ b/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
@@ -136,20 +136,13 @@ private struct PercentLabel: View {
             .font(.caption2)
             .foregroundStyle(.secondary)
         }
-        // Self-ticking countdown to the projected completion; parks at 0:00 (dimmed via the
-        // stale treatment) if the completion wake never confirms it.
-        if let interval = projectionInterval(for: context) {
-          Text(timerInterval: interval, countsDown: true)
-            .font(.caption.weight(.semibold))
-            .monospacedDigit()
-            .multilineTextAlignment(.trailing)
-            .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
-        } else {
-          Text(percentText(for: context))
-            .font(.caption.weight(.semibold))
-            .monospacedDigit()
-            .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
-        }
+        // Measured percent, not a countdown — the owner's call. It freezes while the app is
+        // suspended (no self-updating percent primitive exists); the timer-driven bar beside it
+        // is what keeps advancing, and the stale treatment covers a projection that expires.
+        Text(percentText(for: context))
+          .font(.caption.weight(.semibold))
+          .monospacedDigit()
+          .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
       }
     }
   }
@@ -160,18 +153,10 @@ private struct TrailingStatus: View {
 
   var body: some View {
     VStack(alignment: .trailing, spacing: 2) {
-      if let interval = projectionInterval(for: context) {
-        Text(timerInterval: interval, countsDown: true)
-          .font(.body.weight(.semibold))
-          .monospacedDigit()
-          .multilineTextAlignment(.trailing)
-          .foregroundStyle(isProgressStale(context) ? .secondary : .primary)
-      } else {
-        Text(percentText(for: context))
-          .font(.body.weight(.semibold))
-          .monospacedDigit()
-          .foregroundStyle(isProgressStale(context) ? .secondary : .primary)
-      }
+      Text(percentText(for: context))
+        .font(.body.weight(.semibold))
+        .monospacedDigit()
+        .foregroundStyle(isProgressStale(context) ? .secondary : .primary)
       if context.state.queuedCount > 0 {
         Text("+\(context.state.queuedCount)")
           .font(.caption2)
@@ -185,18 +170,9 @@ private struct CompactTrailing: View {
   let context: ActivityViewContext<DownloadActivityAttributes>
 
   var body: some View {
-    if let interval = projectionInterval(for: context) {
-      // Timer text is greedy about width; the compact slot needs a hard cap.
-      Text(timerInterval: interval, countsDown: true)
-        .monospacedDigit()
-        .multilineTextAlignment(.trailing)
-        .frame(maxWidth: 44)
-        .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
-    } else {
-      Text(percentText(for: context))
-        .monospacedDigit()
-        .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
-    }
+    Text(percentText(for: context))
+      .monospacedDigit()
+      .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
   }
 }
 

--- a/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
+++ b/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
@@ -1,0 +1,238 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+private let brandTint = Color(red: 0.576, green: 0.200, blue: 0.918)  // #9333EA
+
+/// Live Activity for the active download.
+///
+/// Text is deliberately kept to values that need no translation — byte counts are formatted by
+/// Foundation against the user's locale, and the only prose (the state label) is passed in from JS,
+/// which already has the app's i18n catalog.
+///
+/// There is intentionally no time remaining. An ETA has to be derived from a speed average, and
+/// download throughput is spiky enough that dividing into it produced a figure that jumped around
+/// constantly. A percentage is measured rather than predicted, so it only ever moves forward.
+struct DownloadActivityWidget: Widget {
+  var body: some WidgetConfiguration {
+    ActivityConfiguration(for: DownloadActivityAttributes.self) { context in
+      LockScreenView(context: context)
+        .activityBackgroundTint(Color.black.opacity(0.55))
+        .activitySystemActionForegroundColor(.white)
+    } dynamicIsland: { context in
+      DynamicIsland {
+        DynamicIslandExpandedRegion(.leading) {
+          PosterView(fileName: context.attributes.posterFileName, size: 46)
+            .padding(.leading, 4)
+        }
+        DynamicIslandExpandedRegion(.center) {
+          VStack(alignment: .leading, spacing: 2) {
+            Text(context.attributes.title)
+              .font(.headline)
+              .lineLimit(1)
+            Text(subtitleText(for: context))
+              .font(.caption)
+              .foregroundStyle(.secondary)
+              .lineLimit(1)
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        DynamicIslandExpandedRegion(.trailing) {
+          TrailingStatus(context: context)
+        }
+        DynamicIslandExpandedRegion(.bottom) {
+          ProgressBar(context: context)
+        }
+      } compactLeading: {
+        Image(systemName: compactSymbol(for: context.state.state))
+          .foregroundStyle(brandTint)
+      } compactTrailing: {
+        CompactTrailing(context: context)
+      } minimal: {
+        Image(systemName: compactSymbol(for: context.state.state))
+          .foregroundStyle(brandTint)
+      }
+      .keylineTint(brandTint)
+    }
+  }
+}
+
+// MARK: - Lock Screen
+
+private struct LockScreenView: View {
+  let context: ActivityViewContext<DownloadActivityAttributes>
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 12) {
+      PosterView(fileName: context.attributes.posterFileName, size: 60)
+
+      VStack(alignment: .leading, spacing: 5) {
+        HStack(alignment: .firstTextBaseline) {
+          Text(context.attributes.title)
+            .font(.headline)
+            .lineLimit(1)
+          Spacer(minLength: 8)
+          Text(context.attributes.label(for: context.state.state))
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(context.state.state == .failed ? .red : .secondary)
+            .lineLimit(1)
+        }
+
+        Text(subtitleText(for: context))
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+
+        ProgressBar(context: context)
+
+        HStack {
+          if context.state.state == .downloading {
+            Text(transferredText(for: context))
+              .font(.caption2)
+              .foregroundStyle(.secondary)
+          }
+          Spacer(minLength: 8)
+          PercentLabel(context: context)
+        }
+      }
+    }
+    .padding(16)
+  }
+}
+
+// MARK: - Pieces
+
+private struct ProgressBar: View {
+  let context: ActivityViewContext<DownloadActivityAttributes>
+
+  var body: some View {
+    // Honest, value-driven progress. It stops advancing while the app is suspended rather than
+    // guessing forward — the ETA beside it is what conveys that the transfer is still alive.
+    ProgressView(value: displayProgress(for: context))
+      .progressViewStyle(.linear)
+      .tint(context.state.state == .failed ? .red : brandTint)
+  }
+}
+
+private struct PercentLabel: View {
+  let context: ActivityViewContext<DownloadActivityAttributes>
+
+  var body: some View {
+    if context.state.state == .downloading {
+      Text(percentText(for: context))
+        .font(.caption.weight(.semibold))
+        .monospacedDigit()
+        .foregroundStyle(brandTint)
+    }
+  }
+}
+
+private struct TrailingStatus: View {
+  let context: ActivityViewContext<DownloadActivityAttributes>
+
+  var body: some View {
+    VStack(alignment: .trailing, spacing: 2) {
+      Text(percentText(for: context))
+        .font(.body.weight(.semibold))
+        .monospacedDigit()
+      if context.state.queuedCount > 0 {
+        Text("+\(context.state.queuedCount)")
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+}
+
+private struct CompactTrailing: View {
+  let context: ActivityViewContext<DownloadActivityAttributes>
+
+  var body: some View {
+    Text(percentText(for: context))
+      .monospacedDigit()
+      .foregroundStyle(brandTint)
+  }
+}
+
+private struct PosterView: View {
+  let fileName: String?
+  let size: CGFloat
+
+  var body: some View {
+    Group {
+      if let image = loadPoster() {
+        Image(uiImage: image)
+          .resizable()
+          .aspectRatio(contentMode: .fill)
+      } else {
+        ZStack {
+          Color.white.opacity(0.12)
+          Image(systemName: "arrow.down.circle.fill")
+            .font(.system(size: size * 0.4))
+            .foregroundStyle(brandTint)
+        }
+      }
+    }
+    .frame(width: size, height: size * 1.5)
+    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+  }
+
+  /// The extension has no access to the app's Documents directory, so posters are staged into the
+  /// shared App Group container before the activity starts.
+  private func loadPoster() -> UIImage? {
+    guard let url = DownloadActivitySharedContainer.posterURL(fileName: fileName) else {
+      return nil
+    }
+    return UIImage(contentsOfFile: url.path)
+  }
+}
+
+// MARK: - Formatting
+
+private func displayProgress(for context: ActivityViewContext<DownloadActivityAttributes>) -> Double
+{
+  switch context.state.state {
+  case .completed: return 1
+  case .queued: return 0
+  default: return min(max(context.state.progress, 0), 1)
+  }
+}
+
+private func percentText(for context: ActivityViewContext<DownloadActivityAttributes>) -> String {
+  "\(Int((displayProgress(for: context) * 100).rounded()))%"
+}
+
+private func subtitleText(for context: ActivityViewContext<DownloadActivityAttributes>) -> String {
+  let subtitle = context.attributes.subtitle
+  guard context.state.queuedCount > 0, context.state.state == .downloading else { return subtitle }
+  let queued = "+\(context.state.queuedCount)"
+  return subtitle.isEmpty ? queued : "\(subtitle) · \(queued)"
+}
+
+private func transferredText(for context: ActivityViewContext<DownloadActivityAttributes>) -> String
+{
+  let formatter = ByteCountFormatter()
+  formatter.countStyle = .file
+  let downloaded = formatter.string(fromByteCount: context.state.bytesDownloaded)
+
+  var parts: [String] = []
+  if context.state.totalBytes > 0 {
+    parts.append("\(downloaded) / \(formatter.string(fromByteCount: context.state.totalBytes))")
+  } else {
+    parts.append(downloaded)
+  }
+  if context.state.speedBytesPerSec > 0 {
+    let speed = formatter.string(fromByteCount: Int64(context.state.speedBytesPerSec))
+    parts.append("\(speed)/s")
+  }
+  return parts.joined(separator: " · ")
+}
+
+private func compactSymbol(for state: DownloadActivityState) -> String {
+  switch state {
+  case .completed: return "checkmark.circle.fill"
+  case .failed: return "exclamationmark.triangle.fill"
+  case .queued: return "clock"
+  case .downloading: return "arrow.down.circle.fill"
+  }
+}

--- a/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
+++ b/targets/StreamyfinDownloadActivity/DownloadActivityWidget.swift
@@ -106,11 +106,22 @@ private struct ProgressBar: View {
   let context: ActivityViewContext<DownloadActivityAttributes>
 
   var body: some View {
-    // Honest, value-driven progress. It stops advancing while the app is suspended rather than
-    // guessing forward — the stale treatment is what conveys that the numbers are frozen.
-    ProgressView(value: displayProgress(for: context))
+    // The timer-driven bar is one of the two primitives iOS animates while the app is suspended —
+    // it keeps advancing toward the projected completion with no process running. Without a
+    // projection (no speed sample yet, or a terminal state) fall back to the measured bar.
+    if let interval = projectionInterval(for: context) {
+      ProgressView(timerInterval: interval, countsDown: false) {
+        EmptyView()
+      } currentValueLabel: {
+        EmptyView()
+      }
       .progressViewStyle(.linear)
       .tint(progressTint(for: context))
+    } else {
+      ProgressView(value: displayProgress(for: context))
+        .progressViewStyle(.linear)
+        .tint(progressTint(for: context))
+    }
   }
 }
 
@@ -125,10 +136,20 @@ private struct PercentLabel: View {
             .font(.caption2)
             .foregroundStyle(.secondary)
         }
-        Text(percentText(for: context))
-          .font(.caption.weight(.semibold))
-          .monospacedDigit()
-          .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
+        // Self-ticking countdown to the projected completion; parks at 0:00 (dimmed via the
+        // stale treatment) if the completion wake never confirms it.
+        if let interval = projectionInterval(for: context) {
+          Text(timerInterval: interval, countsDown: true)
+            .font(.caption.weight(.semibold))
+            .monospacedDigit()
+            .multilineTextAlignment(.trailing)
+            .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
+        } else {
+          Text(percentText(for: context))
+            .font(.caption.weight(.semibold))
+            .monospacedDigit()
+            .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
+        }
       }
     }
   }
@@ -139,10 +160,18 @@ private struct TrailingStatus: View {
 
   var body: some View {
     VStack(alignment: .trailing, spacing: 2) {
-      Text(percentText(for: context))
-        .font(.body.weight(.semibold))
-        .monospacedDigit()
-        .foregroundStyle(isProgressStale(context) ? .secondary : .primary)
+      if let interval = projectionInterval(for: context) {
+        Text(timerInterval: interval, countsDown: true)
+          .font(.body.weight(.semibold))
+          .monospacedDigit()
+          .multilineTextAlignment(.trailing)
+          .foregroundStyle(isProgressStale(context) ? .secondary : .primary)
+      } else {
+        Text(percentText(for: context))
+          .font(.body.weight(.semibold))
+          .monospacedDigit()
+          .foregroundStyle(isProgressStale(context) ? .secondary : .primary)
+      }
       if context.state.queuedCount > 0 {
         Text("+\(context.state.queuedCount)")
           .font(.caption2)
@@ -156,9 +185,18 @@ private struct CompactTrailing: View {
   let context: ActivityViewContext<DownloadActivityAttributes>
 
   var body: some View {
-    Text(percentText(for: context))
-      .monospacedDigit()
-      .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
+    if let interval = projectionInterval(for: context) {
+      // Timer text is greedy about width; the compact slot needs a hard cap.
+      Text(timerInterval: interval, countsDown: true)
+        .monospacedDigit()
+        .multilineTextAlignment(.trailing)
+        .frame(maxWidth: 44)
+        .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
+    } else {
+      Text(percentText(for: context))
+        .monospacedDigit()
+        .foregroundStyle(isProgressStale(context) ? Color.secondary : brandTint)
+    }
   }
 }
 
@@ -207,6 +245,20 @@ private func isProgressStale(_ context: ActivityViewContext<DownloadActivityAttr
 private func progressTint(for context: ActivityViewContext<DownloadActivityAttributes>) -> Color {
   if context.state.state == .failed { return .red }
   return isProgressStale(context) ? brandTint.opacity(0.4) : brandTint
+}
+
+/// Interval driving the self-advancing bar and countdown, when the last update carried a
+/// completion projection. Once the end passes, the pair parks at full / 0:00 — the stale
+/// treatment is what keeps that from looking confident.
+private func projectionInterval(
+  for context: ActivityViewContext<DownloadActivityAttributes>
+) -> ClosedRange<Date>? {
+  guard context.state.state == .downloading,
+    let start = context.state.progressBarStartDate,
+    let end = context.state.projectedEndDate,
+    end > start
+  else { return nil }
+  return start...end
 }
 
 private func leadingSymbol(for context: ActivityViewContext<DownloadActivityAttributes>) -> String {

--- a/targets/StreamyfinDownloadActivity/Info.plist
+++ b/targets/StreamyfinDownloadActivity/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>StreamyfinDownloadsAppGroupIdentifier</key>
+  <string>$(DOWNLOADS_APP_GROUP_IDENTIFIER)</string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>$(DEVELOPMENT_LANGUAGE)</string>
+  <key>CFBundleDisplayName</key>
+  <string>Streamyfin Downloads</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(MARKETING_VERSION)</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSExtension</key>
+  <dict>
+    <key>NSExtensionPointIdentifier</key>
+    <string>com.apple.widgetkit-extension</string>
+  </dict>
+</dict>
+</plist>

--- a/targets/StreamyfinDownloadActivity/StreamyfinDownloadActivity.entitlements
+++ b/targets/StreamyfinDownloadActivity/StreamyfinDownloadActivity.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.application-groups</key>
+  <array>
+    <string>$(DOWNLOADS_APP_GROUP_IDENTIFIER)</string>
+  </array>
+</dict>
+</plist>

--- a/targets/StreamyfinDownloadActivity/StreamyfinDownloadActivityBundle.swift
+++ b/targets/StreamyfinDownloadActivity/StreamyfinDownloadActivityBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct StreamyfinDownloadActivityBundle: WidgetBundle {
+  var body: some Widget {
+    DownloadActivityWidget()
+  }
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -149,6 +149,8 @@
       },
       "appearance": {
         "title": "Appearance",
+        "download_live_activity": "Live Activity",
+        "download_live_activity_hint": "Show download progress on the Lock Screen and in the Dynamic Island.",
         "merge_next_up_continue_watching": "Merge Continue watching & Next up",
         "merge_next_up_continue_watching_hint": "Combine Continue Watching and Next Up into a single home row.",
         "use_episode_images_next_up": "Use episode images for Next Up & Continue Watching",
@@ -417,8 +419,6 @@
         "app_usage": "App {{usedSpace}}%",
         "device_usage": "Device {{availableSpace}}%",
         "size_used": "{{used}} of {{total}} used",
-        "download_live_activity": "Live Activity",
-        "download_live_activity_hint": "Show download progress on the Lock Screen and in the Dynamic Island.",
         "delete_all_downloaded_files": "Delete all downloaded files",
         "delete_all_downloaded_files_confirm": "Delete all downloaded files?",
         "delete_all_downloaded_files_confirm_desc": "Are you sure you want to delete all downloaded files? This action cannot be undone.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -417,6 +417,8 @@
         "app_usage": "App {{usedSpace}}%",
         "device_usage": "Device {{availableSpace}}%",
         "size_used": "{{used}} of {{total}} used",
+        "download_live_activity": "Live Activity",
+        "download_live_activity_hint": "Show download progress on the Lock Screen and in the Dynamic Island.",
         "delete_all_downloaded_files": "Delete all downloaded files",
         "delete_all_downloaded_files_confirm": "Delete all downloaded files?",
         "delete_all_downloaded_files_confirm_desc": "Are you sure you want to delete all downloaded files? This action cannot be undone.",
@@ -499,6 +501,12 @@
       "something_went_wrong": "Something went wrong",
       "could_not_get_stream_url_from_jellyfin": "Could not get the stream URL from Jellyfin",
       "eta": "ETA {{eta}}",
+      "live_activity": {
+        "downloading": "Downloading",
+        "completed": "Downloaded",
+        "failed": "Download failed",
+        "queued": "Queued"
+      },
       "toasts": {
         "you_are_not_allowed_to_download_files": "You are not allowed to download files.",
         "deleted_all_movies_successfully": "Deleted all movies successfully!",

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -417,6 +417,8 @@
         "app_usage": "Streamyfin {{usedSpace}}%",
         "device_usage": "Telefon {{availableSpace}}%",
         "size_used": "{{used}} av {{total}} används",
+        "download_live_activity": "Liveaktivitet",
+        "download_live_activity_hint": "Visa nedladdningens förlopp på låsskärmen och i Dynamic Island.",
         "delete_all_downloaded_files": "Ta bort alla nerladdade filer",
         "delete_all_downloaded_files_confirm": "Delete All Downloaded Files?",
         "delete_all_downloaded_files_confirm_desc": "Are you sure you want to delete all downloaded files? This action cannot be undone.",
@@ -499,6 +501,12 @@
       "something_went_wrong": "Något Gick Fel",
       "could_not_get_stream_url_from_jellyfin": "Det gick inte att hämta strömadressen från Jellyfin",
       "eta": "ETA {{eta}}",
+      "live_activity": {
+        "downloading": "Laddar ner",
+        "completed": "Nedladdad",
+        "failed": "Nedladdningen misslyckades",
+        "queued": "I kö"
+      },
       "toasts": {
         "you_are_not_allowed_to_download_files": "Du har inte behörighet att ladda ner filer.",
         "deleted_all_movies_successfully": "Alla Filmer Har Tagits Bort!",

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -149,6 +149,8 @@
       },
       "appearance": {
         "title": "Utseende",
+        "download_live_activity": "Liveaktivitet",
+        "download_live_activity_hint": "Visa nedladdningens förlopp på låsskärmen och i Dynamic Island.",
         "merge_next_up_continue_watching": "Slå ihop Fortsätt titta och nästa avsnitt",
         "merge_next_up_continue_watching_hint": "Combine Continue Watching and Next Up into a single home row.",
         "use_episode_images_next_up": "Use episode images for Next Up & Continue Watching",
@@ -417,8 +419,6 @@
         "app_usage": "Streamyfin {{usedSpace}}%",
         "device_usage": "Telefon {{availableSpace}}%",
         "size_used": "{{used}} av {{total}} används",
-        "download_live_activity": "Liveaktivitet",
-        "download_live_activity_hint": "Visa nedladdningens förlopp på låsskärmen och i Dynamic Island.",
         "delete_all_downloaded_files": "Ta bort alla nerladdade filer",
         "delete_all_downloaded_files_confirm": "Delete All Downloaded Files?",
         "delete_all_downloaded_files_confirm_desc": "Are you sure you want to delete all downloaded files? This action cannot be undone.",

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -267,6 +267,8 @@ export type Settings = {
   streamyStatsSeriesRecommendations?: boolean;
   streamyStatsPromotedWatchlists?: boolean;
   downloadQuality?: DownloadOption;
+  /** iOS only: show a Lock Screen / Dynamic Island Live Activity while a download runs. */
+  showDownloadLiveActivity: boolean;
   defaultBitrate?: Bitrate;
   libraryOptions: LibraryOptions;
   defaultAudioLanguage: CultureDto | null;
@@ -369,6 +371,7 @@ export const defaultValues: Settings = {
   streamyStatsSeriesRecommendations: false,
   streamyStatsPromotedWatchlists: false,
   downloadQuality: DownloadOptions[0],
+  showDownloadLiveActivity: true,
   defaultBitrate: BITRATES[0],
   libraryOptions: {
     display: "list",


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Show download progress on the Lock Screen with a Live Activity (poster, title, episode, progress bar, percent, speed, queued count). On iOS 26+ we additionally submit a continued processing task (`BGContinuedProcessingTask`) when a download starts, which keeps the app running while it transfers, so the activity shows real measured progress the whole way, including chained queued episodes. The system shows its own small task pill alongside while that task runs. Apple mandates that UI for background execution and it can't be suppressed or replaced (see the DTS rationale linked below), so we title it as a status ("Downloading" plus item name) to keep it from reading as a duplicate of the card. On older iOS there is no keeper, so the activity's bar advances on a timer projection while the app is suspended and re-syncs at every wake.

Testing this surfaced real bugs, so the branch also hardens the whole download pipeline:

- Native downloader state is now confined to a serial queue (iOS) and a lock (Android). It was shared unsynchronized across four execution contexts.
- The download queue is persisted natively and re-armed on launch. In-flight downloads get a persisted pending record in JS, and a launch reconciliation settles records left by a dead process (finalize completed files, restore running ones, re-enqueue lost queued ones).
- Events carry the Jellyfin `itemId`, which replaced the taskId/URL mapping in JS.
- Android streams to a `.part` file and renames on completion, so a killed process can't leave a partial file that reconciliation would mistake for a finished download. Android also gained the `metadata` parameter JS already passes.
- The next queued download is armed synchronously inside the completion and error delegate callbacks. The old detached `Task` raced background suspension, which is why the next episode sometimes only started when you opened the app.
- One Live Activity is reused across the whole queue since iOS can't create new activities from the background. Per-download fields moved into `ContentState` to make that possible.
- The wake chain logs to the unified log (subsystem `com.fredrikburmester.streamyfin`) so background issues can be diagnosed untethered with `log collect`.

### ⚠️ Known limitation: the stop button does not cancel the download

The system task pill on iOS 26+ has a stop button. Tapping it only ends the live progress reporting. The transfer keeps running in the background session and completes normally, notification included. The card then falls back to projected progress.

We can't do better right now. Apple gives no way to tell a user tap apart from a system expiration, the same bare handler fires for both. The system also expires tasks on its own after roughly 30s without progress, which happens on transcode stalls, so wiring stop to cancel would destroy healthy downloads. DTS has acknowledged the gap and says a fix is planned, but nothing has shipped as of the iOS 26.5 SDK and iOS 27. I verified both in the SDK headers and on device.

- [BGContinuedProcessingTask expirationHandler, is there a way to distinguish the stop reason?](https://developer.apple.com/forums/thread/818873)
- [BGContinuedProcessingTask expiring unpredictably (includes DTS notes on expiration causes)](https://developer.apple.com/forums/thread/805554)
- [DTS: user/system cancellation distinction is planned, and rationale for the mandatory system UI](https://developer.apple.com/forums/thread/805088)

The keeper logs `progress.isCancelled` on every expiration, so we'll notice when Apple ships the real signal. A heuristic version (cancel when the expiration lands while bytes were still flowing) was implemented and then reverted on purpose, see ca4dccc2 and its revert 81d0ad30.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms (iOS tested on device, Android not yet)
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. `bun run prebuild`, then build Release and launch from the Home Screen. Background behavior is not representative under Metro or the debugger.
2. Download a movie, minimize and lock the phone. On iOS 26+ both the Live Activity card and the system pill keep updating with real progress until done, then the completion notification fires.
3. Queue several episodes and lock the phone. Each episode chains into the next without opening the app, and both the card and the pill switch to the new episode.
4. Kill the app from Xcode mid-download (not a swipe, that cancels transfers by design), let the download finish, reopen the app. The item shows up under downloads via launch reconciliation.
5. Tap the pill's stop button. Live progress stops and the card falls back to projected progress, but the download still completes (see limitation above).
6. On a pre-iOS 26 device only the card shows, with a bar that keeps advancing while backgrounded and dims once its projection goes stale.

https://claude.ai/code/session_013PKbkzXFzV1bFX4HdvRPPR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS Live Activities for downloads, including Lock Screen and Dynamic Island progress, artwork, speed, status, and queue information.
  * Added a setting to enable or disable download Live Activities.
  * Added support for queued downloads and richer download status updates.
* **Bug Fixes**
  * Prevented incomplete downloads from replacing finished files.
  * Improved recovery after background activity, interruptions, or app restarts.
  * Improved download spacing across supported platforms.
* **Localization**
  * Added English and Swedish translations for download activity settings and statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->