### PR TITLE
fix(player): align tvOS overlay layers to the chrome inset

### DIFF
--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVChromeLayerView.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVChromeLayerView.swift
@@ -1,6 +1,26 @@
 #if os(tvOS)
 import SwiftUI
 
+/// Edge inset ON TOP OF the tvOS overscan safe area, which SwiftUI has
+/// already applied by the time these run: the layer hosts are pinned to the
+/// full view bounds, not the safe-area guide, so the system's ~90pt
+/// horizontal / ~60pt vertical insets are inside these. Keep them small —
+/// the old 80/60 put the transport bar ~170pt from the screen edge, far
+/// deeper than the system player.
+///
+/// EVERY layer that touches a screen edge measures from here. The layers are
+/// separate hosting controllers over identical bounds, so a literal left
+/// behind in one of them reads as that layer being misaligned against the
+/// chrome — with nothing in its own file to hint at why.
+enum TVChromeMetrics {
+	static let insetH: CGFloat = 40
+	static let insetV: CGFloat = 24
+	/// The floating skip pill / countdown card ride slightly clear of the
+	/// bottom margin: they only ever show with the chrome hidden, so nothing
+	/// anchors that edge for them the way the time row does for the chrome.
+	static let floatingBottomInset: CGFloat = insetV + 20
+}
+
 /// The chrome layer of the TV player: scrims, metadata header, the focusable
 /// controls row and the transport bar. One of the stacked layer hosts built
 /// by NativePlayerViewController — TVFocusCoordinator flips this host into
@@ -15,15 +35,6 @@ struct TVChromeLayerView: View {
 	/// Focus memory for the button row — lives here because the row unmounts
 	/// whenever the chrome hides, and should reappear on the same control.
 	@State private var lastFocusedControl: TVControl?
-
-	/// Chrome inset ON TOP OF the tvOS overscan safe area, which SwiftUI has
-	/// already applied by the time this runs: the layer hosts are pinned to
-	/// the full view bounds, not the safe-area guide, so the system's ~90pt
-	/// horizontal / ~60pt vertical insets are inside these. Keep them small —
-	/// the old 80/60 put the transport bar ~170pt from the screen edge, far
-	/// deeper than the system player.
-	private static let insetH: CGFloat = 40
-	private static let insetV: CGFloat = 24
 
 	var body: some View {
 		ZStack {
@@ -50,8 +61,8 @@ struct TVChromeLayerView: View {
 						TVTransportBar(viewModel: viewModel, time: viewModel.time)
 					}
 				}
-				.padding(.horizontal, Self.insetH)
-				.padding(.vertical, Self.insetV)
+				.padding(.horizontal, TVChromeMetrics.insetH)
+				.padding(.vertical, TVChromeMetrics.insetV)
 				.transition(.opacity)
 			}
 		}

--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVMediaOverlays.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVMediaOverlays.swift
@@ -131,7 +131,7 @@ struct TVEpisodeShelf: View {
 			Text(viewModel.str("episodes", "Episodes"))
 				.font(.title3.weight(.semibold))
 				.foregroundStyle(.white)
-				.padding(.horizontal, 80)
+				.padding(.horizontal, TVChromeMetrics.insetH)
 			ScrollView(.horizontal, showsIndicators: false) {
 				HStack(spacing: 28) {
 					ForEach(Array(viewModel.episodeList.enumerated()), id: \.offset) {
@@ -142,7 +142,7 @@ struct TVEpisodeShelf: View {
 						episodeCard(episode, index: index)
 					}
 				}
-				.padding(.horizontal, 80)
+				.padding(.horizontal, TVChromeMetrics.insetH)
 				.padding(.vertical, 30)
 			}
 		}

--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVOverlayLayers.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVOverlayLayers.swift
@@ -37,8 +37,8 @@ struct TVStatusLayerView: View {
 					}
 					Spacer()
 				}
-				.padding(.top, 60)
-				.padding(.leading, 80)
+				.padding(.top, TVChromeMetrics.insetV)
+				.padding(.leading, TVChromeMetrics.insetH)
 			}
 
 			// Skip pill / countdown card (Select acts on both) stay
@@ -63,8 +63,10 @@ struct TVStatusLayerView: View {
 						}
 					}
 				}
-				.padding(.trailing, 80)
-				.padding(.bottom, 80)
+				// Right edge on the chrome's margin, so the card/pill lines up
+				// with the controls row that replaces it when the chrome opens.
+				.padding(.trailing, TVChromeMetrics.insetH)
+				.padding(.bottom, TVChromeMetrics.floatingBottomInset)
 			}
 		}
 		.frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Aligns the tvOS player's overlay layers to the chrome inset. #1935 moved the chrome to 40/24, but that was a private constant on `TVChromeLayerView`, so the other layers kept the old 80/60. Each layer is its own hosting controller over the same bounds, so the skip intro/credits pill, the next-episode countdown card, the technical info overlay and the episode shelf all ended up sitting further in than the chrome they line up against.

I moved the insets into a shared `TVChromeMetrics` enum and pointed every edge-touching layer at it. The relationships from before are kept: trailing matches the chrome, and the floating pill/card still sit 20pt above its bottom margin.

The focusable Skip and Next-episode buttons in `TVControlsRow` already live inside the chrome's padded stack, so they needed no change.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [ ] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

tvOS 26+ only, native player. Run `bun run ios:tv`.

1. Play an episode and let the chrome hide. Trigger the skip intro/credits pill and check its right edge lines up with the controls row when you bring the chrome back up.
2. Let an episode run into the next-episode countdown, same check on the card.
3. Open the episode shelf. The "Episodes" title should line up with the title in the top left metadata header.
4. Turn on stats for nerds and check its top left inset matches the metadata header.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized spacing and alignment across TV playback overlays.
  * Improved consistency for episode shelves, technical information, and skip/countdown displays.
  * Centralized TV interface inset values to help maintain a uniform layout across screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->