### PR TITLE
fix(player): subtitle search in the native tvOS player

### DIFF
--- a/modules/mpv-player/ios/NativePlayer/NativePlayerModule.swift
+++ b/modules/mpv-player/ios/NativePlayer/NativePlayerModule.swift
@@ -135,17 +135,13 @@ public class NativePlayerModule: Module {
 		}.runOnQueue(.main)
 
 		AsyncFunction("updateSubtitleSearch") { (state: SubtitleSearchStateRecord) in
-			#if os(iOS)
 			self.session?.viewModel.updateSubtitleSearch(state)
-			#endif
 		}.runOnQueue(.main)
 
 		// Adds a sidecar subtitle to the live mpv handle and selects it
 		// (client-side downloaded subtitle file, e.g. OpenSubtitles fallback).
 		AsyncFunction("addExternalSubtitle") { (url: String) in
-			#if os(iOS)
 			self.session?.engine.addSubtitleFile(url: url, select: true)
-			#endif
 		}.runOnQueue(.main)
 
 		// MARK: - Transport (driven by the JS coordinator: WebSocket remote


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Fixes subtitle search in the native tvOS player, which was stuck on a loading spinner forever. `updateSubtitleSearch` and `addExternalSubtitle` in `NativePlayerModule` had their bodies wrapped in `#if os(iOS)`, so on tvOS both resolved their promise without doing anything. The search itself worked fine, the results just got pushed into a no-op and the panel never left its searching state. The dead `addExternalSubtitle` would have broken OpenSubtitles picks the same way once you got past the spinner. Neither guard was needed. `PlayerViewModel.updateSubtitleSearch`, `SubtitleSearchStateRecord` and `PlayerEngine.addSubtitleFile` all build for tvOS already, and the module drives the engine unguarded there for the track functions.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Swift only change, so it needs a fresh tvOS build.

1. Build and run on Apple TV (tvOS 26+) with the native player enabled, then start playback.
2. Open the subtitles menu and pick "Search subtitles".
3. Results should appear instead of the spinner running forever.
4. Pick one and check that it gets applied. Worth doing once against a server with the OpenSubtitles plugin and once with just an OpenSubtitles API key in settings, since those take different paths.
5. On iOS nothing should change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subtitle search updates are now available on tvOS.
  * External subtitle loading is now supported on tvOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->