### PR TITLE
fix(nav): restore back navigation from home "See All"

### DIFF
--- a/app/(auth)/(tabs)/(libraries)/_layout.tsx
+++ b/app/(auth)/(tabs)/(libraries)/_layout.tsx
@@ -7,6 +7,18 @@ import { PlatformDropdown } from "@/components/PlatformDropdown";
 import { nestedTabPageScreenOptions } from "@/components/stacks/NestedTabPageStack";
 import { useSettings } from "@/utils/atoms/settings";
 
+// Deep entries into this tab — the home "See All" button, or tapping a library /
+// playlist row from another tab (see `itemRouter` in TouchableItemRouter) — push a
+// fully qualified `(libraries)` path from outside the tab. Without an anchor the
+// tab's stack is built as just [detail]: there is nothing to pop to, so the screen
+// has no back button and the tab stays pinned to that library, because pop-to-top
+// on a single-route stack does nothing. Anchoring the group to `index` seeds the
+// library list underneath, and the native stack renders its own back button.
+//
+// TV is excluded on purpose: its "See All" flow deliberately collapses the stack
+// back to [detail] and intercepts Back itself — see [libraryId].tsx.
+export const unstable_settings = Platform.isTV ? {} : { anchor: "index" };
+
 export default function IndexLayout() {
   const { settings, updateSettings, pluginSettings } = useSettings();
   const [dropdownOpen, setDropdownOpen] = useState(false);

--- a/app/(auth)/(tabs)/(watchlists)/_layout.tsx
+++ b/app/(auth)/(tabs)/(watchlists)/_layout.tsx
@@ -7,6 +7,12 @@ import { nestedTabPageScreenOptions } from "@/components/stacks/NestedTabPageSta
 import useRouter from "@/hooks/useAppRouter";
 import { useStreamystatsEnabled } from "@/hooks/useWatchlists";
 
+// The promoted-watchlists "See all" on the home page pushes a fully qualified
+// `(watchlists)` path from the home tab, which would otherwise build this tab's
+// stack as just [detail] — no back button, and the tab pinned to that watchlist.
+// Same reasoning as the `(libraries)` layout; see the comment there.
+export const unstable_settings = Platform.isTV ? {} : { anchor: "index" };
+
 export default function WatchlistsLayout() {
   const { t } = useTranslation();
   const router = useRouter();


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Anchor the `(libraries)` and `(watchlists)` tab groups to their `index` route, so the home "See All" button gets a working back button.

See All pushes the fully qualified `/(auth)/(tabs)/(libraries)/[libraryId]`, and that route only exists in the `(libraries)` group. That makes it a cross tab push, so Expo Router switches tab and builds the libraries stack from the URL. Without an anchor that stack is just the detail screen. There's nothing to pop to, so you get no back button, and the Libraries tab stays stuck on that library because pop to top on a one route stack does nothing.

Same fix covers the other cross tab pushes into `(libraries)` from `itemRouter` (music library, CollectionFolder, Playlist), and the promoted watchlists "See all" that strands `(watchlists)` the same way.

TV is left alone. Its See All flow already collapses the stack back to just the detail and intercepts Back itself, so its state shape doesn't change.

## 🏷️ Ticket / Issue

N/A. Related: #1679 is the same bug on tvOS, fixed separately in #1782.

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [ ] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Not verified on a device yet, so don't merge on my word. The reasoning is from the route graph and expo-router's `getRoutesCore`, not from watching it work.

1. Cold launch and go straight to Home without opening the Libraries tab first. That's the state that produces the one route stack.
2. Press "See All" on a Recently Added row. The library should open with a back chevron.
3. Press back. You should land on the library list.
4. Watch the detail for a second after it opens. If it flips to the library list on its own, that's the same bounce we hit on tvOS in #1782 and this is the wrong lever.
5. Tap the Libraries tab while on the detail. It should pop to the library list instead of staying stuck.
6. Regression check: Libraries tab, tap a library, back. Should be unchanged.

Note on the checklist: `biome` is clean. `tsc` reports one error in `app/(auth)/(tabs)/_layout.tsx:54`, but it's already there on `c1ad83c0` without this change, from stale generated `.expo/types`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation behavior when opening library and watchlist tabs.
  * Ensured non-TV platforms return to the correct tab landing page after navigating through details.
  * Preserved existing detail navigation behavior on TV platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->