### PR TITLE
feat(player): rebuild the tvOS trickplay preview as an episode poster

### DIFF
--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVChromeLayerView.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVChromeLayerView.swift
@@ -121,7 +121,7 @@ private struct TVBareButtonStyle: ButtonStyle {
 
 /// Bottom transport bar: play-state glyph, progress (played + buffered),
 /// position, remaining and the wall-clock finish time. While a remote scrub
-/// is armed, the playhead follows the scrub target and a trickplay bubble
+/// is armed, the playhead follows the scrub target and a trickplay card
 /// rides above it. Observes PlaybackTimeModel directly — PlayerViewModel
 /// deliberately does not publish the ~30Hz clock (see PlaybackTimeModel).
 ///
@@ -139,7 +139,8 @@ private struct TVTransportBar: View {
 	@ObservedObject var time: PlaybackTimeModel
 	@FocusState private var barFocused: Bool
 
-	private static let bubbleHeight: CGFloat = 180
+	/// Clearance between the scrub preview card and the track it rides over.
+	private static let cardGap: CGFloat = 40
 
 	private static let endsAtFormatter: DateFormatter = {
 		let formatter = DateFormatter()
@@ -254,7 +255,7 @@ private struct TVTransportBar: View {
 	}
 
 	/// First horizontal input on the focused bar: arm the scrub (pauses,
-	/// shows the trickplay bubble) and take the first step. Every further
+	/// shows the trickplay card) and take the first step. Every further
 	/// press/pan is handled by the VC recognizers, which re-enable the
 	/// moment isScrubbing flips.
 	private func armScrub(nudge delta: Double) {
@@ -302,29 +303,25 @@ private struct TVTransportBar: View {
 			.overlay(alignment: .topLeading) {
 				if viewModel.isScrubbing, let trickplay = viewModel.trickplay,
 					trickplay.isAvailable {
-					let chapterName = viewModel.chapterName(at: viewModel.scrubPosition)
-					TrickplayBubbleView(
+					TVTrickplayCard(
 						provider: trickplay,
-						positionSec: viewModel.scrubPosition,
-						chapterName: chapterName,
-						bubbleHeight: Self.bubbleHeight
+						positionSec: viewModel.scrubPosition
 					)
 					.offset(
-						x: bubbleOffsetX(trackWidth: width, provider: trickplay, playedFraction: playedFraction),
-						y: -Self.bubbleHeight - 90 - (chapterName != nil ? 30 : 0)
+						x: cardOffsetX(trackWidth: width, playedFraction: playedFraction),
+						y: -TVTrickplayCard.height - Self.cardGap
 					)
 				}
 			}
 		}
 	}
 
-	/// Center the bubble over the playhead, clamped to the track bounds.
-	private func bubbleOffsetX(
-		trackWidth: CGFloat, provider: TrickplayProvider, playedFraction: CGFloat
-	) -> CGFloat {
-		let bubbleWidth = Self.bubbleHeight * provider.aspectRatio
+	/// Center the card over the playhead, clamped to the track bounds.
+	private func cardOffsetX(trackWidth: CGFloat, playedFraction: CGFloat) -> CGFloat {
 		let thumbX = trackWidth * playedFraction
-		return min(max(thumbX - bubbleWidth / 2, 0), max(trackWidth - bubbleWidth, 0))
+		return min(
+			max(thumbX - TVTrickplayCard.width / 2, 0),
+			max(trackWidth - TVTrickplayCard.width, 0))
 	}
 
 	/// Wall-clock finish time. The i18n template carries a %TIME% placeholder;

--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVMediaOverlays.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVMediaOverlays.swift
@@ -1,6 +1,52 @@
 #if os(tvOS)
 import SwiftUI
 
+/// The 16:9 poster of the TV player chrome. The episode shelf cards and the
+/// trickplay scrub preview are deliberately the same object — same size, same
+/// corner, same frosted band under the text — so both draw through here
+/// instead of carrying their own copies of these numbers.
+enum TVPoster {
+	static let width: CGFloat = 300
+	static let height: CGFloat = 168
+	static let cornerRadius: CGFloat = 12
+	/// Depth of the frosted band that grounds the text.
+	static let scrimHeight: CGFloat = 110
+	/// Text inset inside the band.
+	static let textInsetH: CGFloat = 14
+	static let textInsetV: CGFloat = 12
+}
+
+/// Frosted gradient rather than a flat black band: a material masked to fade
+/// in toward the bottom keeps the artwork visible through it while still
+/// grounding the text. The black underlay carries the contrast the material
+/// alone cannot guarantee over a bright frame. Stack it over the artwork,
+/// under the text; it aligns itself to the bottom of whatever it is in.
+@available(tvOS 26.0, *)
+struct TVPosterScrim: View {
+	var body: some View {
+		ZStack {
+			LinearGradient(
+				colors: [.black.opacity(0), .black.opacity(0.55)],
+				startPoint: .top, endPoint: .bottom
+			)
+			Rectangle()
+				.fill(.ultraThinMaterial)
+				.mask(
+					LinearGradient(
+						stops: [
+							.init(color: .clear, location: 0),
+							.init(color: .black.opacity(0.65), location: 0.5),
+							.init(color: .black, location: 1),
+						],
+						startPoint: .top, endPoint: .bottom
+					)
+				)
+		}
+		.frame(height: TVPoster.scrimHeight)
+		.frame(maxHeight: .infinity, alignment: .bottom)
+	}
+}
+
 /// Skip intro/credits pill — non-focusable on purpose, and shown only while
 /// the chrome is hidden: Select triggers the skip via the VC recognizers
 /// (Play/Pause stays playback-only). In the full chrome the controls row
@@ -203,31 +249,7 @@ struct TVEpisodeShelf: View {
 				} else {
 					Color.white.opacity(0.1)
 				}
-				// Frosted gradient rather than a flat black band: a material
-				// masked to fade in toward the bottom keeps the artwork visible
-				// through it while still grounding the title. The black
-				// underlay carries the contrast the material alone cannot
-				// guarantee over a bright frame.
-				LinearGradient(
-					colors: [.black.opacity(0), .black.opacity(0.55)],
-					startPoint: .top, endPoint: .bottom
-				)
-				.frame(height: 110)
-				.frame(maxHeight: .infinity, alignment: .bottom)
-				Rectangle()
-					.fill(.ultraThinMaterial)
-					.mask(
-						LinearGradient(
-							stops: [
-								.init(color: .clear, location: 0),
-								.init(color: .black.opacity(0.65), location: 0.5),
-								.init(color: .black, location: 1),
-							],
-							startPoint: .top, endPoint: .bottom
-						)
-					)
-					.frame(height: 110)
-					.frame(maxHeight: .infinity, alignment: .bottom)
+				TVPosterScrim()
 				VStack(alignment: .leading, spacing: 8) {
 					Text(
 						episode.indexNumber.map { "\($0). \(episode.title)" } ?? episode.title
@@ -248,10 +270,10 @@ struct TVEpisodeShelf: View {
 						.frame(height: 4)
 					}
 				}
-				.padding(.horizontal, 14)
-				.padding(.bottom, 12)
+				.padding(.horizontal, TVPoster.textInsetH)
+				.padding(.bottom, TVPoster.textInsetV)
 			}
-			.frame(width: 300, height: 168)
+			.frame(width: TVPoster.width, height: TVPoster.height)
 			.overlay(alignment: .topLeading) {
 				// Matches the app's existing badge (TVPosterCard.tsx): solid
 				// white, black content, radius 8, top-left. Replaces the white
@@ -271,7 +293,7 @@ struct TVEpisodeShelf: View {
 					.padding(10)
 				}
 			}
-			.clipShape(RoundedRectangle(cornerRadius: 12))
+			.clipShape(RoundedRectangle(cornerRadius: TVPoster.cornerRadius))
 		}
 		.buttonStyle(.card)
 		.focused($focusedEpisode, equals: index)

--- a/modules/mpv-player/ios/NativePlayer/Views/TV/TVTrickplayCard.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TV/TVTrickplayCard.swift
@@ -1,0 +1,66 @@
+#if os(tvOS)
+import SwiftUI
+
+/// Scrub preview for the tvOS chrome: the episode shelf card with a trickplay
+/// frame in it. Same poster geometry, same frosted band, same text inset —
+/// all of it via TVPoster/TVPosterScrim rather than copied numbers, so the
+/// two cannot drift apart.
+///
+/// The timestamp is the only text inside. The bar underneath already carries
+/// the chapter at the scrub position (under the elapsed time, paired with the
+/// ends-at line), so repeating it here would print the same string twice,
+/// 30pt apart.
+///
+/// Loads are keyed on the bucketed tile index, so scrubbing across one tile
+/// issues exactly one fetch — .task(id:) naturally debounces.
+@available(tvOS 26.0, *)
+struct TVTrickplayCard: View {
+	static let width = TVPoster.width
+	static let height = TVPoster.height
+	/// Rounder than TVPoster.cornerRadius on purpose — the shelf cards sit in
+	/// a row where a tight corner reads as crisp, but this one floats alone
+	/// over the picture, where the softer corner reads better.
+	private static let cornerRadius: CGFloat = 18
+
+	let provider: TrickplayProvider
+	let positionSec: Double
+
+	@State private var image: UIImage?
+
+	var body: some View {
+		ZStack(alignment: .bottomLeading) {
+			// The shelf cards use white 10% here, but they sit on their own
+			// dark gradient. This one floats over the picture, where a 10%
+			// white fill is just a smudge of the video showing through.
+			Color.black.opacity(0.6)
+
+			if let image {
+				Image(uiImage: image)
+					.resizable()
+					.aspectRatio(contentMode: .fill)
+			}
+
+			TVPosterScrim()
+
+			Text(formatTime(positionSec))
+				.font(.system(size: 20, weight: .medium).monospacedDigit())
+				.foregroundStyle(.white)
+				.padding(.horizontal, TVPoster.textInsetH)
+				.padding(.bottom, TVPoster.textInsetV)
+		}
+		.frame(width: Self.width, height: Self.height)
+		.clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
+		// No border and no shadow, matching the shelf cards: the white ring
+		// was removed there for competing with the focus ring, and the bottom
+		// scrim already grounds the card against the video.
+		.task(id: provider.tileIndex(forSeconds: positionSec)) {
+			// Keep the last frame when a fetch fails or is cancelled by the
+			// next tile: blanking to the placeholder for a beat reads as a
+			// flicker while scrubbing fast.
+			if let next = await provider.thumbnail(forSeconds: positionSec) {
+				image = next
+			}
+		}
+	}
+}
+#endif

--- a/modules/mpv-player/ios/NativePlayer/Views/TrickplayBubbleView.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/TrickplayBubbleView.swift
@@ -1,7 +1,9 @@
+#if os(iOS)
 import SwiftUI
 
-/// Preview thumbnail bubble shown above the scrubber thumb while dragging
-/// (iOS) or above the transport bar while remote-scrubbing (tvOS).
+/// Preview thumbnail bubble shown above the scrubber thumb while dragging.
+/// The tvOS chrome has its own preview (TVTrickplayCard), built as an episode
+/// poster, so this one stays phone-shaped.
 /// Loads are keyed on the bucketed tile index, so scrubbing across one tile
 /// issues exactly one fetch — .task(id:) naturally debounces.
 struct TrickplayBubbleView: View {
@@ -11,9 +13,6 @@ struct TrickplayBubbleView: View {
 	let positionSec: Double
 	/// Chapter at the scrub position (JS bubble shows it over the thumbnail).
 	var chapterName: String?
-	/// iOS callers use the default; the TV chrome renders the bubble larger
-	/// for viewing distance.
-	var bubbleHeight: CGFloat = TrickplayBubbleView.height
 
 	@State private var image: UIImage?
 
@@ -29,7 +28,7 @@ struct TrickplayBubbleView: View {
 						.clipShape(RoundedRectangle(cornerRadius: 8))
 				}
 			}
-			.frame(width: bubbleHeight * provider.aspectRatio, height: bubbleHeight)
+			.frame(width: Self.height * provider.aspectRatio, height: Self.height)
 			.overlay(
 				RoundedRectangle(cornerRadius: 8)
 					.stroke(.white.opacity(0.3), lineWidth: 1)
@@ -40,7 +39,7 @@ struct TrickplayBubbleView: View {
 					.font(.caption2)
 					.foregroundStyle(.white.opacity(0.9))
 					.lineLimit(1)
-					.frame(maxWidth: bubbleHeight * provider.aspectRatio)
+					.frame(maxWidth: Self.height * provider.aspectRatio)
 			}
 
 			Text(formatTime(positionSec))
@@ -55,3 +54,4 @@ struct TrickplayBubbleView: View {
 		}
 	}
 }
+#endif


### PR DESCRIPTION
## What

The tvOS scrub preview was a stacked bubble: thumbnail on top, a chapter line and a time capsule underneath. Its height therefore depended on whether a chapter name existed at the scrub position, so the card grew a row and shifted while you were scrubbing through one.

It is now the episode shelf card with a trickplay frame in it — same poster, text contained inside the artwork.

## How

`TVPoster` (300×168, corner 12, scrim depth 110, text inset 14/12) and `TVPosterScrim` (black `0 → 0.55` underlay plus `.ultraThinMaterial` masked `clear@0 → 0.65@0.5 → black@1`) are extracted out of `episodeCard` so both cards draw through one definition instead of two copies of the same numbers. The shelf card renders identically — same layers, same order, same values, just lifted out.

The timestamp is the only text inside the card. The transport bar already shows the chapter at the scrub position under the elapsed time, so repeating it in the card would print the same string twice a few points apart.

Two deliberate departures from the shelf card, both commented at the point of divergence:

- **Corner radius 18 instead of 12.** The shelf cards sit in a row where a tight corner reads as crisp; this one floats alone over the picture.
- **Placeholder is black 60%, not white 10%.** The shelf cards sit on their own dark gradient; this one floats over live video, where a 10% white fill is just a smudge of the picture showing through.

No border and no shadow, matching the shelf cards — the white ring was removed there in #1935 for competing with the focus ring, and the chrome's bottom scrim already grounds the card against the video.

`TrickplayBubbleView` keeps its phone shape and is now `#if os(iOS)`; its `bubbleHeight` parameter existed solely for the TV caller and is gone.

## Also

A cancelled tile fetch no longer blanks the card to its placeholder — scrubbing fast cancels in-flight requests, and dropping to an empty card for a beat read as a flicker. The last frame stays up until a new one decodes.

## Testing

Swift parse-checked for both `arm64-apple-tvos26.0` and `arm64-apple-ios18.0`. Needs one `pod install` before the first build: `TVTrickplayCard.swift` is a new file, and the podspec's `**/*.swift` glob is expanded into `Pods.xcodeproj` at install time, so Xcode cannot see it until then.

Not yet exercised on device — worth a look at the card riding the playhead near both ends of the track (it clamps to the track bounds) and over a blown-out bright frame, where the scrim's black underlay is what carries the text contrast.

https://claude.ai/code/session_01GWdFbQa44DTTh6nJb4SXn1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a tvOS scrub-preview card with thumbnail imagery, rounded styling, and a timestamp.
  - Improved TV episode cards with consistent poster sizing, overlays, spacing, and corner styling.

- **Bug Fixes**
  - Updated the TV transport bar to use the new scrub-preview card for more consistent positioning and sizing.
  - Improved preview thumbnail loading so temporary failures or cancellations retain the previous image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->