### PR TITLE
feat(player): double tap to seek in the native iOS player

### DIFF
--- a/components/settings/GestureControls.tsx
+++ b/components/settings/GestureControls.tsx
@@ -10,6 +10,8 @@ import { ListItem } from "../list/ListItem";
 
 interface Props extends ViewProps {}
 
+const isIOSMobile = Platform.OS === "ios" && !Platform.isTV;
+
 export const GestureControls: React.FC<Props> = ({ ...props }) => {
   const { t } = useTranslation();
 
@@ -81,41 +83,61 @@ export const GestureControls: React.FC<Props> = ({ ...props }) => {
         </ListItem>
 
         {/* Hold-for-2x and pinch-to-zoom only exist in the iOS native
-            player — showing dead toggles on Android would be misleading. */}
-        {Platform.OS === "ios" && !Platform.isTV && (
-          <>
-            <ListItem
-              title={t("home.settings.gesture_controls.hold_to_speed")}
-              subtitle={t(
-                "home.settings.gesture_controls.hold_to_speed_description",
-              )}
+            player — showing dead toggles on Android would be misleading.
+            Each item is gated individually: ListGroup clones its children
+            to inject separator styles, which a Fragment can't accept. */}
+        {isIOSMobile && (
+          <ListItem
+            title={t("home.settings.gesture_controls.hold_to_speed")}
+            subtitle={t(
+              "home.settings.gesture_controls.hold_to_speed_description",
+            )}
+            disabled={pluginSettings?.enableHoldToSpeed?.locked}
+          >
+            <SettingSwitch
+              value={settings.enableHoldToSpeed}
               disabled={pluginSettings?.enableHoldToSpeed?.locked}
-            >
-              <SettingSwitch
-                value={settings.enableHoldToSpeed}
-                disabled={pluginSettings?.enableHoldToSpeed?.locked}
-                onValueChange={(enableHoldToSpeed) =>
-                  updateSettings({ enableHoldToSpeed })
-                }
-              />
-            </ListItem>
+              onValueChange={(enableHoldToSpeed) =>
+                updateSettings({ enableHoldToSpeed })
+              }
+            />
+          </ListItem>
+        )}
 
-            <ListItem
-              title={t("home.settings.gesture_controls.pinch_to_zoom")}
-              subtitle={t(
-                "home.settings.gesture_controls.pinch_to_zoom_description",
-              )}
+        {isIOSMobile && (
+          <ListItem
+            title={t("home.settings.gesture_controls.pinch_to_zoom")}
+            subtitle={t(
+              "home.settings.gesture_controls.pinch_to_zoom_description",
+            )}
+            disabled={pluginSettings?.enablePinchToZoom?.locked}
+          >
+            <SettingSwitch
+              value={settings.enablePinchToZoom}
               disabled={pluginSettings?.enablePinchToZoom?.locked}
-            >
-              <SettingSwitch
-                value={settings.enablePinchToZoom}
-                disabled={pluginSettings?.enablePinchToZoom?.locked}
-                onValueChange={(enablePinchToZoom) =>
-                  updateSettings({ enablePinchToZoom })
-                }
-              />
-            </ListItem>
-          </>
+              onValueChange={(enablePinchToZoom) =>
+                updateSettings({ enablePinchToZoom })
+              }
+            />
+          </ListItem>
+        )}
+
+        {isIOSMobile && (
+          <ListItem
+            title={t("home.settings.gesture_controls.double_tap_to_seek")}
+            subtitle={t(
+              "home.settings.gesture_controls.double_tap_to_seek_description",
+            )}
+            disabled={pluginSettings?.enableDoubleTapToSeek?.locked}
+          >
+            <SettingSwitch
+              value={settings.enableDoubleTapToSeek}
+              disabled={pluginSettings?.enableDoubleTapToSeek?.locked}
+              onValueChange={(enableDoubleTapToSeek) =>
+                updateSettings({ enableDoubleTapToSeek })
+              }
+            />
+          </ListItem>
         )}
 
         <ListItem

--- a/modules/mpv-player/ios/NativePlayer/PlayerConfig.swift
+++ b/modules/mpv-player/ios/NativePlayer/PlayerConfig.swift
@@ -153,6 +153,7 @@ struct UIOptionsRecord: Record {
 	@Field var showBrightnessSlider: Bool = true
 	@Field var holdToSpeedEnabled: Bool = true
 	@Field var pinchToZoomEnabled: Bool = true
+	@Field var doubleTapToSeekEnabled: Bool = false
 	/// Remote subtitle search (online sessions with an API only).
 	@Field var subtitleSearchEnabled: Bool = false
 	@Field var subtitleSearchLanguages: [SubtitleSearchLanguageRecord] = []

--- a/modules/mpv-player/ios/NativePlayer/PlayerViewModel.swift
+++ b/modules/mpv-player/ios/NativePlayer/PlayerViewModel.swift
@@ -105,6 +105,13 @@ final class PlayerViewModel: NSObject, ObservableObject {
 	@Published var seekFeedbackVisible = false
 	private var seekFeedbackTask: Task<Void, Never>?
 	#endif
+	#if os(iOS)
+	/// Direction of the last double-tap jump (true = forward) while its
+	/// feedback pill is showing; nil once the pill has faded. Lives outside
+	/// controlsVisible so the pill shows over clean video too.
+	@Published var doubleTapSeekForward: Bool?
+	private var doubleTapSeekFeedbackTask: Task<Void, Never>?
+	#endif
 	@Published var showSubtitleSearch = false
 
 	// MARK: - Content state
@@ -153,6 +160,7 @@ final class PlayerViewModel: NSObject, ObservableObject {
 	private(set) var showBrightnessSlider = true
 	private(set) var holdToSpeedEnabled = true
 	private(set) var pinchToZoomEnabled = true
+	private(set) var doubleTapToSeekEnabled = false
 	private(set) var subtitleSearchEnabled = false
 	private(set) var subtitleSearchLanguages: [SubtitleSearchLanguageRecord] = []
 	private(set) var videoWidth: Int?
@@ -322,6 +330,7 @@ final class PlayerViewModel: NSObject, ObservableObject {
 		showBrightnessSlider = config.ui.showBrightnessSlider
 		holdToSpeedEnabled = config.ui.holdToSpeedEnabled
 		pinchToZoomEnabled = config.ui.pinchToZoomEnabled
+		doubleTapToSeekEnabled = config.ui.doubleTapToSeekEnabled
 		subtitleSearchEnabled = config.ui.subtitleSearchEnabled
 		subtitleSearchLanguages = config.ui.subtitleSearchLanguages
 		subtitleScale = config.subtitleStyle?.scale ?? 1.0
@@ -483,6 +492,29 @@ final class PlayerViewModel: NSObject, ObservableObject {
 		haptic()
 		seek(to: displayPosition - seekBackwardSec)
 	}
+
+	#if os(iOS)
+	/// Double tap on empty video: right half jumps forward, left half back
+	/// (settings.enableDoubleTapToSeek). Same guards as the surface drag —
+	/// lock mode and end-of-playback overlays swallow the gesture.
+	func doubleTapSeek(forward: Bool) {
+		guard doubleTapToSeekEnabled, !controlsLocked, !showStillWatching,
+			errorMessage == nil, duration > 0
+		else { return }
+		if forward {
+			seekForward()
+		} else {
+			seekBackward()
+		}
+		doubleTapSeekForward = forward
+		doubleTapSeekFeedbackTask?.cancel()
+		doubleTapSeekFeedbackTask = Task { [weak self] in
+			try? await Task.sleep(nanoseconds: 800_000_000)
+			guard !Task.isCancelled, let self else { return }
+			await MainActor.run { self.doubleTapSeekForward = nil }
+		}
+	}
+	#endif
 
 	// MARK: Scrubbing
 

--- a/modules/mpv-player/ios/NativePlayer/Views/PlayerCenterControls.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/PlayerCenterControls.swift
@@ -136,14 +136,8 @@ struct PlayerCenterControls: View {
 		}
 	}
 
-	/// SF Symbols only ship numbered seek glyphs for specific intervals.
-	private func seekSymbol(prefix: String, seconds: Double) -> String {
-		let supported: Set<Int> = [5, 10, 15, 30, 45, 60, 75, 90]
-		// Int(_: Double) traps on non-finite input; this runs in body, so a
-		// bad persisted skip-time setting must degrade, not crash.
-		guard let rounded = Int(exactly: seconds.rounded()) else { return prefix }
-		return supported.contains(rounded) ? "\(prefix).\(rounded)" : prefix
-	}
+	// seekSymbol lives in Views/TimeFormatting.swift (shared with the
+	// double-tap seek feedback pill).
 
 	private func controlButton(
 		systemName: String,

--- a/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
@@ -42,9 +42,7 @@ struct PlayerControlsRootView: View {
 			// Tap-to-toggle catcher behind everything interactive; also the
 			// gesture surface — controls layered above receive their own
 			// touches first, so drags here only start on empty video area.
-			Color.clear
-				.contentShape(Rectangle())
-				.onTapGesture { viewModel.toggleControls() }
+			tapSurface(size: size)
 				.gesture(surfaceDragGesture(size: size))
 				.gesture(holdSpeedGesture)
 
@@ -144,6 +142,31 @@ struct PlayerControlsRootView: View {
 				.allowsHitTesting(false)
 			}
 
+			// Double-tap seek feedback: the numbered seek glyph flashes on the
+			// tapped half; lives outside controlsVisible so it shows over
+			// clean video too. id(forward) swaps sides via a crossfade instead
+			// of sliding the pill across the screen.
+			if let forward = viewModel.doubleTapSeekForward {
+				HStack {
+					if forward { Spacer() }
+					Image(
+						systemName: seekSymbol(
+							prefix: forward ? "goforward" : "gobackward",
+							seconds: forward ? viewModel.seekForwardSec : viewModel.seekBackwardSec
+						)
+					)
+					.font(.system(size: 28, weight: .semibold))
+					.foregroundStyle(.white)
+					.padding(18)
+					.background(.black.opacity(0.55), in: Circle())
+					if !forward { Spacer() }
+				}
+				.id(forward)
+				.padding(.horizontal, 48)
+				.transition(.opacity)
+				.allowsHitTesting(false)
+			}
+
 			// Lock mode: taps only toggle this transient unlock pill.
 			if viewModel.controlsLocked && viewModel.unlockButtonRevealed {
 				VStack {
@@ -207,6 +230,7 @@ struct PlayerControlsRootView: View {
 		.animation(.easeInOut(duration: 0.2), value: viewModel.brightnessSliderRevealed)
 		.animation(.easeInOut(duration: 0.2), value: viewModel.unlockButtonRevealed)
 		.animation(.easeInOut(duration: 0.15), value: viewModel.isHoldSpeedActive)
+		.animation(.easeInOut(duration: 0.15), value: viewModel.doubleTapSeekForward)
 		// SwiftUI never delivers onEnded when the SYSTEM cancels the touch
 		// (incoming call, Control Center edge swipe, backgrounding) — release
 		// an engaged hold here or playback stays stuck at 2×.
@@ -226,6 +250,29 @@ struct PlayerControlsRootView: View {
 	}
 
 	// MARK: - Surface gestures
+
+	/// The tap catcher. With double-tap-to-seek on, the double tap is
+	/// composed exclusively before the single tap, so the toggle waits out
+	/// the double-tap window; when off (the default, and in lock mode where
+	/// taps must keep revealing the unlock pill instantly) no double tap is
+	/// attached at all and the toggle stays immediate.
+	@ViewBuilder
+	private func tapSurface(size: CGSize) -> some View {
+		let surface = Color.clear.contentShape(Rectangle())
+		if viewModel.doubleTapToSeekEnabled && !viewModel.controlsLocked {
+			surface.gesture(
+				SpatialTapGesture(count: 2)
+					.onEnded { value in
+						viewModel.doubleTapSeek(forward: value.location.x >= size.width / 2)
+					}
+					.exclusively(
+						before: TapGesture().onEnded { viewModel.toggleControls() }
+					)
+			)
+		} else {
+			surface.onTapGesture { viewModel.toggleControls() }
+		}
+	}
 
 	/// Press-and-hold anywhere on empty video = 2× until release. The long
 	/// press alone ends the moment its duration elapses, so it sequences into

--- a/modules/mpv-player/ios/NativePlayer/Views/TimeFormatting.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TimeFormatting.swift
@@ -13,3 +13,13 @@ func formatTime(_ seconds: Double) -> String {
 	}
 	return String(format: "%d:%02d", minutes, secs)
 }
+
+/// SF Symbols only ship numbered seek glyphs for specific intervals. Shared
+/// by the center transport buttons and the double-tap seek feedback pill.
+func seekSymbol(prefix: String, seconds: Double) -> String {
+	let supported: Set<Int> = [5, 10, 15, 30, 45, 60, 75, 90]
+	// Int(_: Double) traps on non-finite input; this runs in body, so a
+	// bad persisted skip-time setting must degrade, not crash.
+	guard let rounded = Int(exactly: seconds.rounded()) else { return prefix }
+	return supported.contains(rounded) ? "\(prefix).\(rounded)" : prefix
+}

--- a/modules/mpv-player/src/NativePlayerPresentation.types.ts
+++ b/modules/mpv-player/src/NativePlayerPresentation.types.ts
@@ -226,6 +226,8 @@ export type NativePlayerUIOptions = {
   holdToSpeedEnabled?: boolean;
   /** false disables pinch to zoom-to-fill (settings.enablePinchToZoom). */
   pinchToZoomEnabled?: boolean;
+  /** true enables double tap on the video halves to seek (settings.enableDoubleTapToSeek). */
+  doubleTapToSeekEnabled?: boolean;
   /** Remote subtitle search entry in the subtitles menu (online only). */
   subtitleSearchEnabled?: boolean;
   /** ISO 639-2 codes + localized display names for the language picker. */

--- a/translations/en.json
+++ b/translations/en.json
@@ -262,6 +262,8 @@
         "hold_to_speed_description": "Press and hold the video to play at 2× speed until released",
         "pinch_to_zoom": "Pinch to zoom",
         "pinch_to_zoom_description": "Pinch out to fill the screen, pinch in to fit",
+        "double_tap_to_seek": "Double tap to seek",
+        "double_tap_to_seek_description": "Double tap the left or right side of the video to skip backward or forward",
         "hide_volume_slider": "Hide volume slider",
         "hide_volume_slider_description": "Hide the volume slider in the video player",
         "hide_brightness_slider": "Hide brightness slider",

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -262,6 +262,8 @@
         "hold_to_speed_description": "Tryck och håll på videon för att spela i 2× hastighet tills du släpper",
         "pinch_to_zoom": "Nyp för att zooma",
         "pinch_to_zoom_description": "Nyp utåt för att fylla skärmen, nyp inåt för att anpassa",
+        "double_tap_to_seek": "Dubbeltryck för att hoppa",
+        "double_tap_to_seek_description": "Dubbeltryck på vänster eller höger sida av videon för att hoppa bakåt eller framåt",
         "hide_volume_slider": "Dölj volymreglage",
         "hide_volume_slider_description": "Dölj volymreglaget i videospelaren",
         "hide_brightness_slider": "Dölj ljusstyrkeglage",

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -364,6 +364,7 @@ export type Settings = {
   enableRightSideVolumeSwipe: boolean;
   enableHoldToSpeed: boolean;
   enablePinchToZoom: boolean;
+  enableDoubleTapToSeek: boolean;
   hideVolumeSlider: boolean;
   hideBrightnessSlider: boolean;
   usePopularPlugin: boolean;
@@ -483,6 +484,7 @@ export const defaultValues: Settings = {
   enableRightSideVolumeSwipe: true,
   enableHoldToSpeed: true,
   enablePinchToZoom: true,
+  enableDoubleTapToSeek: false,
   hideVolumeSlider: false,
   hideBrightnessSlider: false,
   usePopularPlugin: true,

--- a/utils/nativePlayer/buildNativePlayerConfig.ts
+++ b/utils/nativePlayer/buildNativePlayerConfig.ts
@@ -532,6 +532,7 @@ export async function buildNativePlayerConfig(params: {
       // Touch gestures — no equivalent on the Siri remote.
       holdToSpeedEnabled: !Platform.isTV && settings.enableHoldToSpeed,
       pinchToZoomEnabled: !Platform.isTV && settings.enablePinchToZoom,
+      doubleTapToSeekEnabled: !Platform.isTV && settings.enableDoubleTapToSeek,
       // Server search needs connectivity; the OpenSubtitles fallback needs
       // the network either way — offline sessions hide the entry.
       subtitleSearchEnabled: !offline && !!api,


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Add double tap to seek to the native iOS player. Double tap the right half of the video to skip forward, the left half to skip back, using the configured skip times. A glyph flashes briefly on the tapped half as feedback. Off by default, toggled under Settings > Gesture controls (iOS only). When it's off, or the controls are locked, no double tap recognizer is attached, so tap to toggle controls stays instant.

Also fixes the gesture settings group rendering. ListGroup clones its children to inject separator styles, which broke when the iOS-only toggles were wrapped in a Fragment. Each item is now gated individually.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Native change, needs a rebuild (`bun run ios`).

1. Enable "Double tap to seek" in Settings > Gesture controls on an iPhone or iPad.
2. Play something in the native player. Double tap the right half of the video, playback jumps forward and a glyph flashes. Left half jumps back.
3. Single tap still toggles the controls (slightly delayed while the feature is on, that's the double tap window).
4. Turn the setting off and verify double tap does nothing and single tap is instant again.
5. In the gesture controls settings group, verify the separators between the iOS-only toggles render correctly.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an iOS video-player option for double-tap seeking.
  - Double-tap the left or right side of the video to seek backward or forward, with visual feedback.
  - Gesture controls now display individually on supported iOS mobile devices.
  - Added English and Swedish translations for the new setting.

- **Settings**
  - Double-tap seeking is disabled by default and can be enabled in gesture controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->