### PR TITLE
feat(player): UIKit focus orchestration and native chrome for the tvOS player

### DIFF
--- a/modules/mpv-player/ios/NativePlayer/NativePlayerViewController.swift
+++ b/modules/mpv-player/ios/NativePlayer/NativePlayerViewController.swift
@@ -7,10 +7,14 @@ import CoreMedia
 #endif
 
 /// Full-screen presented player: hosts the engine's display layer and a
-/// SwiftUI controls overlay (child UIHostingController). On iOS it owns
-/// orientation, status bar, home indicator and keep-awake for the duration of
-/// playback; on tvOS it owns the Siri Remote press handling (SwiftUI focus is
-/// only used INSIDE panels/shelves in later phases).
+/// SwiftUI controls overlay. On iOS that overlay is a single child
+/// UIHostingController and the VC owns orientation, status bar, home
+/// indicator and keep-awake for the duration of playback. On tvOS the VC
+/// owns the Siri Remote press handling AND the focus orchestration: the
+/// overlay is split into stacked layer hosts (chrome, status, shelf,
+/// subtitle search, still watching, error) and TVFocusCoordinator decides
+/// which single layer the focus engine may see at any moment — SwiftUI
+/// handles focus WITHIN a layer, UIKit decides between layers.
 final class NativePlayerViewController: UIViewController {
 	private let engine: MPVPlayerEngine
 	private let viewModel: PlayerViewModel
@@ -21,7 +25,9 @@ final class NativePlayerViewController: UIViewController {
 
 	private let videoContainerView = UIView()
 	#if os(tvOS)
-	private var hostingController: UIHostingController<AnyView>?
+	/// UIKit-side focus orchestration between the stacked layer hosts —
+	/// see TVFocusCoordinator for the sequencing contract.
+	private let focusCoordinator = TVFocusCoordinator()
 	#else
 	private var hostingController: UIHostingController<PlayerControlsRootView>?
 	#endif
@@ -120,16 +126,39 @@ final class NativePlayerViewController: UIViewController {
 		// The TV chrome is tvOS 26+ by design (native glass menus etc.) —
 		// the JS chooser never routes older boxes here, so pre-26 gets a
 		// bare spinner-less surface as a defensive fallback only.
-		let tvRoot: AnyView
+		//
+		// One hosting controller per layer, stacked back-to-front. The zones
+		// (.chrome/.shelf/...) are the focusable layers; the coordinator
+		// enables exactly one of their host views at a time, which is the
+		// UIKit-level containment that used to be per-view .disabled()
+		// bookkeeping. `zone: nil` layers are display-only and never join
+		// the focus system.
 		if #available(tvOS 26.0, *) {
-			tvRoot = AnyView(TVPlayerRootView(viewModel: viewModel))
+			addOverlayLayer(
+				AnyView(
+					TVChromeLayerView(viewModel: viewModel, focusCoordinator: focusCoordinator)),
+				zone: .chrome)
+			addOverlayLayer(AnyView(TVStatusLayerView(viewModel: viewModel)), zone: nil)
+			addOverlayLayer(
+				AnyView(
+					TVShelfLayerView(viewModel: viewModel, focusCoordinator: focusCoordinator)),
+				zone: .shelf)
+			addOverlayLayer(
+				AnyView(
+					TVSubtitleSearchLayerView(
+						viewModel: viewModel, focusCoordinator: focusCoordinator)),
+				zone: .subtitleSearch)
+			addOverlayLayer(
+				AnyView(
+					TVStillWatchingLayerView(
+						viewModel: viewModel, focusCoordinator: focusCoordinator)),
+				zone: .stillWatching)
+			addOverlayLayer(AnyView(TVErrorLayerView(viewModel: viewModel)), zone: nil)
 		} else {
-			tvRoot = AnyView(EmptyView())
+			addOverlayLayer(AnyView(EmptyView()), zone: nil)
 		}
-		let hosting = UIHostingController(rootView: tvRoot)
 		#else
 		let hosting = UIHostingController(rootView: PlayerControlsRootView(viewModel: viewModel))
-		#endif
 		hosting.view.backgroundColor = .clear
 		addChild(hosting)
 		hosting.view.translatesAutoresizingMaskIntoConstraints = false
@@ -142,6 +171,7 @@ final class NativePlayerViewController: UIViewController {
 		])
 		hosting.didMove(toParent: self)
 		hostingController = hosting
+		#endif
 
 		#if os(iOS)
 		viewModel.$controlsVisible
@@ -218,6 +248,42 @@ final class NativePlayerViewController: UIViewController {
 		#endif
 	}
 
+	// MARK: - tvOS layer hosting & focus orchestration
+
+	#if os(tvOS)
+	/// Adds one full-screen SwiftUI layer as a child hosting controller.
+	/// Layers stack in call order (later = on top). A `zone` registers the
+	/// layer with the focus coordinator, which enables its host view only
+	/// while that zone is active; `zone: nil` layers are display-only and
+	/// never join the focus system.
+	private func addOverlayLayer(_ root: AnyView, zone: TVFocusZone?) {
+		let hosting = UIHostingController(rootView: root)
+		hosting.view.backgroundColor = .clear
+		hosting.view.isUserInteractionEnabled = false
+		addChild(hosting)
+		hosting.view.translatesAutoresizingMaskIntoConstraints = false
+		view.addSubview(hosting.view)
+		NSLayoutConstraint.activate([
+			hosting.view.topAnchor.constraint(equalTo: view.topAnchor),
+			hosting.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+			hosting.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+			hosting.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+		])
+		hosting.didMove(toParent: self)
+		if let zone {
+			focusCoordinator.register(hosting.view, for: zone)
+		}
+	}
+
+	/// System-driven focus updates (initial assignment when the window
+	/// attaches, restore after a UIAlertController dismisses) resolve into
+	/// whatever layer the coordinator has active.
+	override var preferredFocusEnvironments: [UIFocusEnvironment] {
+		let environments = focusCoordinator.preferredEnvironments
+		return environments.isEmpty ? super.preferredFocusEnvironments : environments
+	}
+	#endif
+
 	#if os(iOS)
 	@objc private func handlePinch(_ recognizer: UIPinchGestureRecognizer) {
 		switch recognizer.state {
@@ -283,6 +349,12 @@ final class NativePlayerViewController: UIViewController {
 		#if os(iOS)
 		UIApplication.shared.setStatusBarHidden(!viewModel.controlsVisible, with: .none)
 		#endif
+		#if os(tvOS)
+		// The initial zone activation ran at viewDidLoad time, before the
+		// view joined a window — no focus system existed and the kick was
+		// dropped. Re-assert now that focus updates can resolve.
+		focusCoordinator.refresh()
+		#endif
 	}
 
 	override func viewWillDisappear(_ animated: Bool) {
@@ -302,10 +374,11 @@ final class NativePlayerViewController: UIViewController {
 	// MARK: - tvOS remote input
 
 	#if os(tvOS)
-	/// VC-level press recognizers own the transport gestures; SwiftUI focus is
-	/// reserved for panels/shelves (later phases). Consuming Menu here is
-	/// mandatory: an unhandled Menu press on a presented full-screen VC would
-	/// suspend the app instead of closing the player.
+	/// VC-level press recognizers own the transport gestures whenever no
+	/// focusable layer is up (zone .none); the zone sink below hands the
+	/// remote to SwiftUI focus otherwise. Consuming Menu here is mandatory:
+	/// an unhandled Menu press on a presented full-screen VC would suspend
+	/// the app instead of closing the player.
 	private func setupRemotePressRecognizers() {
 		// Menu stays enabled even while the options panel owns the remote:
 		// if focus ever fails to land inside the panel, an unhandled Menu
@@ -328,32 +401,37 @@ final class NativePlayerViewController: UIViewController {
 		view.addGestureRecognizer(pan)
 		remoteRecognizers.append(pan)
 
-		// Focus mode: whenever the button chrome is up, SwiftUI focus owns
-		// the remote and the transport recognizers go quiet (a recognizer
-		// firing on .select would eat the press before the focused Button
-		// gets it). Scrubbing keeps them live — the bar shows without
-		// focusable content in that state. The native Menu popups present in
-		// their own window, so they never see these recognizers at all.
+		// Zone routing: whenever any focusable layer is up, SwiftUI focus
+		// owns the remote and the transport recognizers go quiet (a
+		// recognizer firing on .select would eat the press before the
+		// focused Button gets it). Scrubbing keeps them live — the bar shows
+		// without focusable content in that state. The native Menu popups
+		// present in their own window, so they never see these recognizers
+		// at all. The coordinator flips host focusability and points the
+		// focus engine at the active layer AFTER SwiftUI commits — see
+		// TVFocusCoordinator for why that ordering is the whole ballgame.
 		Publishers.CombineLatest4(
 			viewModel.$controlsVisible, viewModel.$isScrubbing,
 			viewModel.$showEpisodeList, viewModel.$showStillWatching
 		)
 		.combineLatest(viewModel.$showSubtitleSearch)
-		.map { state, subtitleSearch in
+		.map { state, subtitleSearch -> TVFocusZone in
 			let (visible, scrubbing, shelf, stillWatching) = state
-			return (visible && !scrubbing) || shelf || stillWatching || subtitleSearch
+			// Top-most focusable layer wins — mirror of the hosts' z-order.
+			if stillWatching { return .stillWatching }
+			if subtitleSearch { return .subtitleSearch }
+			if shelf { return .shelf }
+			if visible && !scrubbing { return .chrome }
+			return .none
 		}
 		.removeDuplicates()
 		.receive(on: DispatchQueue.main)
-		.sink { [weak self] focusMode in
+		.sink { [weak self] zone in
 			guard let self else { return }
 			for recognizer in self.remoteRecognizers {
-				recognizer.isEnabled = !focusMode
+				recognizer.isEnabled = zone == TVFocusZone.none
 			}
-			// No forced focus-engine kick here: SwiftUI requests focus itself
-			// when focusable content mounts, and a UIKit-level update would
-			// resolve to the left-most button, stomping the row's remembered
-			// default (prefersDefaultFocus/FocusState restore).
+			self.focusCoordinator.activate(zone)
 		}
 		.store(in: &cancellables)
 	}

--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVChromeLayerView.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVChromeLayerView.swift
@@ -1,17 +1,29 @@
 #if os(tvOS)
 import SwiftUI
 
-/// tvOS root overlay. Phase 2: show/hide chrome with a bottom transport bar
-/// (progress + times + ends-at) and a top-left metadata header. Nothing here
-/// is focusable — all transport input arrives through the hosting view
-/// controller's press recognizers, so Menu reliably reaches the VC. SwiftUI
-/// focus enters only with the panels/shelves of later phases.
+/// The chrome layer of the TV player: scrims, metadata header, the focusable
+/// controls row and the transport bar. One of the stacked layer hosts built
+/// by NativePlayerViewController — TVFocusCoordinator flips this host into
+/// the focus system when the zone is .chrome and points the engine at it
+/// after SwiftUI commits, so the row's prefersDefaultFocus memory is honored
+/// on the engine's first pick. The status/shelf/subtitle-search/
+/// still-watching/error layers live in TVOverlayLayers.swift.
 @available(tvOS 26.0, *)
-struct TVPlayerRootView: View {
+struct TVChromeLayerView: View {
 	@ObservedObject var viewModel: PlayerViewModel
+	let focusCoordinator: TVFocusCoordinator
 	/// Focus memory for the button row — lives here because the row unmounts
 	/// whenever the chrome hides, and should reappear on the same control.
 	@State private var lastFocusedControl: TVControl?
+
+	/// Chrome inset ON TOP OF the tvOS overscan safe area, which SwiftUI has
+	/// already applied by the time this runs: the layer hosts are pinned to
+	/// the full view bounds, not the safe-area guide, so the system's ~90pt
+	/// horizontal / ~60pt vertical insets are inside these. Keep them small —
+	/// the old 80/60 put the transport bar ~170pt from the screen edge, far
+	/// deeper than the system player.
+	private static let insetH: CGFloat = 40
+	private static let insetV: CGFloat = 24
 
 	var body: some View {
 		ZStack {
@@ -24,101 +36,29 @@ struct TVPlayerRootView: View {
 				VStack {
 					TVMetadataHeader(viewModel: viewModel)
 					Spacer()
-					VStack(alignment: .leading, spacing: 30) {
+					// Tight: nothing sits between the button row and the track
+					// now that the chapter label moved down under the elapsed
+					// time, so the row can sit close to the bar it drives.
+					VStack(alignment: .leading, spacing: 16) {
 						if viewModel.controlsVisible, !viewModel.isScrubbing {
 							TVControlsRow(
 								viewModel: viewModel,
-								lastFocused: $lastFocusedControl
+								lastFocused: $lastFocusedControl,
+								focusCoordinator: focusCoordinator
 							)
 						}
 						TVTransportBar(viewModel: viewModel, time: viewModel.time)
 					}
 				}
-				.padding(.horizontal, 80)
-				.padding(.vertical, 60)
+				.padding(.horizontal, Self.insetH)
+				.padding(.vertical, Self.insetV)
 				.transition(.opacity)
-			}
-
-			if viewModel.isBuffering && viewModel.errorMessage == nil {
-				ProgressView()
-					.progressViewStyle(.circular)
-					.tint(.white)
-					.scaleEffect(1.6)
-			}
-
-			// Stats for nerds — independent of the chrome, like on iOS. The
-			// shared overlay is phone-sized; scale it up for viewing distance.
-			if viewModel.showTechnicalInfo {
-				VStack {
-					HStack {
-						TechnicalInfoOverlay(viewModel: viewModel)
-							.scaleEffect(1.5, anchor: .topLeading)
-						Spacer()
-					}
-					Spacer()
-				}
-				.padding(.top, 60)
-				.padding(.leading, 80)
-			}
-
-			// Skip pill / countdown card (Select acts on both) stay
-			// actionable while the chrome is hidden, via the VC recognizers.
-			// In the full chrome both yield to the row's focusable Skip /
-			// Next-episode buttons — focus owns the remote there, so a
-			// non-focusable card next to focusable glass buttons reads as a
-			// control that focus can never reach.
-			if !viewModel.controlsVisible, !viewModel.showEpisodeList,
-				!viewModel.showSubtitleSearch {
-				VStack {
-					Spacer()
-					HStack {
-						Spacer()
-						if let countdown = viewModel.countdownRemaining,
-							let next = viewModel.nextEpisode {
-							TVCountdownCard(
-								viewModel: viewModel, next: next, remaining: countdown)
-						} else if let segment = viewModel.activeSegment,
-							!viewModel.isScrubbing {
-							TVSkipPill(viewModel: viewModel, segment: segment)
-						}
-					}
-				}
-				.padding(.trailing, 80)
-				.padding(.bottom, 80)
-			}
-
-			if viewModel.showEpisodeList {
-				VStack {
-					Spacer()
-					TVEpisodeShelf(viewModel: viewModel)
-				}
-				.transition(.move(edge: .bottom).combined(with: .opacity))
-				.zIndex(3)
-			}
-
-			if viewModel.showSubtitleSearch {
-				TVSubtitleSearchPanel(viewModel: viewModel)
-					.transition(.opacity)
-					.zIndex(4)
-			}
-
-			if viewModel.showStillWatching {
-				TVStillWatchingCard(viewModel: viewModel)
-					.zIndex(5)
-			}
-
-			if let message = viewModel.errorMessage {
-				errorOverlay(message: message)
 			}
 		}
 		.frame(maxWidth: .infinity, maxHeight: .infinity)
 		.animation(.easeInOut(duration: 0.2), value: viewModel.controlsVisible)
 		.animation(.easeInOut(duration: 0.2), value: viewModel.isScrubbing)
 		.animation(.easeInOut(duration: 0.2), value: viewModel.seekFeedbackVisible)
-		.animation(.easeInOut(duration: 0.2), value: viewModel.activeSegment?.startSec)
-		.animation(.easeInOut(duration: 0.2), value: viewModel.countdownRemaining != nil)
-		.animation(.easeInOut(duration: 0.25), value: viewModel.showEpisodeList)
-		.animation(.easeInOut(duration: 0.2), value: viewModel.showSubtitleSearch)
 	}
 
 	/// Subtitles are burned into the video frames by mpv, so the scrims and
@@ -139,26 +79,6 @@ struct TVPlayerRootView: View {
 		}
 		.ignoresSafeArea()
 		.allowsHitTesting(false)
-	}
-
-	/// No Close button on TV — Menu owns dismissal (VC recognizer).
-	private func errorOverlay(message: String) -> some View {
-		VStack(spacing: 20) {
-			Image(systemName: "exclamationmark.triangle.fill")
-				.font(.system(size: 56))
-				.foregroundStyle(.yellow)
-			Text(viewModel.str("playbackError", "Playback error"))
-				.font(.title3)
-				.foregroundStyle(.white)
-			Text(message)
-				.font(.body)
-				.foregroundStyle(.white.opacity(0.8))
-				.multilineTextAlignment(.center)
-				.lineLimit(4)
-		}
-		.padding(48)
-		.frame(maxWidth: 720)
-		.background(.black.opacity(0.85), in: RoundedRectangle(cornerRadius: 24))
 	}
 }
 
@@ -190,8 +110,8 @@ private struct TVMetadataHeader: View {
 }
 
 /// Bare style for the focusable transport bar: the bar draws its own focus
-/// treatment (thicker track + glow), so the style must add none of the
-/// system decor.
+/// treatment (the track thickens), so the style must add none of the system
+/// decor — every built-in style puts a platter around a progress track.
 @available(tvOS 26.0, *)
 private struct TVBareButtonStyle: ButtonStyle {
 	func makeBody(configuration: Configuration) -> some View {
@@ -235,13 +155,6 @@ private struct TVTransportBar: View {
 		let remaining = max(0, duration - position)
 
 		VStack(alignment: .leading, spacing: 12) {
-			if let chapterName = viewModel.chapterName(at: position) {
-				Text(chapterName)
-					.font(.caption)
-					.foregroundStyle(.white.opacity(0.7))
-					.lineLimit(1)
-			}
-
 			Button {
 				// Select with the bar focused mirrors the system player:
 				// toggle play/pause. While a scrub is armed (or the chrome is
@@ -257,7 +170,6 @@ private struct TVTransportBar: View {
 
 					progressBar(position: position, duration: duration)
 						.frame(height: barHeight)
-						.shadow(color: .white.opacity(barFocused ? 0.45 : 0), radius: 8)
 				}
 			}
 			.buttonStyle(TVBareButtonStyle())
@@ -283,7 +195,18 @@ private struct TVTransportBar: View {
 			}
 
 			HStack(alignment: .top) {
-				Text(formatTime(position))
+				// Chapter sits under the elapsed time, mirroring the ends-at
+				// line under the remaining time on the right — same size and
+				// opacity, so the two secondary lines read as a pair.
+				VStack(alignment: .leading, spacing: 2) {
+					Text(formatTime(position))
+					if let chapterName = viewModel.chapterName(at: position) {
+						Text(chapterName)
+							.font(.system(size: 20))
+							.foregroundStyle(.white.opacity(0.55))
+							.lineLimit(1)
+					}
+				}
 				Spacer()
 				VStack(alignment: .trailing, spacing: 2) {
 					Text("-" + formatTime(remaining))
@@ -353,7 +276,11 @@ private struct TVTransportBar: View {
 				: 0
 
 			ZStack(alignment: .leading) {
-				Capsule().fill(.white.opacity(0.25))
+				// Unplayed track: Liquid Glass, same material as the buttons
+				// above it. It samples the video behind the bar, so the
+				// specular highlight travels with the picture instead of being
+				// a painted-on tint.
+				Color.clear.glassEffect(.regular, in: Capsule())
 				Capsule()
 					.fill(.white.opacity(0.35))
 					.frame(width: width * bufferedFraction)

--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVControlsRow.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVControlsRow.swift
@@ -28,20 +28,19 @@ struct TVControlsRow: View {
 	/// Owned by the root view (which outlives this row): the last focused
 	/// control, restored when the chrome reappears.
 	@Binding var lastFocused: TVControl?
-	@Namespace private var focusNamespace
+	@ObservedObject var focusCoordinator: TVFocusCoordinator
 	@FocusState private var focusedControl: TVControl?
-	@Environment(\.resetFocus) private var resetFocus
-	/// The row stays invisible until focus has settled on the remembered
-	/// control — the engine's initial left-most pick and our correction both
-	/// happen off-screen, so the row appears already focused correctly.
-	@State private var revealed = false
-	@State private var pendingTarget: TVControl?
+	/// While non-nil, every control except this one is out of the focus
+	/// graph. Held for the frame in which the chrome host joins the graph,
+	/// so the engine's geometric repair has exactly one candidate - the
+	/// remembered control - instead of the left-most button. Cleared the
+	/// moment focus lands (below), with a backstop in tvFocusZone.
+	@State private var focusGate: TVControl?
 
 	/// The control that should own default focus when the row (re)appears:
-	/// the remembered one when it still exists, play/pause otherwise. The
-	/// preference carries the memory — a programmatic FocusState write alone
-	/// loses the race against the focus-engine update the VC kicks after the
-	/// row mounts (which lands on the left-most button).
+	/// the remembered one when it still exists, play/pause otherwise. Fed to
+	/// `.defaultFocus(_:_:priority:)` below, evaluated when the scope takes
+	/// focus — which the coordinator triggers once this host is live.
 	private var defaultFocusTarget: TVControl {
 		guard let lastFocused, isAvailable(lastFocused) else { return .playPause }
 		return lastFocused
@@ -73,37 +72,37 @@ struct TVControlsRow: View {
 			if viewModel.metadata?.isEpisode == true {
 				iconButton("backward.end.fill") { viewModel.playPreviousEpisode() }
 					.focused($focusedControl, equals: .previousEpisode)
-				.prefersDefaultFocus(defaultFocusTarget == .previousEpisode, in: focusNamespace)
+					.tvFocusGated(focusGate, TVControl.previousEpisode)
 			}
 			iconButton(skipSymbol("gobackward", viewModel.seekBackwardSec)) {
 				viewModel.seekBackward()
 			}
 			.focused($focusedControl, equals: .skipBack)
-				.prefersDefaultFocus(defaultFocusTarget == .skipBack, in: focusNamespace)
+			.tvFocusGated(focusGate, TVControl.skipBack)
 			if !viewModel.chapters.isEmpty {
 				iconButton("backward.fill") { viewModel.goToPreviousChapter() }
 					.focused($focusedControl, equals: .previousChapter)
-				.prefersDefaultFocus(defaultFocusTarget == .previousChapter, in: focusNamespace)
+					.tvFocusGated(focusGate, TVControl.previousChapter)
 			}
 			iconButton(viewModel.isPlaying ? "pause.fill" : "play.fill") {
 				viewModel.togglePlayPause()
 			}
 			.focused($focusedControl, equals: .playPause)
-				.prefersDefaultFocus(defaultFocusTarget == .playPause, in: focusNamespace)
+			.tvFocusGated(focusGate, TVControl.playPause)
 			if !viewModel.chapters.isEmpty {
 				iconButton("forward.fill") { viewModel.goToNextChapter() }
 					.focused($focusedControl, equals: .nextChapter)
-				.prefersDefaultFocus(defaultFocusTarget == .nextChapter, in: focusNamespace)
+					.tvFocusGated(focusGate, TVControl.nextChapter)
 			}
 			iconButton(skipSymbol("goforward", viewModel.seekForwardSec)) {
 				viewModel.seekForward()
 			}
 			.focused($focusedControl, equals: .skipForward)
-				.prefersDefaultFocus(defaultFocusTarget == .skipForward, in: focusNamespace)
+			.tvFocusGated(focusGate, TVControl.skipForward)
 			if viewModel.metadata?.isEpisode == true {
 				iconButton("forward.end.fill") { viewModel.playNextEpisode() }
 					.focused($focusedControl, equals: .nextEpisode)
-				.prefersDefaultFocus(defaultFocusTarget == .nextEpisode, in: focusNamespace)
+					.tvFocusGated(focusGate, TVControl.nextEpisode)
 			}
 			// Focus-mode counterpart of TVSkipPill: while the row owns the
 			// remote the pill would just be a non-focusable impostor, so the
@@ -120,12 +119,12 @@ struct TVControlsRow: View {
 							? viewModel.str("skipIntro", "Skip Intro")
 							: viewModel.str("skipCredits", "Skip Credits")
 					)
-					.font(.system(size: 26, weight: .semibold))
-					.frame(height: 40)
+					.font(.system(size: 22, weight: .semibold))
+					.frame(height: 34)
 				}
 				.buttonStyle(.glass)
 				.focused($focusedControl, equals: .skipSegment)
-				.prefersDefaultFocus(defaultFocusTarget == .skipSegment, in: focusNamespace)
+				.tvFocusGated(focusGate, TVControl.skipSegment)
 			}
 
 			Spacer(minLength: 12)
@@ -135,73 +134,73 @@ struct TVControlsRow: View {
 					viewModel.showEpisodeList = true
 				}
 				.focused($focusedControl, equals: .episodes)
-				.prefersDefaultFocus(defaultFocusTarget == .episodes, in: focusNamespace)
+				.tvFocusGated(focusGate, TVControl.episodes)
 			}
 			if !viewModel.chapters.isEmpty {
 				chaptersMenu
 					.focused($focusedControl, equals: .chapters)
-				.prefersDefaultFocus(defaultFocusTarget == .chapters, in: focusNamespace)
+					.tvFocusGated(focusGate, TVControl.chapters)
 			}
 			if !viewModel.qualityMenu.isEmpty {
 				qualityMenu
 					.focused($focusedControl, equals: .quality)
-				.prefersDefaultFocus(defaultFocusTarget == .quality, in: focusNamespace)
+					.tvFocusGated(focusGate, TVControl.quality)
 			}
 			if !viewModel.audioMenu.isEmpty {
 				audioMenu
 					.focused($focusedControl, equals: .audio)
-				.prefersDefaultFocus(defaultFocusTarget == .audio, in: focusNamespace)
+					.tvFocusGated(focusGate, TVControl.audio)
 			}
 			// Also mounted with no subtitle tracks when remote search is
 			// available — the search entry is then the way to get some.
 			if !viewModel.subtitleMenu.isEmpty || viewModel.subtitleSearchEnabled {
 				subtitlesMenu
 					.focused($focusedControl, equals: .subtitles)
-				.prefersDefaultFocus(defaultFocusTarget == .subtitles, in: focusNamespace)
+					.tvFocusGated(focusGate, TVControl.subtitles)
 			}
 			speedMenu
 				.focused($focusedControl, equals: .speed)
-				.prefersDefaultFocus(defaultFocusTarget == .speed, in: focusNamespace)
+				.tvFocusGated(focusGate, TVControl.speed)
 			moreMenu
 				.focused($focusedControl, equals: .more)
-				.prefersDefaultFocus(defaultFocusTarget == .more, in: focusNamespace)
+				.tvFocusGated(focusGate, TVControl.more)
 		}
-		.focusScope(focusNamespace)
-		.opacity(revealed ? 1 : 0.02)
-		.animation(.easeInOut(duration: 0.15), value: revealed)
+		// The row's focus memory. `.userInitiated` is load-bearing: at the
+		// default priority the engine's automatic choice (the LEFT-MOST
+		// control) wins and focus visibly slides from there to the
+		// remembered button on every summon. This is also why the older
+		// `prefersDefaultFocus(_:in:)` was dropped — for a FocusState-driven
+		// row it never took effect at all, with or without resetFocus.
+		//
+		// ORDER IS LOAD-BEARING: the grouping modifier must come AFTER
+		// defaultFocus. Reversed, the grouping wins and the preference is
+		// silently ignored — Swiftfin shipped exactly that bug on tvOS
+		// (jellyfin/Swiftfin #2178/#2180) and fixed it by this reordering.
+		.defaultFocus($focusedControl, defaultFocusTarget, priority: .userInitiated)
+		.focusSection()
 		.onChange(of: focusedControl) { newValue in
 			if let newValue {
+				TVFocusLog.log.info(
+					"row focus -> \(String(describing: newValue), privacy: .public)")
 				lastFocused = newValue
-				if newValue == pendingTarget {
-					revealed = true
-				}
+				// Focus has landed: let the rest of the row back into the
+				// focus graph. Adding focusable siblings does not move an
+				// already-held focus, so this is invisible.
+				focusGate = nil
 				// Navigating the row counts as interaction — keep the chrome
 				// up while the user is moving between buttons.
 				viewModel.scheduleAutoHide()
 			}
 		}
-		.onAppear {
-			// Steer focus to the remembered control (fallback play/pause)
-			// while still invisible; reveal as soon as it lands (onChange),
-			// with a worst-case reveal at 300ms so the row can never stay
-			// hidden if the engine refuses the target.
-			let target = defaultFocusTarget
-			pendingTarget = target
-			DispatchQueue.main.async {
-				resetFocus(in: focusNamespace)
-				focusedControl = target
-			}
-			DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-				if focusedControl != target {
-					focusedControl = target
-				}
-				// Reveal on the NEXT tick so the assignment above resolves
-				// while the row is still in its focusable (0.02) state.
-				DispatchQueue.main.async {
-					revealed = true
-				}
-			}
-		}
+		// Backstop for `.defaultFocus` above, which Apple documents as
+		// evaluated "when the window first appears" - this row remounts per
+		// summon, which is outside that guarantee. The coordinator now
+		// publishes this BEFORE it touches the focus engine, so in the good
+		// case the write below is the engine's first and only instruction and
+		// there is no left-most pick to slide away from.
+		.tvFocusZone(
+			.chrome, coordinator: focusCoordinator, focus: $focusedControl,
+			gate: $focusGate, target: { defaultFocusTarget })
 	}
 
 	// MARK: - Native menus (mirror of PlayerTopBar)
@@ -431,8 +430,8 @@ struct TVControlsRow: View {
 
 	private func icon(_ systemName: String) -> some View {
 		Image(systemName: systemName)
-			.font(.system(size: 26, weight: .semibold))
-			.frame(width: 40, height: 40)
+			.font(.system(size: 22, weight: .semibold))
+			.frame(width: 34, height: 34)
 	}
 
 	/// "gobackward.30"-style symbol when SF Symbols has the exact count.

--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVFocusCoordinator.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVFocusCoordinator.swift
@@ -1,0 +1,332 @@
+#if os(tvOS)
+import SwiftUI
+import UIKit
+import os
+
+/// Shared logger for the TV focus machinery — read from the simulator with:
+/// xcrun simctl spawn booted log show --last 5m --info \
+///   --predicate 'subsystem == "com.fredrikburmester.streamyfin"'
+/// (`--info` is required: these are info-level records. os.Logger spelled
+/// out because this module has its own `Logger` type that shadows it.)
+enum TVFocusLog {
+	static let log = os.Logger(
+		subsystem: "com.fredrikburmester.streamyfin", category: "tvfocus")
+}
+
+/// The focus zones of the TV player — one per hosted SwiftUI layer that can
+/// own the remote. `.none` is recognizer mode: nothing focusable anywhere,
+/// the VC's press/pan recognizers own every press.
+enum TVFocusZone: Hashable {
+	case none
+	case chrome
+	case shelf
+	case subtitleSearch
+	case stillWatching
+}
+
+/// Published hand-off from the coordinator to the SwiftUI layer that just
+/// became focusable: "your host is live and the engine has been pointed at
+/// it — establish your preferred focus now". The epoch makes repeat
+/// activations of the same zone distinct values so onChange always fires.
+struct TVFocusRequest: Equatable {
+	var zone: TVFocusZone
+	var epoch: Int
+}
+
+/// UIKit-side focus orchestration for the TV player.
+///
+/// The division of labour: UIKit decides WHICH layer may hold focus, SwiftUI
+/// decides WHICH control within it. The sequencing between the two halves is
+/// what makes or breaks it:
+///
+/// 1. Every layer host starts — and between activations stays —
+///    `isUserInteractionEnabled = false`, keeping its whole subtree out of
+///    the focus system. Only one layer is ever focusable.
+/// 2. A zone is only enabled once its SwiftUI content reports itself mounted
+///    (`contentMounted`). Activation and mounting race in either order, so
+///    both paths converge here. Enabling earlier is what let the focus
+///    engine fall through to the React Native views BEHIND the player: the
+///    host was focusable but empty, so the engine looked elsewhere.
+/// 3. After enabling, `focusRequest` is published so the layer can assert
+///    its own `@FocusState` target — and ONLY then, if that produced
+///    nothing, is the engine pointed at the host as a fallback. That order
+///    is the whole point: see enableAndKick.
+///
+/// The owning VC routes `preferredFocusEnvironments` here too, so
+/// system-driven updates (initial window attach, restore after a
+/// UIAlertController dismisses) also resolve into the active zone.
+final class TVFocusCoordinator: ObservableObject {
+	/// Observed by the layer views; see TVFocusRequest.
+	@Published private(set) var focusRequest = TVFocusRequest(zone: .none, epoch: 0)
+
+	private var hostViews: [TVFocusZone: UIView] = [:]
+	/// Zones whose SwiftUI content is currently mounted. A zone can be
+	/// activated before its content exists (the chrome sink and the row's
+	/// onAppear fire in either order) — the pending activation completes
+	/// when the content reports in.
+	private var mountedZones: Set<TVFocusZone> = []
+	private(set) var activeZone: TVFocusZone = .none
+
+	func register(_ hostView: UIView, for zone: TVFocusZone) {
+		hostViews[zone] = hostView
+		hostView.isUserInteractionEnabled = false
+	}
+
+	/// What the owning VC reports as its preferredFocusEnvironments.
+	var preferredEnvironments: [UIFocusEnvironment] {
+		guard let hostView = hostViews[activeZone] else { return [] }
+		return [hostView]
+	}
+
+	// MARK: - Zone activation
+
+	func activate(_ zone: TVFocusZone) {
+		guard zone != activeZone else { return }
+		TVFocusLog.log.info(
+			"zone \(String(describing: self.activeZone), privacy: .public) -> \(String(describing: zone), privacy: .public)"
+		)
+		activeZone = zone
+		guard zone != .none else {
+			// Recognizer mode: nothing anywhere may be focusable.
+			for view in hostViews.values {
+				view.isUserInteractionEnabled = false
+			}
+			return
+		}
+		// NOTE: the outgoing host is deliberately NOT disabled here. Going
+		// dark first leaves a frame with nothing focused, and the engine
+		// repairs a focus-less frame GEOMETRICALLY — it takes the left-most
+		// item in reach, not the preferred one. That repair is the hop. The
+		// outgoing layer keeps focus until the incoming one has claimed it;
+		// retireOthers() runs at the end of the handover.
+		if mountedZones.contains(zone) {
+			enableAndKick(zone)
+		} else {
+			// Content not committed yet — contentMounted() finishes the job.
+			TVFocusLog.log.info(
+				"activation deferred: \(String(describing: zone), privacy: .public) content not mounted"
+			)
+		}
+	}
+
+	/// Called from a layer's onAppear once its focusable content exists.
+	func contentMounted(_ zone: TVFocusZone) {
+		guard !mountedZones.contains(zone) else { return }
+		mountedZones.insert(zone)
+		TVFocusLog.log.info("content mounted: \(String(describing: zone), privacy: .public)")
+		if zone == activeZone {
+			enableAndKick(zone)
+		}
+	}
+
+	/// Called from a layer's onDisappear.
+	func contentUnmounted(_ zone: TVFocusZone) {
+		mountedZones.remove(zone)
+	}
+
+	/// Re-assert the active zone. The first activation can happen before the
+	/// view joins a window — no focus system exists yet and the kick is
+	/// dropped — so the VC calls this from viewDidAppear.
+	func refresh() {
+		guard activeZone != .none, mountedZones.contains(activeZone) else { return }
+		enableAndKick(activeZone)
+	}
+
+	// MARK: - Focus placement
+
+	/// Grace given to the handover to settle before it is checked. Three
+	/// frames at 60Hz - long enough for a state write plus a render pass,
+	/// short enough to stay inside the layer's own 0.2s fade-in.
+	private static let establishGrace: TimeInterval = 0.05
+
+	/// Hand a zone the remote, in three beats on separate runloop turns.
+	///
+	/// The beats are not ceremony; each one exists because of a specific
+	/// failure:
+	///
+	/// - BEAT 1 publishes the request while the host is still OUT of the
+	///   focus graph. The layer gates itself down to a single focusable
+	///   control and names it. Nothing the engine does can interfere yet.
+	/// - BEAT 2 joins the graph, one turn later. Separate turns because a
+	///   focus claim made in the same transaction as the structural
+	///   re-enable is dropped by the engine. And because the engine repairs
+	///   a focus-less frame GEOMETRICALLY - left-most item wins, preferred
+	///   focus is not consulted - the layer's gate is what makes that repair
+	///   land on the target: by now it is the only candidate there is.
+	/// - BEAT 3 checks the result, and only then retires the outgoing layer.
+	///
+	/// The fallback `requestFocusUpdate(to:)` is kept, but do not expect much
+	/// of it: Apple documents it as having no effect unless the target
+	/// already contains the focused item ("focus cannot be taken, only
+	/// given"), which is exactly the case we would be invoking it for. It
+	/// costs nothing and the log line tells us which path ran.
+	private func enableAndKick(_ zone: TVFocusZone) {
+		guard let hostView = hostViews[zone] else { return }
+		focusRequest = TVFocusRequest(zone: zone, epoch: focusRequest.epoch + 1)
+		DispatchQueue.main.async { [weak self] in
+			// A newer activation supersedes this one entirely.
+			guard let self, self.activeZone == zone else { return }
+			hostView.isUserInteractionEnabled = true
+			DispatchQueue.main.asyncAfter(deadline: .now() + Self.establishGrace) {
+				guard self.activeZone == zone else { return }
+				self.settle(zone, hostView: hostView)
+			}
+		}
+	}
+
+	private func settle(_ zone: TVFocusZone, hostView: UIView) {
+		defer { retireOthers(than: zone) }
+		guard let focusSystem = UIFocusSystem.focusSystem(for: hostView) else {
+			TVFocusLog.log.info("settle skipped: no focus system (not in window yet)")
+			return
+		}
+		if Self.focus(focusSystem.focusedItem, isInside: hostView) {
+			TVFocusLog.log.info(
+				"focus landed in \(String(describing: zone), privacy: .public): \(String(describing: focusSystem.focusedItem), privacy: .public)"
+			)
+			return
+		}
+		focusSystem.requestFocusUpdate(to: hostView)
+		focusSystem.updateFocusIfNeeded()
+		TVFocusLog.log.info(
+			"fallback kick \(String(describing: zone), privacy: .public); engine picked: \(String(describing: focusSystem.focusedItem), privacy: .public)"
+		)
+	}
+
+	/// Drop every other layer out of the focus graph, once the incoming one
+	/// has had its chance to claim focus. Deliberately last: see activate().
+	private func retireOthers(than zone: TVFocusZone) {
+		for (hostZone, view) in hostViews where hostZone != zone {
+			view.isUserInteractionEnabled = false
+		}
+	}
+
+	/// Whether the focus system's current item lives under `host`. Walks
+	/// `parentFocusEnvironment` rather than the view tree: SwiftUI's focus
+	/// items are not guaranteed to be UIViews, but they are always focus
+	/// environments parented into the hosting view.
+	private static func focus(_ item: UIFocusItem?, isInside host: UIView) -> Bool {
+		var environment: UIFocusEnvironment? = item
+		while let current = environment {
+			if current === host { return true }
+			environment = current.parentFocusEnvironment
+		}
+		return false
+	}
+}
+
+// MARK: - SwiftUI integration
+
+/// Applied to a focusable layer's root: reports its mount state to the
+/// coordinator, and runs `establish` when the coordinator reports the host
+/// live so the layer can assert its `@FocusState` target.
+///
+/// Deliberately NOT here: `resetFocus(in:)` and a `Namespace`. Those exist
+/// to re-arm `prefersDefaultFocus`, which is a separate mechanism keyed on
+/// `focusScope(_:)` — Apple documents no interaction between it and
+/// `@FocusState`, and every layer here now steers focus through
+/// `.defaultFocus(_:_:priority:)` instead.
+@available(tvOS 26.0, *)
+struct TVFocusZoneModifier: ViewModifier {
+	@ObservedObject var coordinator: TVFocusCoordinator
+	let zone: TVFocusZone
+	let establish: () -> Void
+
+	func body(content: Content) -> some View {
+		content
+			.onAppear { coordinator.contentMounted(zone) }
+			.onDisappear { coordinator.contentUnmounted(zone) }
+			.onChange(of: coordinator.focusRequest) { request in
+				guard request.zone == zone else { return }
+				establish()
+			}
+	}
+}
+
+@available(tvOS 26.0, *)
+extension View {
+	func tvFocusZone(
+		_ zone: TVFocusZone,
+		coordinator: TVFocusCoordinator,
+		establish: @escaping () -> Void = {}
+	) -> some View {
+		modifier(
+			TVFocusZoneModifier(coordinator: coordinator, zone: zone, establish: establish))
+	}
+
+	/// The standard establish body, which every focusable layer wants: gate
+	/// the layer down to a single focusable control, name it, and let the
+	/// rest back in once focus has landed (the layer clears `gate`).
+	///
+	/// The gate is the load-bearing half. The engine repairs a focus-less
+	/// frame geometrically - left-most item wins - and a layer joining the
+	/// focus graph from nothing is exactly such a frame. Preferred focus is
+	/// not consulted for that repair, so the only reliable way to be picked
+	/// is to be the sole candidate. Layers whose target already IS the
+	/// left-most control (the still-watching card, the search panel) can skip
+	/// it and pass the default.
+	///
+	/// The `@FocusState` write matters too, and not just as a backstop:
+	/// `.defaultFocus` is documented as evaluated when the WINDOW first
+	/// appears, so for layers that mount per presentation it is decorative -
+	/// and inside a ScrollView it is ignored outright (Apple FB706321), which
+	/// is why the episode shelf opened on the left-most card instead of the
+	/// episode you are actually watching.
+	func tvFocusZone<Value: Hashable>(
+		_ zone: TVFocusZone,
+		coordinator: TVFocusCoordinator,
+		focus: FocusState<Value?>.Binding,
+		gate: Binding<Value?> = .constant(nil),
+		target: @escaping () -> Value
+	) -> some View {
+		tvFocusZone(zone, coordinator: coordinator) {
+			let value = target()
+			TVFocusLog.log.info(
+				"establish \(String(describing: zone), privacy: .public) -> \(String(describing: value), privacy: .public)"
+			)
+			// Gate BEFORE naming: the coordinator only joins the host to the
+			// focus graph on the next runloop turn, so this is the frame in
+			// which the layer gets to decide what the engine may pick.
+			gate.wrappedValue = value
+			focus.wrappedValue = value
+			DispatchQueue.main.async {
+				guard focus.wrappedValue != value else { return }
+				TVFocusLog.log.info(
+					"re-assert \(String(describing: zone), privacy: .public) -> \(String(describing: value), privacy: .public)"
+				)
+				focus.wrappedValue = value
+			}
+			// Backstop: if focus never lands the layer never clears the gate,
+			// and a gated layer is a layer you cannot navigate.
+			DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+				guard gate.wrappedValue != nil else { return }
+				TVFocusLog.log.info(
+					"gate released by backstop in \(String(describing: zone), privacy: .public)"
+				)
+				gate.wrappedValue = nil
+			}
+		}
+	}
+
+	/// Out of the focus graph while a gate is active and names something
+	/// else. Applied to every member of a gated layer; see the gate note on
+	/// tvFocusZone above.
+	///
+	/// Both modifiers, on purpose. `.focusable(false)` is the one that says
+	/// what we mean, but its effect on views that are ALREADY focusable
+	/// (Button, Menu) is not something Apple documents. `.disabled(true)`
+	/// definitely removes a control from the focus graph and propagates
+	/// through the environment, so it does not care that it is applied
+	/// outside `.focused(_:equals:)`. Its cost is a dimmed control, which is
+	/// invisible here: the gate is held for the frames in which the chrome is
+	/// still fading up from zero.
+	@ViewBuilder
+	func tvFocusGated<Value: Equatable>(_ gate: Value?, _ id: Value) -> some View {
+		if let gate, gate != id {
+			focusable(false).disabled(true)
+		} else {
+			self
+		}
+	}
+}
+#endif

--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVMediaOverlays.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVMediaOverlays.swift
@@ -69,10 +69,15 @@ struct TVCountdownCard: View {
 }
 
 /// "Are you still watching?" — focusable card (the VC hands the remote to
-/// SwiftUI focus while it is up). Same actions as the iOS overlay.
+/// SwiftUI focus while it is up). Same actions as the iOS overlay. The
+/// affirmative answer owns default focus so one Select continues playback.
 @available(tvOS 26.0, *)
 struct TVStillWatchingCard: View {
+	private enum Choice: Hashable { case continueWatching, goBack }
+
 	@ObservedObject var viewModel: PlayerViewModel
+	let focusCoordinator: TVFocusCoordinator
+	@FocusState private var focusedButton: Choice?
 
 	var body: some View {
 		VStack(spacing: 28) {
@@ -83,37 +88,43 @@ struct TVStillWatchingCard: View {
 				Button(viewModel.str("continueWatching", "Continue watching")) {
 					viewModel.continueWatchingTapped()
 				}
+				.focused($focusedButton, equals: .continueWatching)
 				Button(viewModel.str("goBack", "Go back")) {
 					viewModel.stillWatchingCloseTapped()
 				}
+				.focused($focusedButton, equals: .goBack)
 			}
 		}
 		.padding(48)
 		.glassEffect(.regular, in: RoundedRectangle(cornerRadius: 24))
-	}
-}
-
-/// Focus style for shelf cards: no platter, just scale + shadow on the
-/// whole label (image and text together). Every built-in tvOS style draws
-/// its own focus decor (.card/.plain add a platter around the label,
-/// .borderless lifts only the image), so the bare look needs this.
-@available(tvOS 26.0, *)
-private struct TVShelfCardButtonStyle: ButtonStyle {
-	@Environment(\.isFocused) private var isFocused
-
-	func makeBody(configuration: Configuration) -> some View {
-		configuration.label
-			.scaleEffect(isFocused ? 1.1 : 1.0)
-			.shadow(color: .black.opacity(isFocused ? 0.5 : 0), radius: 18, y: 10)
-			.animation(.easeOut(duration: 0.15), value: isFocused)
+		.defaultFocus($focusedButton, .continueWatching, priority: .userInitiated)
+		.focusSection()
+		.tvFocusZone(
+			.stillWatching, coordinator: focusCoordinator, focus: $focusedButton,
+			target: { Choice.continueWatching })
 	}
 }
 
 /// Horizontal episode shelf (bottom third). Focusable cards; Select fires
-/// the existing onEpisodeSelected intent via viewModel.selectEpisode.
+/// the existing onEpisodeSelected intent via viewModel.selectEpisode. The
+/// card of the CURRENTLY PLAYING episode owns default focus — the engine
+/// scrolls it into view on its first pick (the coordinator only points
+/// focus here after the shelf has committed), so the shelf opens oriented
+/// on where you are instead of at episode 1.
 @available(tvOS 26.0, *)
 struct TVEpisodeShelf: View {
 	@ObservedObject var viewModel: PlayerViewModel
+	let focusCoordinator: TVFocusCoordinator
+	@FocusState private var focusedEpisode: Int?
+	/// See TVControlsRow.focusGate. It matters more here: the shelf's
+	/// target is almost never the left-most card, so the engine's repair
+	/// had no chance of guessing it.
+	@State private var focusGate: Int?
+
+	/// Index of the episode that should take focus when the shelf opens.
+	private var defaultFocusIndex: Int {
+		viewModel.episodeList.firstIndex { $0.isCurrent } ?? 0
+	}
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: 16) {
@@ -123,14 +134,21 @@ struct TVEpisodeShelf: View {
 				.padding(.horizontal, 80)
 			ScrollView(.horizontal, showsIndicators: false) {
 				HStack(spacing: 28) {
-					ForEach(Array(viewModel.episodeList.enumerated()), id: \.offset) { _, episode in
-						episodeCard(episode)
+					ForEach(Array(viewModel.episodeList.enumerated()), id: \.offset) {
+						index, episode in
+						// Focus modifiers live on the artwork Button inside, not
+						// out here: the lockup's VStack is not the focusable
+						// element any more, only the card is.
+						episodeCard(episode, index: index)
 					}
 				}
 				.padding(.horizontal, 80)
 				.padding(.vertical, 30)
 			}
 		}
+		// Grouping AFTER defaultFocus — see the note in TVControlsRow.
+		.defaultFocus($focusedEpisode, defaultFocusIndex, priority: .userInitiated)
+		.focusSection()
 		.padding(.vertical, 30)
 		.frame(maxWidth: .infinity, alignment: .leading)
 		.background(
@@ -149,55 +167,115 @@ struct TVEpisodeShelf: View {
 			.ignoresSafeArea()
 		)
 		.onExitCommand { viewModel.showEpisodeList = false }
+		// The shelf MUST assert its target itself. `.defaultFocus` above is
+		// inert here twice over: it is documented as evaluated when the window
+		// first appears (the shelf mounts per opening), and inside a ScrollView
+		// it is ignored outright (Apple FB706321 - focus goes to the first card
+		// visible on the left). Naming the index through @FocusState is what
+		// actually scrolls the playing episode into view and focuses it.
+		.onChange(of: focusedEpisode) { newValue in
+			// Focus landed - let the other cards back in so the shelf scrolls.
+			if newValue != nil { focusGate = nil }
+		}
+		.tvFocusZone(
+			.shelf, coordinator: focusCoordinator, focus: $focusedEpisode,
+			gate: $focusGate, target: { defaultFocusIndex })
 	}
 
-	private func episodeCard(_ episode: EpisodeListItemRecord) -> some View {
+	/// Everything lives INSIDE the card - title and progress overlay the
+	/// artwork rather than sitting under it, which is how the TV app's
+	/// in-player episode shelf is built. `.card` is what carries the tvOS
+	/// focus float (the layer tilts toward your thumb and a specular
+	/// highlight tracks across it); it wraps whatever it is given, and here
+	/// what it is given is the whole card, so there is nothing left over for
+	/// it to draw a platter around.
+	private func episodeCard(_ episode: EpisodeListItemRecord, index: Int) -> some View {
 		Button {
 			viewModel.selectEpisode(episode)
 		} label: {
-			VStack(alignment: .leading, spacing: 8) {
-				ZStack(alignment: .bottomLeading) {
-					if let imageUrl = episode.imageUrl, let url = URL(string: imageUrl) {
-						AsyncImage(url: url) { image in
-							image.resizable().aspectRatio(contentMode: .fill)
-						} placeholder: {
-							Color.white.opacity(0.1)
-						}
-					} else {
+			ZStack(alignment: .bottomLeading) {
+				if let imageUrl = episode.imageUrl, let url = URL(string: imageUrl) {
+					AsyncImage(url: url) { image in
+						image.resizable().aspectRatio(contentMode: .fill)
+					} placeholder: {
 						Color.white.opacity(0.1)
 					}
+				} else {
+					Color.white.opacity(0.1)
+				}
+				// Frosted gradient rather than a flat black band: a material
+				// masked to fade in toward the bottom keeps the artwork visible
+				// through it while still grounding the title. The black
+				// underlay carries the contrast the material alone cannot
+				// guarantee over a bright frame.
+				LinearGradient(
+					colors: [.black.opacity(0), .black.opacity(0.55)],
+					startPoint: .top, endPoint: .bottom
+				)
+				.frame(height: 110)
+				.frame(maxHeight: .infinity, alignment: .bottom)
+				Rectangle()
+					.fill(.ultraThinMaterial)
+					.mask(
+						LinearGradient(
+							stops: [
+								.init(color: .clear, location: 0),
+								.init(color: .black.opacity(0.65), location: 0.5),
+								.init(color: .black, location: 1),
+							],
+							startPoint: .top, endPoint: .bottom
+						)
+					)
+					.frame(height: 110)
+					.frame(maxHeight: .infinity, alignment: .bottom)
+				VStack(alignment: .leading, spacing: 8) {
+					Text(
+						episode.indexNumber.map { "\($0). \(episode.title)" } ?? episode.title
+					)
+					.font(.system(size: 20, weight: .medium))
+					.foregroundStyle(.white)
+					.lineLimit(1)
 					if episode.progressPercent > 0 {
 						GeometryReader { geometry in
-							VStack {
-								Spacer()
-								Rectangle().fill(.white.opacity(0.3)).frame(height: 5)
-									.overlay(alignment: .leading) {
-										Rectangle().fill(.white)
-											.frame(
-												width: geometry.size.width
-													* CGFloat(min(max(episode.progressPercent / 100, 0), 1)),
-												height: 5)
-									}
-							}
+							Capsule().fill(.white.opacity(0.3))
+								.overlay(alignment: .leading) {
+									Capsule().fill(.white)
+										.frame(
+											width: geometry.size.width
+												* CGFloat(min(max(episode.progressPercent / 100, 0), 1)))
+								}
 						}
+						.frame(height: 4)
 					}
 				}
-				.frame(width: 300, height: 168)
-				.clipShape(RoundedRectangle(cornerRadius: 12))
-				.overlay(
-					RoundedRectangle(cornerRadius: 12)
-						.stroke(episode.isCurrent ? .white : .clear, lineWidth: 3)
-				)
-				Text(
-					episode.indexNumber.map { "\($0). \(episode.title)" } ?? episode.title
-				)
-				.font(.caption)
-				.foregroundStyle(.white.opacity(0.9))
-				.lineLimit(1)
-				.frame(maxWidth: 300, alignment: .leading)
+				.padding(.horizontal, 14)
+				.padding(.bottom, 12)
 			}
+			.frame(width: 300, height: 168)
+			.overlay(alignment: .topLeading) {
+				// Matches the app's existing badge (TVPosterCard.tsx): solid
+				// white, black content, radius 8, top-left. Replaces the white
+				// border, which competed with the focus ring and read as a
+				// second focus state. Inside the clip so it rounds with the card.
+				if episode.isCurrent {
+					HStack(spacing: 6) {
+						Image(systemName: "play.fill")
+							.font(.system(size: 13, weight: .bold))
+						Text(viewModel.str("nowPlaying", "Now Playing"))
+							.font(.system(size: 15, weight: .bold))
+					}
+					.foregroundStyle(.black)
+					.padding(.horizontal, 10)
+					.padding(.vertical, 6)
+					.background(.white, in: RoundedRectangle(cornerRadius: 8))
+					.padding(10)
+				}
+			}
+			.clipShape(RoundedRectangle(cornerRadius: 12))
 		}
-		.buttonStyle(TVShelfCardButtonStyle())
+		.buttonStyle(.card)
+		.focused($focusedEpisode, equals: index)
+		.tvFocusGated(focusGate, index)
 	}
 }
 #endif

--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVOverlayLayers.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVOverlayLayers.swift
@@ -1,0 +1,166 @@
+#if os(tvOS)
+import SwiftUI
+
+/// Thin per-host layer roots. NativePlayerViewController stacks one hosting
+/// controller per layer (back-to-front: chrome, status, shelf, subtitle
+/// search, still watching, error) and TVFocusCoordinator flips exactly one
+/// of the focusable ones into the focus system at a time. Each layer carries
+/// its own transition/animation — the conditions and values mirror the old
+/// single-ZStack root view exactly.
+
+/// Display-only status layer: buffering spinner, technical info, and the
+/// skip pill / countdown card. Nothing here is ever focusable — the pill and
+/// card are actioned via the VC's Select recognizer while the chrome is
+/// hidden; in the full chrome the controls row hosts focusable equivalents.
+/// Its host view stays isUserInteractionEnabled = false permanently.
+@available(tvOS 26.0, *)
+struct TVStatusLayerView: View {
+	@ObservedObject var viewModel: PlayerViewModel
+
+	var body: some View {
+		ZStack {
+			if viewModel.isBuffering && viewModel.errorMessage == nil {
+				ProgressView()
+					.progressViewStyle(.circular)
+					.tint(.white)
+					.scaleEffect(1.6)
+			}
+
+			// Stats for nerds — independent of the chrome, like on iOS. The
+			// shared overlay is phone-sized; scale it up for viewing distance.
+			if viewModel.showTechnicalInfo {
+				VStack {
+					HStack {
+						TechnicalInfoOverlay(viewModel: viewModel)
+							.scaleEffect(1.5, anchor: .topLeading)
+						Spacer()
+					}
+					Spacer()
+				}
+				.padding(.top, 60)
+				.padding(.leading, 80)
+			}
+
+			// Skip pill / countdown card (Select acts on both) stay
+			// actionable while the chrome is hidden, via the VC recognizers.
+			// In the full chrome both yield to the row's focusable Skip /
+			// Next-episode buttons — focus owns the remote there, so a
+			// non-focusable card next to focusable glass buttons reads as a
+			// control that focus can never reach.
+			if !viewModel.controlsVisible, !viewModel.showEpisodeList,
+				!viewModel.showSubtitleSearch {
+				VStack {
+					Spacer()
+					HStack {
+						Spacer()
+						if let countdown = viewModel.countdownRemaining,
+							let next = viewModel.nextEpisode {
+							TVCountdownCard(
+								viewModel: viewModel, next: next, remaining: countdown)
+						} else if let segment = viewModel.activeSegment,
+							!viewModel.isScrubbing {
+							TVSkipPill(viewModel: viewModel, segment: segment)
+						}
+					}
+				}
+				.padding(.trailing, 80)
+				.padding(.bottom, 80)
+			}
+		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
+		.animation(.easeInOut(duration: 0.2), value: viewModel.controlsVisible)
+		.animation(.easeInOut(duration: 0.2), value: viewModel.activeSegment?.startSec)
+		.animation(.easeInOut(duration: 0.2), value: viewModel.countdownRemaining != nil)
+		.animation(.easeInOut(duration: 0.25), value: viewModel.showEpisodeList)
+		.animation(.easeInOut(duration: 0.2), value: viewModel.showSubtitleSearch)
+	}
+}
+
+/// Episode shelf layer (focus zone: .shelf).
+@available(tvOS 26.0, *)
+struct TVShelfLayerView: View {
+	@ObservedObject var viewModel: PlayerViewModel
+	let focusCoordinator: TVFocusCoordinator
+
+	var body: some View {
+		ZStack {
+			if viewModel.showEpisodeList {
+				VStack {
+					Spacer()
+					TVEpisodeShelf(viewModel: viewModel, focusCoordinator: focusCoordinator)
+				}
+				.transition(.move(edge: .bottom).combined(with: .opacity))
+			}
+		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
+		.animation(.easeInOut(duration: 0.25), value: viewModel.showEpisodeList)
+	}
+}
+
+/// Remote subtitle search layer (focus zone: .subtitleSearch).
+@available(tvOS 26.0, *)
+struct TVSubtitleSearchLayerView: View {
+	@ObservedObject var viewModel: PlayerViewModel
+	let focusCoordinator: TVFocusCoordinator
+
+	var body: some View {
+		ZStack {
+			if viewModel.showSubtitleSearch {
+				TVSubtitleSearchPanel(viewModel: viewModel, focusCoordinator: focusCoordinator)
+					.transition(.opacity)
+			}
+		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
+		.animation(.easeInOut(duration: 0.2), value: viewModel.showSubtitleSearch)
+	}
+}
+
+/// "Are you still watching?" layer (focus zone: .stillWatching) — the
+/// top-most focusable layer, matching its old zIndex(5).
+@available(tvOS 26.0, *)
+struct TVStillWatchingLayerView: View {
+	@ObservedObject var viewModel: PlayerViewModel
+	let focusCoordinator: TVFocusCoordinator
+
+	var body: some View {
+		ZStack {
+			if viewModel.showStillWatching {
+				TVStillWatchingCard(viewModel: viewModel, focusCoordinator: focusCoordinator)
+			}
+		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
+	}
+}
+
+/// Playback-error layer. Display-only (no Close button on TV — Menu owns
+/// dismissal via the VC recognizer) and stacked above everything, matching
+/// its old last-in-ZStack position.
+@available(tvOS 26.0, *)
+struct TVErrorLayerView: View {
+	@ObservedObject var viewModel: PlayerViewModel
+
+	var body: some View {
+		ZStack {
+			if let message = viewModel.errorMessage {
+				VStack(spacing: 20) {
+					Image(systemName: "exclamationmark.triangle.fill")
+						.font(.system(size: 56))
+						.foregroundStyle(.yellow)
+					Text(viewModel.str("playbackError", "Playback error"))
+						.font(.title3)
+						.foregroundStyle(.white)
+					Text(message)
+						.font(.body)
+						.foregroundStyle(.white.opacity(0.8))
+						.multilineTextAlignment(.center)
+						.lineLimit(4)
+				}
+				.padding(48)
+				.frame(maxWidth: 720)
+				.background(.black.opacity(0.85), in: RoundedRectangle(cornerRadius: 24))
+			}
+		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
+	}
+}
+#endif

--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVSubtitleSearchPanel.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVSubtitleSearchPanel.swift
@@ -10,7 +10,16 @@ import SwiftUI
 /// panel from the JS side, straight back to the video.
 @available(tvOS 26.0, *)
 struct TVSubtitleSearchPanel: View {
+	/// The panel's two focusable regions. Results are addressed by index so
+	/// the coordinator can name one — see the tvFocusZone call below.
+	private enum PanelFocus: Hashable {
+		case language
+		case result(Int)
+	}
+
 	@ObservedObject var viewModel: PlayerViewModel
+	let focusCoordinator: TVFocusCoordinator
+	@FocusState private var focusedElement: PanelFocus?
 
 	var body: some View {
 		ZStack {
@@ -29,6 +38,20 @@ struct TVSubtitleSearchPanel: View {
 		// Backup for the VC's always-live Menu recognizer (same pattern as
 		// the episode shelf) — whichever fires, closing twice is harmless.
 		.onExitCommand { viewModel.closeSubtitleSearch() }
+		// Results arrive from JS after the panel is already up, so opening
+		// lands on the language picker; the first batch then takes focus,
+		// which is also what you want after switching language.
+		.onChange(of: viewModel.subtitleSearchResults.count) { count in
+			if count > 0, focusedElement == .language {
+				focusedElement = .result(0)
+			}
+		}
+		.tvFocusZone(
+			.subtitleSearch, coordinator: focusCoordinator, focus: $focusedElement,
+			target: {
+				viewModel.subtitleSearchResults.isEmpty
+					? PanelFocus.language : PanelFocus.result(0)
+			})
 	}
 
 	private var header: some View {
@@ -98,8 +121,9 @@ struct TVSubtitleSearchPanel: View {
 				LazyVStack(spacing: 14) {
 					ForEach(
 						Array(viewModel.subtitleSearchResults.enumerated()), id: \.offset
-					) { _, result in
+					) { index, result in
 						resultRow(result)
+							.focused($focusedElement, equals: .result(index))
 					}
 				}
 				// Headroom for the focus scale so rows don't clip at the
@@ -187,6 +211,7 @@ struct TVSubtitleSearchPanel: View {
 		}
 		.menuOrder(.fixed)
 		.buttonStyle(.glass)
+		.focused($focusedElement, equals: .language)
 	}
 
 	private var currentLanguageName: String {


### PR DESCRIPTION
Focus in the tvOS player hopped visibly on every chrome summon — the focus ring slid from the left-most button to the intended one — and the episode shelf always opened on the first card instead of the episode you were watching.

## What was actually wrong

Two findings, both verified against Apple's docs and shipping tvOS players, overturned the original diagnosis:

**`UIFocusSystem.requestFocusUpdate(to:)` is a no-op in the case we were calling it.** Apple's Discussion: *"If the specified object does not contain a focused item, calling this method has no effect."* — the same restriction as `setNeedsFocusUpdate()`. The whole imperative-kick design was built around a call that does nothing.

**The left-most pick is a repair, not a choice.** Any frame with nothing focused gets repaired by the engine *geometrically* — first/left-most item wins, preferred focus is not consulted. The old `activate()` blanked every layer host *before* enabling the incoming one, manufacturing exactly that frame on every summon.

## The change

The single SwiftUI root is split into stacked `UIHostingController` layers (chrome, status, shelf, subtitle search, still-watching, error) owned by a new `TVFocusCoordinator`. UIKit decides *which layer* may hold focus by toggling each host's `isUserInteractionEnabled`; SwiftUI decides *which control within it* via `@FocusState`. The view controller routes `preferredFocusEnvironments` into the active zone — the only supported bridge, since SwiftUI vends non-`UIView` "virtual focus items" and there is no UIKit handle on an individual `Button`.

Three details are load-bearing, each traced to a specific failure:

- **Never go dark.** The outgoing layer keeps focus until the incoming one has claimed it; other hosts retire at the *end* of the handover.
- **Three beats on separate runloop turns** — publish the request while the host is still outside the focus graph, join the graph, then check and retire. A focus claim made in the same transaction as the structural re-enable is dropped by the engine.
- **A focus gate.** For the frame a layer joins the graph, every control except the target is removed from the focus graph, so the geometric repair has exactly one candidate. Released the instant focus lands, with a backstop. This is also what puts the shelf on the playing episode: `.defaultFocus` is ignored outright inside a `ScrollView` (Apple FB706321, open since 2022).

Also removed the vestigial `prefersDefaultFocus`/`focusScope`/`resetFocus` apparatus, and `.focusSection()` now follows `.defaultFocus` — reversed, the grouping wins and the preference is silently ignored (Swiftfin shipped that bug as #2178/#2180).

## Styling pass

- Chrome inset halved (80/60 → 40/24). The layer hosts are pinned to the full view bounds, so SwiftUI already applies the tvOS overscan safe area *inside* them; the old values stacked on top and put the transport bar ~170pt from the screen edge.
- Chapter name moved under the elapsed time, mirroring the ends-at line on the right; the freed space closes the gap between the button row and the bar.
- Transport buttons shrunk (26pt glyph in 40×40 → 22 in 34).
- Liquid Glass on the unplayed seek track instead of a flat white tint; white focus halo dropped, leaving the track thickening as the focus cue, as in the system player.
- Episode cards adopt `.buttonStyle(.card)`, which is what carries the tvOS focus float — the card tilts toward your thumb and a specular highlight tracks its position. Everything now lives *inside* the card over a frosted gradient rather than a flat black band, with a Now Playing badge (matching `components/tv/TVPosterCard.tsx`) replacing the white border, which competed with the focus ring and read as a second focus state.

## Testing

Built and exercised on Apple TV 4K (3rd gen, tvOS 26.5): chrome summon/hide cycles, dropdown open/close, episode shelf, and scrubbing. Focus placement was instrumented with `os.Logger` under the `tvfocus` category throughout — the logs distinguish a SwiftUI-placed focus from a fallback kick, and confirmed the hop is gone rather than merely less visible.

tvOS-only; no mobile code paths touched.

https://claude.ai/code/session_019xkHUWrfqjYaSK4ihHBBPf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tvOS player navigation with more reliable focus movement across controls, episode shelves, subtitle search, prompts, and error states.
  * Added clearer focus transitions between layered playback interface elements.
  * Redesigned episode cards with artwork, progress indicators, title overlays, and a “Now Playing” badge.

* **Improvements**
  * Refined playback controls with more compact sizing and spacing.
  * Subtitle search now automatically focuses the first available result.
  * Updated chapter and progress display styling for a cleaner viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->