### PR TITLE
fix(player): pause tvOS playback when the app is backgrounded

### DIFF
--- a/modules/mpv-player/ios/MpvPlayerView.swift
+++ b/modules/mpv-player/ios/MpvPlayerView.swift
@@ -67,8 +67,6 @@ class MpvPlayerView: ExpoView {
 	let onTracksReady = EventDispatcher()
 	let onPictureInPictureChange = EventDispatcher()
 
-	private var appStateObserver: NSObjectProtocol?
-
 	required init(appContext: AppContext? = nil) {
 		super.init(appContext: appContext)
 		setupView()
@@ -100,17 +98,8 @@ class MpvPlayerView: ExpoView {
 		} catch {
 			onError(["error": "Failed to start renderer: \(error.localizedDescription)"])
 		}
-
-		// Pause playback when app enters background on tvOS
-		#if os(tvOS)
-		appStateObserver = NotificationCenter.default.addObserver(
-			forName: UIApplication.didEnterBackgroundNotification,
-			object: nil,
-			queue: .main
-		) { [weak self] _ in
-			self?.pause()
-		}
-		#endif
+		// Pause-on-background for tvOS now lives in MPVPlayerEngine so the
+		// presented native player gets it too.
 	}
 
 	override func layoutSubviews() {
@@ -294,9 +283,6 @@ class MpvPlayerView: ExpoView {
 	}
 
 	deinit {
-		if let observer = appStateObserver {
-			NotificationCenter.default.removeObserver(observer)
-		}
 		#if os(tvOS)
 		resetDisplayCriteria()
 		#endif

--- a/modules/mpv-player/ios/NativePlayer/PlayerViewModel.swift
+++ b/modules/mpv-player/ios/NativePlayer/PlayerViewModel.swift
@@ -1020,7 +1020,12 @@ final class PlayerViewModel: NSObject, ObservableObject {
 	// MARK: PiP / close
 
 	func togglePictureInPicture() {
-		guard let engine else { return }
+		guard let engine else {
+			Logger.shared.log("PiP: button pressed but engine is nil", type: "Error")
+			return
+		}
+		Logger.shared.log(
+			"PiP: button pressed (active=\(engine.isPictureInPictureActive()))", type: "Info")
 		if engine.isPictureInPictureActive() {
 			engine.stopPictureInPicture()
 		} else {

--- a/modules/mpv-player/ios/PiPController.swift
+++ b/modules/mpv-player/ios/PiPController.swift
@@ -69,11 +69,17 @@ final class PiPController: NSObject {
     }
     
     private func setupPictureInPicture() {
-        guard isPictureInPictureSupported,
-              let displayLayer = sampleBufferDisplayLayer else {
+        guard isPictureInPictureSupported else {
+            Logger.shared.log(
+                "PiP: setup skipped — AVPictureInPictureController.isPictureInPictureSupported() == false",
+                type: "Warn")
             return
         }
-        
+        guard let displayLayer = sampleBufferDisplayLayer else {
+            Logger.shared.log("PiP: setup skipped — no sample buffer display layer", type: "Warn")
+            return
+        }
+
         let contentSource = AVPictureInPictureController.ContentSource(
             sampleBufferDisplayLayer: displayLayer,
             playbackDelegate: self
@@ -82,6 +88,9 @@ final class PiPController: NSObject {
         pipController = AVPictureInPictureController(contentSource: contentSource)
         pipController?.delegate = self
         pipController?.requiresLinearPlayback = false
+        Logger.shared.log(
+            "PiP: controller created (possible=\(pipController?.isPictureInPicturePossible ?? false))",
+            type: "Info")
     }
 
     /// Enable/disable auto-PiP ("swipe up while playing").
@@ -103,11 +112,26 @@ final class PiPController: NSObject {
     }
 
     func startPictureInPicture() {
-        guard let pipController = pipController,
-              pipController.isPictureInPicturePossible else {
+        guard let pipController = pipController else {
+            Logger.shared.log("PiP: start refused — controller was never created", type: "Error")
             return
         }
-        
+        Logger.shared.log(
+            "PiP: start requested — supported=\(isPictureInPictureSupported) "
+                + "possible=\(pipController.isPictureInPicturePossible) "
+                + "active=\(pipController.isPictureInPictureActive) "
+                + "layerReady=\(sampleBufferDisplayLayer?.isReadyForMoreMediaData ?? false) "
+                + "hasTimebase=\(sampleBufferDisplayLayer?.controlTimebase != nil)",
+            type: "Info")
+        // The silent one: AVKit only lets PiP begin once it considers the
+        // source eligible, and there is no callback for "never became
+        // possible" — so log the refusal rather than returning into the void.
+        guard pipController.isPictureInPicturePossible else {
+            Logger.shared.log(
+                "PiP: start aborted — isPictureInPicturePossible == false", type: "Error")
+            return
+        }
+
         pipController.startPictureInPicture()
     }
     
@@ -191,7 +215,7 @@ extension PiPController: AVPictureInPictureControllerDelegate {
     }
     
     func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {
-        print("Failed to start PiP: \(error)")
+        Logger.shared.log("PiP: failed to start — \(error.localizedDescription)", type: "Error")
         delegate?.pipController(self, didStartPictureInPicture: false)
     }
     

--- a/modules/mpv-player/ios/PlayerEngine.swift
+++ b/modules/mpv-player/ios/PlayerEngine.swift
@@ -62,7 +62,33 @@ final class MPVPlayerEngine: NSObject {
 		NotificationCenter.default.addObserver(
 			self, selector: #selector(handleAudioSessionInterruption),
 			name: AVAudioSession.interruptionNotification, object: nil)
+
+		// tvOS has no windowed/minimized state: leaving the app backgrounds it
+		// outright. The `audio` background mode keeps our `.playback` session
+		// alive across that, so mpv would go on decoding audio behind the Home
+		// screen with nothing on screen to stop it. Pause instead. Owned here
+		// rather than by the host so BOTH hosts (RN-embedded view and presented
+		// native player) inherit it.
+		#if os(tvOS)
+		NotificationCenter.default.addObserver(
+			self, selector: #selector(handleDidEnterBackground),
+			name: UIApplication.didEnterBackgroundNotification, object: nil)
+		#endif
 	}
+
+	#if os(tvOS)
+	/// PiP would be the one way playback is *meant* to outlive the foreground
+	/// app, so it opts out. Today that guard never fires on tvOS: AVKit never
+	/// engages PiP for an AVSampleBufferDisplayLayer content source there (it
+	/// reports isPictureInPictureSupported() == true but leaves
+	/// isPictureInPicturePossible false forever and never calls the sample
+	/// buffer playback delegate), and mpv has no AVPlayerLayer to offer
+	/// instead. Kept so this stays correct if Apple ever ships the fix.
+	@objc private func handleDidEnterBackground() {
+		guard !isPictureInPictureActive() else { return }
+		pause()
+	}
+	#endif
 
 	func start() throws {
 		try renderer?.start()
@@ -327,8 +353,9 @@ final class MPVPlayerEngine: NSObject {
 	}
 
 	func startPictureInPicture() {
-		print("🎬 MPVPlayerEngine: startPictureInPicture called")
-		print("🎬 Duration: \(getDuration()), IsPlaying: \(!isPaused())")
+		Logger.shared.log(
+			"PiP: engine asked to start (duration=\(getDuration()) playing=\(!isPaused()))",
+			type: "Info")
 		pipController?.startPictureInPicture()
 	}
 
@@ -546,7 +573,7 @@ extension MPVPlayerEngine: MPVLayerRendererDelegate {
 
 extension MPVPlayerEngine: PiPControllerDelegate {
 	func pipController(_ controller: PiPController, willStartPictureInPicture: Bool) {
-		print("PiP will start")
+		Logger.shared.log("PiP: will start", type: "Info")
 		// Sync timebase before PiP starts for smooth transition
 		renderer?.syncTimebase()
 		// Set current time for PiP progress bar
@@ -559,7 +586,7 @@ extension MPVPlayerEngine: PiPControllerDelegate {
 	}
 
 	func pipController(_ controller: PiPController, didStartPictureInPicture: Bool) {
-		print("PiP did start: \(didStartPictureInPicture)")
+		Logger.shared.log("PiP: did start = \(didStartPictureInPicture)", type: "Info")
 		// Ensure current time is synced when PiP starts
 		pipController?.setCurrentTimeFromSeconds(cachedPosition, duration: cachedDuration)
 		// Notify the host of the actual PiP active state. `didStartPictureInPicture`
@@ -568,13 +595,13 @@ extension MPVPlayerEngine: PiPControllerDelegate {
 	}
 
 	func pipController(_ controller: PiPController, willStopPictureInPicture: Bool) {
-		print("PiP will stop")
+		Logger.shared.log("PiP: will stop", type: "Info")
 		// Sync timebase before returning from PiP
 		renderer?.syncTimebase()
 	}
 
 	func pipController(_ controller: PiPController, didStopPictureInPicture: Bool) {
-		print("PiP did stop")
+		Logger.shared.log("PiP: did stop", type: "Info")
 		// Ensure timebase is synced after PiP ends
 		renderer?.syncTimebase()
 		pipController?.updatePlaybackState()
@@ -589,7 +616,7 @@ extension MPVPlayerEngine: PiPControllerDelegate {
 	}
 
 	func pipController(_ controller: PiPController, restoreUserInterfaceForPictureInPictureStop completionHandler: @escaping (Bool) -> Void) {
-		print("PiP restore user interface")
+		Logger.shared.log("PiP: restore user interface requested", type: "Info")
 		completionHandler(true)
 	}
 


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Pause playback when the app is backgrounded on tvOS. Leaving the app kept mpv decoding audio behind the Home screen, and there are no Now Playing controls on TV to stop it.

`MpvPlayerView` already had this guard, but the new native tvOS player drives `MPVPlayerEngine` directly and never got it. I moved it into the engine so both players inherit it.

I also switched the PiP logging from `print()` to the existing `Logger`. `print()` output is invisible on a device unless Xcode is attached, which is what made this hard to debug. `Logger` writes to `logs.txt` in the app container, which you can pull with `devicectl`.

That logging also settled why there is no PiP button on TV. tvOS reports `isPictureInPictureSupported() == true` but then leaves `isPictureInPicturePossible` false forever and never calls the sample buffer playback delegate, so PiP never starts. It needs an `AVPlayerLayer` and mpv renders into an `AVSampleBufferDisplayLayer` (see https://github.com/jazzychad/PiPBugDemo). iOS PiP is unchanged.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [ ] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

On Apple TV (`bun run ios:tv`):

1. Play something in the native tvOS player.
2. Press the TV button to go to the Home screen.
3. Verify the audio stops instead of continuing to play.
4. Go back into the app and verify playback is paused and resumes normally.

On iPhone, verify nothing changed: background audio still plays, and PiP still starts when you minimize the app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playback now pauses automatically when the app moves to the background on tvOS, unless Picture-in-Picture is active.
  * Improved Picture-in-Picture handling prevents unsupported or unavailable configurations from attempting to start.
* **Improvements**
  * Added clearer diagnostic information for Picture-in-Picture setup, startup, and toggle actions, making failures easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->