### PR TITLE
fix(player): consolidate audio & subtitle track selection

### DIFF
--- a/app/(auth)/(tabs)/(home)/settings.tv.tsx
+++ b/app/(auth)/(tabs)/(home)/settings.tv.tsx
@@ -1,7 +1,5 @@
-import {
-  type CultureDto,
-  SubtitlePlaybackMode,
-} from "@jellyfin/sdk/lib/generated-client";
+import { SubtitlePlaybackMode } from "@jellyfin/sdk/lib/generated-client";
+import type { CultureDto } from "@jellyfin/sdk/lib/generated-client/models";
 import { useQueryClient } from "@tanstack/react-query";
 import { Directory, Paths } from "expo-file-system";
 import { Image } from "expo-image";
@@ -13,7 +11,6 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/common/Text";
 import { TVPasswordEntryModal } from "@/components/login/TVPasswordEntryModal";
 import { TVPINEntryModal } from "@/components/login/TVPINEntryModal";
-import { MediaProvider, useMedia } from "@/components/settings/MediaContext";
 import type { TVOptionItem } from "@/components/tv";
 import {
   TVLogoutButton,
@@ -25,6 +22,7 @@ import {
   TVSettingsToggle,
 } from "@/components/tv";
 import { useScaledTVTypography } from "@/constants/TVTypography";
+import { useMediaPreferences } from "@/hooks/useMediaPreferences";
 import { useTVOptionModal } from "@/hooks/useTVOptionModal";
 import { useTVUserSwitchModal } from "@/hooks/useTVUserSwitchModal";
 import { APP_LANGUAGES } from "@/i18n";
@@ -56,91 +54,40 @@ import {
 } from "@/utils/secureCredentials";
 import { clearTopShelfCacheSafely } from "@/utils/topshelf/cache";
 
-function TVAudioLanguageSetting() {
-  const { t } = useTranslation();
-  const {
-    settings,
-    supportsOriginalAudioLanguage,
-    updateSettings,
-    cultures,
-    isReady,
-  } = useMedia();
-  const { pluginSettings } = useSettings();
-  const { showOptions } = useTVOptionModal();
-  const selectedLanguage =
-    settings?.defaultAudioLanguage?.ThreeLetterISOLanguageName;
-
-  const options = useMemo<TVOptionItem<CultureDto | null>[]>(
-    () => [
-      {
-        label: t("home.settings.audio.none"),
-        value: null,
-        selected: !selectedLanguage,
-      },
-      ...(supportsOriginalAudioLanguage
-        ? [
-            {
-              label: t("home.settings.audio.original_language"),
-              value: { ThreeLetterISOLanguageName: ORIGINAL_LANGUAGE },
-              selected: selectedLanguage === ORIGINAL_LANGUAGE,
-            },
-          ]
-        : []),
-      ...cultures.map((culture) => ({
-        label:
-          culture.DisplayName ||
-          culture.ThreeLetterISOLanguageName ||
-          "Unknown",
-        value: culture,
-        selected: culture.ThreeLetterISOLanguageName === selectedLanguage,
-      })),
-    ],
-    [cultures, selectedLanguage, supportsOriginalAudioLanguage, t],
-  );
-
-  // Derived from the stored value rather than from the option list, so it stays
-  // accurate while the cultures query is still loading.
-  const selectedLabel = useMemo(() => {
-    const language = settings?.defaultAudioLanguage;
-    if (language?.ThreeLetterISOLanguageName === ORIGINAL_LANGUAGE)
-      return t("home.settings.audio.original_language");
-    if (!language) return t("home.settings.audio.none");
-    return (
-      language.DisplayName ||
-      language.ThreeLetterISOLanguageName ||
-      t("home.settings.audio.none")
-    );
-  }, [settings?.defaultAudioLanguage, t]);
-
-  return (
-    <TVSettingsOptionButton
-      label={t("home.settings.audio.audio_language")}
-      value={selectedLabel}
-      disabled={
-        !isReady ||
-        pluginSettings?.defaultAudioLanguage?.locked ||
-        pluginSettings?.playDefaultAudioTrack?.locked
-      }
-      onPress={() =>
-        showOptions({
-          title: t("home.settings.audio.language"),
-          options,
-          onSelect: (value) => updateSettings({ defaultAudioLanguage: value }),
-        })
-      }
-    />
-  );
-}
+const buildLanguageOptions = (
+  cultures: CultureDto[],
+  selectedCode: string | null | undefined,
+  noneLabel: string,
+  /** Rows that are not real cultures, listed directly under "None". */
+  extra: TVOptionItem<CultureDto | null>[] = [],
+): TVOptionItem<CultureDto | null>[] => [
+  { label: noneLabel, value: null, selected: !selectedCode },
+  ...extra,
+  ...cultures.map((culture) => ({
+    label: culture.DisplayName ?? culture.Name ?? "",
+    value: culture,
+    selected: culture.ThreeLetterISOLanguageName === selectedCode,
+  })),
+];
 
 export default function SettingsTV() {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
-  const { settings, updateSettings } = useSettings();
+  const { settings, updateSettings, pluginSettings } = useSettings();
   const { logout, loginWithSavedCredential, loginWithPassword } = useJellyfin();
   const [user] = useAtom(userAtom);
   const [api] = useAtom(apiAtom);
   const [, setCacheVersion] = useAtom(cacheVersionAtom);
   const { showOptions } = useTVOptionModal();
+  // Audio/subtitle language and mode are mirrors of the Jellyfin user profile,
+  // not TV-local settings — going through this hook seeds them from the server
+  // on mount and writes edits back, so the Apple TV and the phone cannot drift.
+  const {
+    updateMediaSettings,
+    cultures,
+    supportsOriginalAudioLanguage,
+    isReady,
+  } = useMediaPreferences();
   const { showUserSwitchModal } = useTVUserSwitchModal();
   const typography = useScaledTVTypography();
   const queryClient = useQueryClient();
@@ -626,6 +573,56 @@ export default function SettingsTV() {
     return option?.label || t("home.settings.audio.transcode_mode.auto");
   }, [audioTranscodeModeOptions, t]);
 
+  // The Jellyfin culture list runs to a couple of hundred entries, so these
+  // open in the modal's vertical layout rather than the card strip.
+  const audioLanguageOptions = useMemo(
+    () =>
+      buildLanguageOptions(
+        cultures,
+        settings.defaultAudioLanguage?.ThreeLetterISOLanguageName,
+        t("home.settings.subtitles.none"),
+        // Not an ISO code and so absent from the cultures list: the server
+        // resolves it per item. Only offered where the server understands it.
+        supportsOriginalAudioLanguage
+          ? [
+              {
+                label: t("home.settings.audio.original_language"),
+                value: {
+                  ThreeLetterISOLanguageName: ORIGINAL_LANGUAGE,
+                } as CultureDto,
+                selected:
+                  settings.defaultAudioLanguage?.ThreeLetterISOLanguageName ===
+                  ORIGINAL_LANGUAGE,
+              },
+            ]
+          : [],
+      ),
+    [cultures, settings.defaultAudioLanguage, supportsOriginalAudioLanguage, t],
+  );
+
+  const subtitleLanguageOptions = useMemo(
+    () =>
+      buildLanguageOptions(
+        cultures,
+        settings.defaultSubtitleLanguage?.ThreeLetterISOLanguageName,
+        t("home.settings.subtitles.none"),
+      ),
+    [cultures, settings.defaultSubtitleLanguage, t],
+  );
+
+  // Derived from the stored value rather than from the option list, so it stays
+  // accurate while the cultures query is still loading. The sentinel carries no
+  // DisplayName, so it needs its own label.
+  const audioLanguageLabel =
+    settings.defaultAudioLanguage?.ThreeLetterISOLanguageName ===
+    ORIGINAL_LANGUAGE
+      ? t("home.settings.audio.original_language")
+      : (settings.defaultAudioLanguage?.DisplayName ??
+        t("home.settings.subtitles.none"));
+  const subtitleLanguageLabel =
+    settings.defaultSubtitleLanguage?.DisplayName ??
+    t("home.settings.subtitles.none");
+
   const subtitleModeLabel = useMemo(() => {
     const option = subtitleModeOptions.find((o) => o.selected);
     return option?.label || t("home.settings.subtitles.modes.Default");
@@ -711,6 +708,7 @@ export default function SettingsTV() {
           {/* Security Section */}
           <TVSectionHeader title={t("home.settings.security.title")} />
           <TVSettingsOptionButton
+            disabledByAdmin={pluginSettings?.inactivityTimeout?.locked}
             label={t("home.settings.security.inactivity_timeout.title")}
             value={inactivityTimeoutLabel}
             onPress={() =>
@@ -723,56 +721,103 @@ export default function SettingsTV() {
             }
           />
 
+          {/* Video Player Section — which engine plays video is not an audio
+              setting. The header is conditional along with its contents so the
+              section doesn't render empty on platforms that offer neither
+              choice (Apple TV below tvOS 26, which has no native-player opt-in
+              and no ExoPlayer selector). */}
+          {(isAndroidTv || isNativePlayerSupportedTV) && (
+            <>
+              <TVSectionHeader title={t("home.settings.video_player.title")} />
+
+              {/* Engine selector — Android TV only */}
+              {isAndroidTv && (
+                <>
+                  <TVSettingsOptionButton
+                    disabledByAdmin={pluginSettings?.videoPlayer?.locked}
+                    label={t("home.settings.video_player.title")}
+                    value={videoPlayerLabel}
+                    onPress={() =>
+                      showOptions({
+                        title: t("home.settings.video_player.title"),
+                        options: videoPlayerOptions,
+                        onSelect: (value) =>
+                          updateSettings({ videoPlayer: value }),
+                      })
+                    }
+                  />
+                  {!isMpv && (
+                    <Text style={playerNoteStyle}>
+                      {t("home.settings.video_player.exoplayer_note")}
+                    </Text>
+                  )}
+                  {isMpv && (
+                    <Text style={playerNoteStyle}>
+                      {t("home.settings.video_player.mpv_note")}
+                    </Text>
+                  )}
+                </>
+              )}
+
+              {/* Native tvOS player opt-in — Apple TV on tvOS 26+, default off */}
+              {isNativePlayerSupportedTV && (
+                <>
+                  <TVSettingsToggle
+                    disabledByAdmin={
+                      pluginSettings?.nativeVideoPlayerTV?.locked
+                    }
+                    label={t("home.settings.video_player.native_tv")}
+                    value={settings.nativeVideoPlayerTV}
+                    onToggle={(value) =>
+                      updateSettings({ nativeVideoPlayerTV: value })
+                    }
+                  />
+                  <Text style={playerNoteStyle}>
+                    {t("home.settings.video_player.native_tv_note")}
+                  </Text>
+                </>
+              )}
+            </>
+          )}
+
           {/* Audio Section */}
           <TVSectionHeader title={t("home.settings.audio.audio_title")} />
-          <MediaProvider>
-            <TVAudioLanguageSetting />
-          </MediaProvider>
+          {/* An admin-locked setting is dropped by updateSettings on write and
+              overridden on read, so without these guards the control renders
+              fully interactive and silently does nothing. The audio language
+              also waits on isReady: it needs the cultures list and the server
+              version gate before a write can mean anything.
+              playDefaultAudioTrack is included because picking the original
+              language has to clear it, so a lock there locks this too. */}
+          <TVSettingsOptionButton
+            label={t("home.settings.audio.audio_language")}
+            value={audioLanguageLabel}
+            disabled={!isReady}
+            disabledByAdmin={
+              pluginSettings?.defaultAudioLanguage?.locked ||
+              pluginSettings?.playDefaultAudioTrack?.locked
+            }
+            onPress={() =>
+              showOptions({
+                title: t("home.settings.audio.audio_language"),
+                options: audioLanguageOptions,
+                onSelect: (value) =>
+                  updateMediaSettings({ defaultAudioLanguage: value }),
+              })
+            }
+          />
 
-          {/* Video Player selector — Android TV only */}
-          {isAndroidTv && (
-            <>
-              <TVSettingsOptionButton
-                label={t("home.settings.video_player.title")}
-                value={videoPlayerLabel}
-                onPress={() =>
-                  showOptions({
-                    title: t("home.settings.video_player.title"),
-                    options: videoPlayerOptions,
-                    onSelect: (value) => updateSettings({ videoPlayer: value }),
-                  })
-                }
-              />
-              {!isMpv && (
-                <Text style={playerNoteStyle}>
-                  {t("home.settings.video_player.exoplayer_note")}
-                </Text>
-              )}
-              {isMpv && (
-                <Text style={playerNoteStyle}>
-                  {t("home.settings.video_player.mpv_note")}
-                </Text>
-              )}
-            </>
-          )}
-
-          {/* Native tvOS player opt-in — Apple TV on tvOS 26+, default off */}
-          {isNativePlayerSupportedTV && (
-            <>
-              <TVSettingsToggle
-                label={t("home.settings.video_player.native_tv")}
-                value={settings.nativeVideoPlayerTV}
-                onToggle={(value) =>
-                  updateSettings({ nativeVideoPlayerTV: value })
-                }
-              />
-              <Text style={playerNoteStyle}>
-                {t("home.settings.video_player.native_tv_note")}
-              </Text>
-            </>
-          )}
+          <TVSettingsToggle
+            label={t("home.settings.audio.set_audio_track")}
+            value={settings.rememberAudioSelections}
+            disabledByAdmin={pluginSettings?.rememberAudioSelections?.locked}
+            onToggle={(value) =>
+              updateMediaSettings({ rememberAudioSelections: value })
+            }
+          />
 
           <TVSettingsOptionButton
+            disabledByAdmin={pluginSettings?.audioTranscodeMode?.locked}
             label={t("home.settings.audio.transcode_mode.title")}
             value={audioTranscodeLabel}
             onPress={() =>
@@ -790,24 +835,41 @@ export default function SettingsTV() {
             title={t("home.settings.subtitles.subtitle_title")}
           />
           <TVSettingsOptionButton
+            label={t("home.settings.subtitles.subtitle_language")}
+            value={subtitleLanguageLabel}
+            disabledByAdmin={pluginSettings?.defaultSubtitleLanguage?.locked}
+            onPress={() =>
+              showOptions({
+                title: t("home.settings.subtitles.subtitle_language"),
+                options: subtitleLanguageOptions,
+                onSelect: (value) =>
+                  updateMediaSettings({ defaultSubtitleLanguage: value }),
+              })
+            }
+          />
+          <TVSettingsOptionButton
             label={t("home.settings.subtitles.subtitle_mode")}
             value={subtitleModeLabel}
+            disabledByAdmin={pluginSettings?.subtitleMode?.locked}
             onPress={() =>
               showOptions({
                 title: t("home.settings.subtitles.subtitle_mode"),
                 options: subtitleModeOptions,
-                onSelect: (value) => updateSettings({ subtitleMode: value }),
+                onSelect: (value) =>
+                  updateMediaSettings({ subtitleMode: value }),
               })
             }
           />
           <TVSettingsToggle
             label={t("home.settings.subtitles.set_subtitle_track")}
             value={settings.rememberSubtitleSelections}
+            disabledByAdmin={pluginSettings?.rememberSubtitleSelections?.locked}
             onToggle={(value) =>
-              updateSettings({ rememberSubtitleSelections: value })
+              updateMediaSettings({ rememberSubtitleSelections: value })
             }
           />
           <TVSettingsStepper
+            disabledByAdmin={pluginSettings?.mpvSubtitleScale?.locked}
             label={t("home.settings.subtitles.subtitle_size")}
             value={settings.mpvSubtitleScale ?? 1.0}
             onDecrease={() => {
@@ -831,6 +893,7 @@ export default function SettingsTV() {
             formatValue={(v) => `${v.toFixed(1)}x`}
           />
           <TVSettingsStepper
+            disabledByAdmin={pluginSettings?.mpvSubtitleMarginY?.locked}
             label={t("home.settings.subtitles.mpv_subtitle_margin_y")}
             value={settings.mpvSubtitleMarginY ?? 0}
             onDecrease={() => {
@@ -850,6 +913,7 @@ export default function SettingsTV() {
           />
           {isMpv && (
             <TVSettingsOptionButton
+              disabledByAdmin={pluginSettings?.mpvSubtitleAlignX?.locked}
               label={t("home.settings.subtitles.mpv_subtitle_align_x")}
               value={alignXLabel}
               // ExoPlayer follows authored cue alignment; hide on ExoPlayer.
@@ -866,6 +930,7 @@ export default function SettingsTV() {
             />
           )}
           <TVSettingsOptionButton
+            disabledByAdmin={pluginSettings?.mpvSubtitleAlignY?.locked}
             label={t("home.settings.subtitles.mpv_subtitle_align_y")}
             value={alignYLabel}
             onPress={() =>
@@ -899,6 +964,7 @@ export default function SettingsTV() {
               "Enter your OpenSubtitles API key to enable client-side subtitle search as a fallback when your Jellyfin server doesn't have a subtitle provider configured."}
           </Text>
           <TVSettingsTextInput
+            disabledByAdmin={pluginSettings?.openSubtitlesApiKey?.locked}
             label={
               t("home.settings.subtitles.opensubtitles_api_key") || "API Key"
             }
@@ -926,6 +992,7 @@ export default function SettingsTV() {
           {/* Buffer Settings Section */}
           <TVSectionHeader title={t("home.settings.buffer.title")} />
           <TVSettingsOptionButton
+            disabledByAdmin={pluginSettings?.mpvCacheEnabled?.locked}
             label={t("home.settings.buffer.cache_mode")}
             value={cacheModeLabel}
             onPress={() =>
@@ -942,6 +1009,7 @@ export default function SettingsTV() {
             <>
               <TVSectionHeader title={t("home.settings.vo_driver.title")} />
               <TVSettingsOptionButton
+                disabledByAdmin={pluginSettings?.mpvVoDriver?.locked}
                 label={t("home.settings.vo_driver.vo_mode")}
                 value={voDriverLabel}
                 onPress={() =>
@@ -956,6 +1024,7 @@ export default function SettingsTV() {
           )}
 
           <TVSettingsStepper
+            disabledByAdmin={pluginSettings?.mpvCacheSeconds?.locked}
             label={t("home.settings.buffer.buffer_duration")}
             value={settings.mpvCacheSeconds ?? 10}
             onDecrease={() => {
@@ -975,6 +1044,7 @@ export default function SettingsTV() {
             formatValue={(v) => `${v}s`}
           />
           <TVSettingsStepper
+            disabledByAdmin={pluginSettings?.mpvDemuxerMaxBytes?.locked}
             label={t("home.settings.buffer.max_cache_size")}
             value={settings.mpvDemuxerMaxBytes ?? 150}
             onDecrease={() => {
@@ -994,6 +1064,7 @@ export default function SettingsTV() {
             formatValue={(v) => `${v} MB`}
           />
           <TVSettingsStepper
+            disabledByAdmin={pluginSettings?.mpvDemuxerMaxBackBytes?.locked}
             label={t("home.settings.buffer.max_backward_cache")}
             value={settings.mpvDemuxerMaxBackBytes ?? 50}
             onDecrease={() => {
@@ -1016,6 +1087,7 @@ export default function SettingsTV() {
           {/* Appearance Section */}
           <TVSectionHeader title={t("home.settings.appearance.title")} />
           <TVSettingsOptionButton
+            disabledByAdmin={pluginSettings?.tvTypographyScale?.locked}
             label={t("home.settings.appearance.display_size")}
             value={typographyScaleLabel}
             onPress={() =>
@@ -1028,6 +1100,7 @@ export default function SettingsTV() {
             }
           />
           <TVSettingsOptionButton
+            disabledByAdmin={pluginSettings?.preferedLanguage?.locked}
             label={t("home.settings.languages.app_language")}
             value={languageLabel}
             onPress={() =>
@@ -1040,6 +1113,9 @@ export default function SettingsTV() {
             }
           />
           <TVSettingsToggle
+            disabledByAdmin={
+              pluginSettings?.mergeNextUpAndContinueWatching?.locked
+            }
             label={t(
               "home.settings.appearance.merge_next_up_continue_watching",
             )}
@@ -1049,6 +1125,7 @@ export default function SettingsTV() {
             }
           />
           <TVSettingsToggle
+            disabledByAdmin={pluginSettings?.useEpisodeImagesForNextUp?.locked}
             label={t("home.settings.appearance.use_episode_images_next_up")}
             value={settings.useEpisodeImagesForNextUp}
             onToggle={(value) =>
@@ -1056,16 +1133,19 @@ export default function SettingsTV() {
             }
           />
           <TVSettingsToggle
+            disabledByAdmin={pluginSettings?.showHomeBackdrop?.locked}
             label={t("home.settings.appearance.show_home_backdrop")}
             value={settings.showHomeBackdrop}
             onToggle={(value) => updateSettings({ showHomeBackdrop: value })}
           />
           <TVSettingsToggle
+            disabledByAdmin={pluginSettings?.showTVHeroCarousel?.locked}
             label={t("home.settings.appearance.show_hero_carousel")}
             value={settings.showTVHeroCarousel}
             onToggle={(value) => updateSettings({ showTVHeroCarousel: value })}
           />
           <TVSettingsToggle
+            disabledByAdmin={pluginSettings?.showSeriesPosterOnEpisode?.locked}
             label={t("home.settings.appearance.show_series_poster_on_episode")}
             value={settings.showSeriesPosterOnEpisode}
             onToggle={(value) =>
@@ -1073,6 +1153,7 @@ export default function SettingsTV() {
             }
           />
           <TVSettingsToggle
+            disabledByAdmin={pluginSettings?.tvThemeMusicEnabled?.locked}
             label={t("home.settings.appearance.theme_music")}
             value={settings.tvThemeMusicEnabled}
             onToggle={(value) => updateSettings({ tvThemeMusicEnabled: value })}

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -73,6 +73,10 @@ import {
   localSubtitleIndex,
   toServerSubtitleIndex,
 } from "@/utils/subtitles/subtitleIndex";
+import {
+  applySubtitleStyle,
+  buildSubtitleStyle,
+} from "@/utils/subtitles/subtitleStyle";
 import { msToTicks, ticksToSeconds } from "@/utils/time";
 import { generateDeviceProfile } from "../../../utils/profiles/native";
 
@@ -1451,47 +1455,7 @@ export default function DirectPlayerPage() {
   // Apply subtitle settings when video loads
   useEffect(() => {
     if (!isVideoLoaded || !videoRef.current) return;
-
-    const applySubtitleSettings = async () => {
-      if (settings.mpvSubtitleScale !== undefined) {
-        await videoRef.current?.setSubtitleScale?.(settings.mpvSubtitleScale);
-      }
-      if (settings.mpvSubtitleMarginY !== undefined) {
-        await videoRef.current?.setSubtitleMarginY?.(
-          settings.mpvSubtitleMarginY,
-        );
-      }
-      if (settings.mpvSubtitleAlignX !== undefined) {
-        await videoRef.current?.setSubtitleAlignX?.(settings.mpvSubtitleAlignX);
-      }
-      if (settings.mpvSubtitleAlignY !== undefined) {
-        await videoRef.current?.setSubtitleAlignY?.(settings.mpvSubtitleAlignY);
-      }
-      // Apply subtitle background (iOS only - doesn't work on tvOS due to composite OSD limitation)
-      // mpv uses #RRGGBBAA format (alpha last, same as CSS)
-      if (settings.mpvSubtitleBackgroundEnabled) {
-        const opacity = settings.mpvSubtitleBackgroundOpacity ?? 75;
-        const alphaHex = Math.round((opacity / 100) * 255)
-          .toString(16)
-          .padStart(2, "0")
-          .toUpperCase();
-        // Enable background-box mode (required for sub-back-color to work)
-        await videoRef.current?.setSubtitleBorderStyle?.("background-box");
-        await videoRef.current?.setSubtitleBackgroundColor?.(
-          `#000000${alphaHex}`,
-        );
-        // Force override ASS subtitle styles so background shows on styled subtitles
-        await videoRef.current?.setSubtitleAssOverride?.("force");
-      } else {
-        // Restore default outline-and-shadow style
-        await videoRef.current?.setSubtitleBorderStyle?.("outline-and-shadow");
-        await videoRef.current?.setSubtitleBackgroundColor?.("#00000000");
-        // Restore default ASS behavior (keep original styles)
-        await videoRef.current?.setSubtitleAssOverride?.("no");
-      }
-    };
-
-    applySubtitleSettings();
+    applySubtitleStyle(videoRef.current, buildSubtitleStyle(settings));
   }, [isVideoLoaded, settings]);
 
   // Apply initial playback speed when video loads

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -27,10 +27,6 @@ import { Controls as TVControls } from "@/components/video-player/controls/Contr
 import { PlayerProvider } from "@/components/video-player/controls/contexts/PlayerContext";
 import { VideoProvider } from "@/components/video-player/controls/contexts/VideoContext";
 import {
-  LOCAL_SUBTITLE_INDEX_START,
-  toServerSubtitleIndex,
-} from "@/components/video-player/controls/types";
-import {
   PlaybackSpeedScope,
   updatePlaybackSpeedSettings,
 } from "@/components/video-player/controls/utils/playback-speed-settings";
@@ -72,6 +68,11 @@ import {
   isImageBasedSubtitle,
 } from "@/utils/jellyfin/subtitleUtils";
 import { writeToLog } from "@/utils/log";
+import {
+  isLocalSubtitleIndex,
+  localSubtitleIndex,
+  toServerSubtitleIndex,
+} from "@/utils/subtitles/subtitleIndex";
 import { msToTicks, ticksToSeconds } from "@/utils/time";
 import { generateDeviceProfile } from "../../../utils/profiles/native";
 
@@ -1216,7 +1217,7 @@ export default function DirectPlayerPage() {
     async (index: number) => {
       // Local (client-downloaded) subs are loaded via addSubtitleFile, not
       // resolvable against server streams — just track the live index.
-      if (index <= LOCAL_SUBTITLE_INDEX_START) {
+      if (isLocalSubtitleIndex(index)) {
         setCurrentSubtitleIndex(index);
         return;
       }
@@ -1359,18 +1360,15 @@ export default function DirectPlayerPage() {
   // TV: Add subtitle file to player (for client-side downloaded subtitles)
   const addSubtitleFile = useCallback(
     async (path: string) => {
-      // Set the live index to the new local sub's REAL index BEFORE the add.
-      // Local subs are keyed LOCAL_SUBTITLE_INDEX_START - position, so use the
-      // downloaded path's position (not a blanket sentinel, which would collide
-      // with the first local sub at -100 and mis-record the selection). Any
-      // local index resolves to notFound on the onTracksReady re-apply, so it
-      // still doesn't clobber the freshly selected track; carry-over now keeps
-      // the correct local sub.
+      // Set the live index to the new local sub's REAL index BEFORE the add:
+      // encode the downloaded path's position, not a blanket sentinel, which
+      // would collide with the first local sub and mis-record the selection.
+      // Any local index resolves to notFound on the onTracksReady re-apply, so
+      // it still doesn't clobber the freshly selected track; carry-over now
+      // keeps the correct local sub.
       const locals = itemId ? getSubtitlesForItem(itemId) : [];
       const pos = locals.findIndex((s) => s.filePath === path);
-      setCurrentSubtitleIndex(
-        LOCAL_SUBTITLE_INDEX_START - (pos >= 0 ? pos : 0),
-      );
+      setCurrentSubtitleIndex(localSubtitleIndex(pos >= 0 ? pos : 0));
       await videoRef.current?.addSubtitleFile?.(path, true);
     },
     [itemId],

--- a/app/(auth)/tv-option-modal.tsx
+++ b/app/(auth)/tv-option-modal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Animated,
   Easing,
+  FlatList,
   InteractionManager,
   ScrollView,
   StyleSheet,
@@ -18,6 +19,15 @@ import { useTVBackPress } from "@/hooks/useTVBackPress";
 import { tvOptionModalAtom } from "@/utils/atoms/tvOptionModal";
 import { scaleSize } from "@/utils/scaleSize";
 import { store } from "@/utils/store";
+
+/**
+ * Above this many options the card strip virtualizes; below it, it doesn't.
+ *
+ * Set well clear of the app-language list (28 entries) so only the Jellyfin
+ * culture lists (~200) take the windowed path — adding a translation should not
+ * silently change how an unrelated sheet mounts.
+ */
+const VIRTUALIZE_ABOVE = 60;
 
 export default function TVOptionModal() {
   const router = useRouter();
@@ -114,6 +124,13 @@ export default function TVOptionModal() {
   const { title, options } = modalState;
   const scaledCardWidth = scaleSize(160);
   const scaledCardHeight = scaleSize(75);
+  const cardGap = scaleSize(12);
+  // Every sheet is the same card strip. Past a few dozen options the plain
+  // ScrollView becomes the problem — it mounts a Pressable and a focus
+  // animation per option, and the language pickers carry the whole Jellyfin
+  // culture list — so those render through a virtualized list instead. Same
+  // cards, same layout; only the mounting strategy differs.
+  const shouldVirtualize = options.length > VIRTUALIZE_ABOVE;
 
   return (
     <Animated.View style={[styles.overlay, { opacity: overlayOpacity }]}>
@@ -135,30 +152,72 @@ export default function TVOptionModal() {
             <Text style={[styles.title, { fontSize: typography.callout }]}>
               {title}
             </Text>
-            {isReady && (
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                style={styles.scrollView}
-                contentContainerStyle={styles.scrollContent}
-              >
-                {options.map((option, index) => (
-                  <TVOptionCard
-                    key={index}
-                    ref={
-                      index === initialSelectedIndex ? firstCardRef : undefined
-                    }
-                    label={option.label}
-                    sublabel={option.sublabel}
-                    selected={option.selected}
-                    hasTVPreferredFocus={index === initialSelectedIndex}
-                    onPress={() => handleSelect(option.value)}
-                    width={scaledCardWidth}
-                    height={scaledCardHeight}
-                  />
-                ))}
-              </ScrollView>
-            )}
+            {isReady &&
+              (shouldVirtualize ? (
+                <FlatList
+                  horizontal
+                  data={options}
+                  style={styles.scrollView}
+                  contentContainerStyle={styles.scrollContent}
+                  keyExtractor={(_, index) => String(index)}
+                  showsHorizontalScrollIndicator={false}
+                  initialScrollIndex={initialSelectedIndex}
+                  // Fixed card metrics, so this is exact rather than estimated —
+                  // and initialScrollIndex needs it to open on the current pick.
+                  getItemLayout={(_, index) => ({
+                    length: scaledCardWidth + cardGap,
+                    offset: (scaledCardWidth + cardGap) * index,
+                    index,
+                  })}
+                  // Render a generous buffer either side of the viewport: TV
+                  // focus moves card by card, and focus landing on a card the
+                  // windowing has not mounted yet drops it to the overlay.
+                  initialNumToRender={24}
+                  windowSize={11}
+                  removeClippedSubviews={false}
+                  renderItem={({ item, index }) => (
+                    <TVOptionCard
+                      ref={
+                        index === initialSelectedIndex
+                          ? firstCardRef
+                          : undefined
+                      }
+                      label={item.label}
+                      sublabel={item.sublabel}
+                      selected={item.selected}
+                      hasTVPreferredFocus={index === initialSelectedIndex}
+                      onPress={() => handleSelect(item.value)}
+                      width={scaledCardWidth}
+                      height={scaledCardHeight}
+                    />
+                  )}
+                />
+              ) : (
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  style={styles.scrollView}
+                  contentContainerStyle={styles.scrollContent}
+                >
+                  {options.map((option, index) => (
+                    <TVOptionCard
+                      key={index}
+                      ref={
+                        index === initialSelectedIndex
+                          ? firstCardRef
+                          : undefined
+                      }
+                      label={option.label}
+                      sublabel={option.sublabel}
+                      selected={option.selected}
+                      hasTVPreferredFocus={index === initialSelectedIndex}
+                      onPress={() => handleSelect(option.value)}
+                      width={scaledCardWidth}
+                      height={scaledCardHeight}
+                    />
+                  ))}
+                </ScrollView>
+              ))}
           </TVFocusGuideView>
         </BlurView>
       </Animated.View>

--- a/components/DownloadItem.tsx
+++ b/components/DownloadItem.tsx
@@ -95,16 +95,12 @@ export const DownloadItems: React.FC<DownloadProps> = ({
     SelectedOptions | undefined
   >(undefined);
 
-  const playSettingsOptions = useMemo(
-    () => ({ applyLanguagePreferences: true }),
-    [],
-  );
   const {
     defaultAudioIndex,
     defaultBitrate,
     defaultMediaSource,
     defaultSubtitleIndex,
-  } = useDefaultPlaySettings(items[0], settings, playSettingsOptions);
+  } = useDefaultPlaySettings(items[0], settings);
 
   const userCanDownload = useMemo(
     () => user?.Policy?.EnableContentDownloading,

--- a/components/ItemContent.tsx
+++ b/components/ItemContent.tsx
@@ -76,20 +76,12 @@ const ItemContentMobile: React.FC<ItemContentProps> = ({
   >(undefined);
 
   // Use itemWithSources for play settings since it has MediaSources data
-  const playSettingsOptions = useMemo(
-    () => ({ applyLanguagePreferences: true }),
-    [],
-  );
   const {
     defaultAudioIndex,
     defaultBitrate,
     defaultMediaSource,
     defaultSubtitleIndex,
-  } = useDefaultPlaySettings(
-    itemWithSources ?? item,
-    settings,
-    playSettingsOptions,
-  );
+  } = useDefaultPlaySettings(itemWithSources ?? item, settings);
 
   const logoUrl = useMemo(
     () => (item ? getLogoImageUrlById({ api, item }) : null),

--- a/components/ItemContent.tsx
+++ b/components/ItemContent.tsx
@@ -25,6 +25,7 @@ import useDefaultPlaySettings from "@/hooks/useDefaultPlaySettings";
 import { useImageColorsReturn } from "@/hooks/useImageColorsReturn";
 import { useOrientation } from "@/hooks/useOrientation";
 import * as ScreenOrientation from "@/packages/expo-screen-orientation";
+import { useDownload } from "@/providers/DownloadProvider";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { useOfflineMode } from "@/providers/OfflineModeProvider";
 import { useSettings } from "@/utils/atoms/settings";
@@ -60,6 +61,14 @@ const ItemContentMobile: React.FC<ItemContentProps> = ({
 }) => {
   const [api] = useAtom(apiAtom);
   const isOffline = useOfflineMode();
+  const { getDownloadedItemById } = useDownload();
+  // A download pins the tracks it was pulled with, and only the record knows
+  // them: resolving against the server media source hands back an index for a
+  // stream the local file may not contain.
+  const downloadedTracks =
+    isOffline && item?.Id
+      ? getDownloadedItemById(item.Id)?.userData
+      : undefined;
   const { settings } = useSettings();
   const { orientation } = useOrientation();
   const navigation = useNavigation();
@@ -101,14 +110,16 @@ const ItemContentMobile: React.FC<ItemContentProps> = ({
     setSelectedOptions(() => ({
       bitrate: defaultBitrate,
       mediaSource: defaultMediaSource ?? undefined,
-      subtitleIndex: defaultSubtitleIndex ?? -1,
-      audioIndex: defaultAudioIndex,
+      subtitleIndex:
+        downloadedTracks?.subtitleStreamIndex ?? defaultSubtitleIndex ?? -1,
+      audioIndex: downloadedTracks?.audioStreamIndex ?? defaultAudioIndex,
     }));
   }, [
     defaultAudioIndex,
     defaultBitrate,
     defaultSubtitleIndex,
     defaultMediaSource,
+    downloadedTracks,
   ]);
 
   useEffect(() => {

--- a/components/ItemContent.tv.tsx
+++ b/components/ItemContent.tv.tsx
@@ -57,11 +57,13 @@ import { useSettings } from "@/utils/atoms/settings";
 import type { TVOptionItem } from "@/utils/atoms/tvOptionModal";
 import { getLogoImageUrlById } from "@/utils/jellyfin/image/getLogoImageUrlById";
 import { getPrimaryImageUrlById } from "@/utils/jellyfin/image/getPrimaryImageUrlById";
-import { compareTracksForMenu } from "@/utils/jellyfin/subtitleUtils";
+import { rememberSeriesTrackFromRow } from "@/utils/seriesTrackMemory";
+import { SUBTITLES_OFF } from "@/utils/subtitles/subtitleIndex";
 import {
-  isLocalSubtitleIndex,
-  localSubtitleIndex,
-} from "@/utils/subtitles/subtitleIndex";
+  buildAudioMenu,
+  buildSubtitleMenu,
+  type TrackMenuRow,
+} from "@/utils/subtitles/trackMenu";
 import { formatDuration, runtimeTicksToMinutes } from "@/utils/time";
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
@@ -228,74 +230,80 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
       null,
     );
 
-    // Get available audio tracks
-    const audioTracks = useMemo(() => {
-      const streams = selectedOptions?.mediaSource?.MediaStreams?.filter(
-        (s) => s.Type === "Audio",
-      );
-      return streams ?? [];
-    }, [selectedOptions?.mediaSource]);
-
-    // Get available subtitle tracks (raw MediaStream[] for label lookup),
-    // ordered like jellyfin-web (embedded first, externals last, forced/default up).
-    const subtitleStreams = useMemo(() => {
-      const streams = selectedOptions?.mediaSource?.MediaStreams?.filter(
-        (s) => s.Type === "Subtitle",
-      );
-      return streams ? [...streams].sort(compareTracksForMenu) : [];
-    }, [selectedOptions?.mediaSource]);
-
-    // Store handleSubtitleChange in a ref for stable callback reference
-    const handleSubtitleChangeRef = useRef<((index: number) => void) | null>(
-      null,
+    /** Existing label format on this screen; kept so the menus read the same. */
+    const tvTrackLabel = useCallback(
+      (s: MediaStream) =>
+        s.DisplayTitle || `${s.Language || "Unknown"} (${s.Codec})`,
+      [],
     );
+
+    // Selection carries the whole row, not just an index: the refreshed list
+    // below is built from a *freshly fetched* item, so an index looked up
+    // against the stale list would resolve to the wrong stream — or to none at
+    // all, which is why a just-downloaded subtitle used to remember nothing.
+    const handleSubtitleChangeRef = useRef<
+      ((row: TrackMenuRow) => void) | null
+    >(null);
 
     // State to trigger refresh of local subtitles list
     const [localSubtitlesRefreshKey, setLocalSubtitlesRefreshKey] = useState(0);
 
-    // Convert MediaStream[] to Track[] for the modal (with setTrack callbacks)
-    // Also includes locally downloaded subtitles from OpenSubtitles
-    const subtitleTracksForModal = useMemo((): Track[] => {
-      const tracks: Track[] = subtitleStreams.map((stream) => ({
-        name:
-          stream.DisplayTitle ||
-          `${stream.Language || "Unknown"} (${stream.Codec})`,
-        index: stream.Index ?? -1,
-        setTrack: () => {
-          handleSubtitleChangeRef.current?.(stream.Index ?? -1);
-        },
-      }));
-
-      // Add locally downloaded subtitles (from OpenSubtitles)
-      if (item?.Id) {
-        const localSubs = getSubtitlesForItem(item.Id);
-        let localIdx = 0;
-        for (const localSub of localSubs) {
-          // Verify file still exists (cache may have been cleared)
-          const subtitleFile = new File(localSub.filePath);
-          if (!subtitleFile.exists) {
-            continue;
-          }
-
-          const localIndex = localSubtitleIndex(localIdx);
-          tracks.push({
-            name: localSub.name,
-            index: localIndex,
-            isLocal: true,
-            localPath: localSub.filePath,
-            setTrack: () => {
-              // For ItemContent (outside player), just update the selected index
-              // The actual subtitle will be loaded when playback starts
-              handleSubtitleChangeRef.current?.(localIndex);
-            },
-          });
-          localIdx++;
-        }
-      }
-
-      return tracks;
+    /** Client-side downloads that still exist on disk (the cache may be cleared). */
+    const localSubFiles = useMemo(() => {
+      if (!item?.Id) return [];
+      return getSubtitlesForItem(item.Id)
+        .filter((s) => new File(s.filePath).exists)
+        .map((s) => ({ name: s.name, filePath: s.filePath }));
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [subtitleStreams, item?.Id, localSubtitlesRefreshKey]);
+    }, [item?.Id, localSubtitlesRefreshKey]);
+
+    const audioRows = useMemo(
+      () =>
+        buildAudioMenu(selectedOptions?.mediaSource?.MediaStreams, {
+          selectedIndex: selectedOptions?.audioIndex,
+          isTranscoding: Boolean(selectedOptions?.mediaSource?.TranscodingUrl),
+          formatLabel: tvTrackLabel,
+        }),
+      [selectedOptions?.mediaSource, selectedOptions?.audioIndex, tvTrackLabel],
+    );
+
+    const subtitleRows = useMemo(
+      () =>
+        buildSubtitleMenu(selectedOptions?.mediaSource?.MediaStreams, {
+          selectedIndex: selectedOptions?.subtitleIndex ?? SUBTITLES_OFF,
+          offLabel: t("item_card.subtitles.none"),
+          isTranscoding: Boolean(selectedOptions?.mediaSource?.TranscodingUrl),
+          localSubs: localSubFiles,
+          formatLabel: tvTrackLabel,
+        }),
+      [
+        selectedOptions?.mediaSource,
+        selectedOptions?.subtitleIndex,
+        localSubFiles,
+        tvTrackLabel,
+        t,
+      ],
+    );
+
+    /** The modal supplies its own "None", so the off row is dropped here. */
+    const rowsToTracks = useCallback(
+      (rows: TrackMenuRow[]): Track[] =>
+        rows
+          .filter((row) => row.kind !== "off")
+          .map((row) => ({
+            name: row.label,
+            index: row.index,
+            isLocal: row.kind === "sidecar",
+            localPath: row.localPath,
+            setTrack: () => handleSubtitleChangeRef.current?.(row),
+          })),
+      [],
+    );
+
+    const subtitleTracksForModal = useMemo(
+      () => rowsToTracks(subtitleRows),
+      [subtitleRows, rowsToTracks],
+    );
 
     // Get available media sources
     const mediaSources = useMemo(() => {
@@ -303,15 +311,15 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
     }, [item, itemWithSources]);
 
     // Audio options for selector
-    const audioOptions: TVOptionItem<number>[] = useMemo(() => {
-      return audioTracks.map((track) => ({
-        label:
-          track.DisplayTitle ||
-          `${track.Language || "Unknown"} (${track.Codec})`,
-        value: track.Index!,
-        selected: track.Index === selectedOptions?.audioIndex,
-      }));
-    }, [audioTracks, selectedOptions?.audioIndex]);
+    const audioOptions: TVOptionItem<TrackMenuRow>[] = useMemo(
+      () =>
+        audioRows.map((row) => ({
+          label: row.label,
+          value: row,
+          selected: row.selected,
+        })),
+      [audioRows],
+    );
 
     // Media source options for selector
     const mediaSourceOptions: TVOptionItem<MediaSourceInfo>[] = useMemo(() => {
@@ -338,18 +346,38 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
       }));
     }, [selectedOptions?.bitrate?.value]);
 
-    // Handlers for option changes
-    const handleAudioChange = useCallback((audioIndex: number) => {
-      setSelectedOptions((prev) =>
-        prev ? { ...prev, audioIndex } : undefined,
-      );
-    }, []);
+    // Handlers for option changes. A pick here is as deliberate as one made
+    // inside the player, so it feeds the per-series memory the same way —
+    // otherwise the next episode comes back on the server's default track.
+    const handleAudioChange = useCallback(
+      (row: TrackMenuRow) => {
+        setSelectedOptions((prev) =>
+          prev ? { ...prev, audioIndex: row.index } : undefined,
+        );
+        rememberSeriesTrackFromRow({
+          item: itemWithSources ?? item,
+          kind: "audio",
+          row,
+          settings,
+        });
+      },
+      [item, itemWithSources, settings],
+    );
 
-    const handleSubtitleChange = useCallback((subtitleIndex: number) => {
-      setSelectedOptions((prev) =>
-        prev ? { ...prev, subtitleIndex } : undefined,
-      );
-    }, []);
+    const handleSubtitleChange = useCallback(
+      (row: TrackMenuRow) => {
+        setSelectedOptions((prev) =>
+          prev ? { ...prev, subtitleIndex: row.index } : undefined,
+        );
+        rememberSeriesTrackFromRow({
+          item: itemWithSources ?? item,
+          kind: "subtitle",
+          row,
+          settings,
+        });
+      },
+      [item, itemWithSources, settings],
+    );
 
     // Keep the ref updated with the latest callback
     handleSubtitleChangeRef.current = handleSubtitleChange;
@@ -413,85 +441,47 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
             )
           : freshItem.MediaSources?.[0];
 
-        // Get subtitle streams from the fresh data, ordered like jellyfin-web
-        // (embedded first, externals last) — same as the initial list.
-        const streams = [
-          ...(mediaSource?.MediaStreams?.filter(
-            (s: MediaStream) => s.Type === "Subtitle",
-          ) ?? []),
-        ].sort(compareTracksForMenu);
-
-        // Convert to Track[] with setTrack callbacks
-        const tracks: Track[] = streams.map((stream) => ({
-          name:
-            stream.DisplayTitle ||
-            `${stream.Language || "Unknown"} (${stream.Codec})`,
-          index: stream.Index ?? -1,
-          setTrack: () => {
-            handleSubtitleChangeRef.current?.(stream.Index ?? -1);
-          },
-        }));
-
-        // Add locally downloaded subtitles
-        if (item?.Id) {
-          const localSubs = getSubtitlesForItem(item.Id);
-          let localIdx = 0;
-          for (const localSub of localSubs) {
-            const subtitleFile = new File(localSub.filePath);
-            if (!subtitleFile.exists) continue;
-
-            const localIndex = localSubtitleIndex(localIdx);
-            tracks.push({
-              name: localSub.name,
-              index: localIndex,
-              isLocal: true,
-              localPath: localSub.filePath,
-              setTrack: () => {
-                handleSubtitleChangeRef.current?.(localIndex);
-              },
-            });
-            localIdx++;
-          }
-        }
-
-        return tracks;
+        // Same builder as the initial list — a second hand-rolled copy is how
+        // the two drifted, and each row carries the language its own selection
+        // will remember, so a track that exists only in this fresh fetch is
+        // still stored correctly.
+        return rowsToTracks(
+          buildSubtitleMenu(mediaSource?.MediaStreams, {
+            selectedIndex: selectedOptions?.subtitleIndex ?? SUBTITLES_OFF,
+            offLabel: t("item_card.subtitles.none"),
+            isTranscoding: Boolean(mediaSource?.TranscodingUrl),
+            localSubs: localSubFiles,
+            formatLabel: tvTrackLabel,
+          }),
+        );
       } catch (error) {
         console.error("Failed to refresh subtitle tracks:", error);
         return [];
       }
-    }, [api, item?.Id, selectedOptions?.mediaSource?.Id]);
-
-    // Get display values for buttons
-    const selectedAudioLabel = useMemo(() => {
-      const track = audioTracks.find(
-        (t) => t.Index === selectedOptions?.audioIndex,
-      );
-      return track?.DisplayTitle || track?.Language || t("item_card.audio");
-    }, [audioTracks, selectedOptions?.audioIndex, t]);
-
-    const selectedSubtitleLabel = useMemo(() => {
-      if (selectedOptions?.subtitleIndex === -1)
-        return t("item_card.subtitles.none");
-
-      if (isLocalSubtitleIndex(selectedOptions?.subtitleIndex)) {
-        const localTrack = subtitleTracksForModal.find(
-          (t) => t.index === selectedOptions.subtitleIndex,
-        );
-        return localTrack?.name || t("item_card.subtitles.label");
-      }
-
-      const track = subtitleStreams.find(
-        (t) => t.Index === selectedOptions?.subtitleIndex,
-      );
-      return (
-        track?.DisplayTitle || track?.Language || t("item_card.subtitles.label")
-      );
     }, [
-      subtitleStreams,
-      subtitleTracksForModal,
+      api,
+      item?.Id,
+      selectedOptions?.mediaSource?.Id,
       selectedOptions?.subtitleIndex,
+      localSubFiles,
+      rowsToTracks,
+      tvTrackLabel,
       t,
     ]);
+
+    // Get display values for buttons
+    const selectedAudioLabel = useMemo(
+      () =>
+        audioRows.find((row) => row.selected)?.label ?? t("item_card.audio"),
+      [audioRows, t],
+    );
+
+    const selectedSubtitleLabel = useMemo(
+      () =>
+        subtitleRows.find((row) => row.selected)?.label ??
+        t("item_card.subtitles.label"),
+      [subtitleRows, t],
+    );
 
     const selectedMediaSourceLabel = useMemo(() => {
       const source = selectedOptions?.mediaSource;
@@ -796,7 +786,7 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                 )}
 
                 {/* Audio selector */}
-                {audioTracks.length > 0 && (
+                {audioRows.length > 0 && (
                   <TVOptionButton
                     label={t("item_card.audio")}
                     value={selectedAudioLabel}
@@ -812,7 +802,7 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                 )}
 
                 {/* Subtitle selector */}
-                {(subtitleStreams.length > 0 ||
+                {(subtitleRows.some((row) => row.kind === "server") ||
                   selectedOptions?.subtitleIndex !== undefined) && (
                   <TVOptionButton
                     label={t("item_card.subtitles.label")}
@@ -825,7 +815,14 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
                         subtitleTracks: subtitleTracksForModal,
                         currentSubtitleIndex:
                           selectedOptions?.subtitleIndex ?? -1,
-                        onDisableSubtitles: () => handleSubtitleChange(-1),
+                        // The modal owns its own "None" row, so hand the
+                        // builder's off row back rather than a bare -1.
+                        onDisableSubtitles: () => {
+                          const offRow = subtitleRows.find(
+                            (row) => row.kind === "off",
+                          );
+                          if (offRow) handleSubtitleChange(offRow);
+                        },
                         onServerSubtitleDownloaded:
                           handleServerSubtitleDownloaded,
                         onLocalSubtitleDownloaded:

--- a/components/ItemContent.tv.tsx
+++ b/components/ItemContent.tv.tsx
@@ -40,10 +40,7 @@ import {
   TVSeriesNavigation,
   TVTechnicalDetails,
 } from "@/components/tv";
-import {
-  LOCAL_SUBTITLE_INDEX_START,
-  type Track,
-} from "@/components/video-player/controls/types";
+import type { Track } from "@/components/video-player/controls/types";
 import { useScaledTVTypography } from "@/constants/TVTypography";
 import useRouter from "@/hooks/useAppRouter";
 import useDefaultPlaySettings from "@/hooks/useDefaultPlaySettings";
@@ -61,6 +58,10 @@ import type { TVOptionItem } from "@/utils/atoms/tvOptionModal";
 import { getLogoImageUrlById } from "@/utils/jellyfin/image/getLogoImageUrlById";
 import { getPrimaryImageUrlById } from "@/utils/jellyfin/image/getPrimaryImageUrlById";
 import { compareTracksForMenu } from "@/utils/jellyfin/subtitleUtils";
+import {
+  isLocalSubtitleIndex,
+  localSubtitleIndex,
+} from "@/utils/subtitles/subtitleIndex";
 import { formatDuration, runtimeTicksToMinutes } from "@/utils/time";
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
@@ -126,22 +127,12 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
       SelectedOptions | undefined
     >(undefined);
 
-    // Enable language preference application for TV
-    const playSettingsOptions = useMemo(
-      () => ({ applyLanguagePreferences: true }),
-      [],
-    );
-
     const {
       defaultAudioIndex,
       defaultBitrate,
       defaultMediaSource,
       defaultSubtitleIndex,
-    } = useDefaultPlaySettings(
-      itemWithSources ?? item,
-      settings,
-      playSettingsOptions,
-    );
+    } = useDefaultPlaySettings(itemWithSources ?? item, settings);
 
     const logoUrl = useMemo(
       () => (item ? getLogoImageUrlById({ api, item }) : null),
@@ -286,7 +277,7 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
             continue;
           }
 
-          const localIndex = LOCAL_SUBTITLE_INDEX_START - localIdx;
+          const localIndex = localSubtitleIndex(localIdx);
           tracks.push({
             name: localSub.name,
             index: localIndex,
@@ -449,7 +440,7 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
             const subtitleFile = new File(localSub.filePath);
             if (!subtitleFile.exists) continue;
 
-            const localIndex = LOCAL_SUBTITLE_INDEX_START - localIdx;
+            const localIndex = localSubtitleIndex(localIdx);
             tracks.push({
               name: localSub.name,
               index: localIndex,
@@ -482,11 +473,7 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
       if (selectedOptions?.subtitleIndex === -1)
         return t("item_card.subtitles.none");
 
-      // Check if it's a local subtitle (negative index starting at -100)
-      if (
-        selectedOptions?.subtitleIndex !== undefined &&
-        selectedOptions.subtitleIndex <= LOCAL_SUBTITLE_INDEX_START
-      ) {
+      if (isLocalSubtitleIndex(selectedOptions?.subtitleIndex)) {
         const localTrack = subtitleTracksForModal.find(
           (t) => t.index === selectedOptions.subtitleIndex,
         );

--- a/components/ItemContent.tv.tsx
+++ b/components/ItemContent.tv.tsx
@@ -50,6 +50,7 @@ import { useTVItemActionModal } from "@/hooks/useTVItemActionModal";
 import { useTVOptionModal } from "@/hooks/useTVOptionModal";
 import { useTVSubtitleModal } from "@/hooks/useTVSubtitleModal";
 import { useTVThemeMusic } from "@/hooks/useTVThemeMusic";
+import { useDownload } from "@/providers/DownloadProvider";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { useOfflineMode } from "@/providers/OfflineModeProvider";
 import { getSubtitlesForItem } from "@/utils/atoms/downloadedSubtitles";
@@ -88,6 +89,14 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
     const [api] = useAtom(apiAtom);
     const [user] = useAtom(userAtom);
     const isOffline = useOfflineMode();
+    const { getDownloadedItemById } = useDownload();
+    // A download pins the tracks it was pulled with, and only the record knows
+    // them: resolving against the server media source hands back an index for a
+    // stream the local file may not contain.
+    const downloadedTracks =
+      isOffline && item?.Id
+        ? getDownloadedItemById(item.Id)?.userData
+        : undefined;
     const { settings } = useSettings();
     const insets = useSafeAreaInsets();
     const router = useRouter();
@@ -146,14 +155,16 @@ export const ItemContentTV: React.FC<ItemContentTVProps> = React.memo(
       setSelectedOptions(() => ({
         bitrate: defaultBitrate,
         mediaSource: defaultMediaSource ?? undefined,
-        subtitleIndex: defaultSubtitleIndex ?? -1,
-        audioIndex: defaultAudioIndex,
+        subtitleIndex:
+          downloadedTracks?.subtitleStreamIndex ?? defaultSubtitleIndex ?? -1,
+        audioIndex: downloadedTracks?.audioStreamIndex ?? defaultAudioIndex,
       }));
     }, [
       defaultAudioIndex,
       defaultBitrate,
       defaultSubtitleIndex,
       defaultMediaSource,
+      downloadedTracks,
     ]);
 
     const playMedia = usePlayMedia();

--- a/components/MediaSourceButton.tsx
+++ b/components/MediaSourceButton.tsx
@@ -2,12 +2,16 @@ import { Ionicons } from "@expo/vector-icons";
 import type {
   BaseItemDto,
   MediaSourceInfo,
+  MediaStream,
 } from "@jellyfin/sdk/lib/generated-client";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ActivityIndicator, TouchableOpacity, View } from "react-native";
 import type { ThemeColors } from "@/hooks/useImageColorsReturn";
-import { compareTracksForMenu } from "@/utils/jellyfin/subtitleUtils";
+import { useSettings } from "@/utils/atoms/settings";
+import { rememberSeriesTrackFromRow } from "@/utils/seriesTrackMemory";
+import { SUBTITLES_OFF } from "@/utils/subtitles/subtitleIndex";
+import { buildAudioMenu, buildSubtitleMenu } from "@/utils/subtitles/trackMenu";
 import { BITRATES } from "./BitrateSelector";
 import type { SelectedOptions } from "./ItemContent";
 import { type OptionGroup, PlatformDropdown } from "./PlatformDropdown";
@@ -28,6 +32,7 @@ export const MediaSourceButton: React.FC<Props> = ({
   colors,
 }: Props) => {
   const { t } = useTranslation();
+  const { settings } = useSettings();
   const [open, setOpen] = useState(false);
 
   const effectiveColors = colors || {
@@ -54,23 +59,30 @@ export const MediaSourceButton: React.FC<Props> = ({
     return `Source ${source.Id}`;
   }, []);
 
-  const audioStreams = useMemo(
-    () =>
-      selectedOptions.mediaSource?.MediaStreams?.filter(
-        (x) => x.Type === "Audio",
-      ) || [],
-    [selectedOptions.mediaSource],
+  const trackLabel = useCallback(
+    (s: MediaStream) => s.DisplayTitle || `${t("common.track")} ${s.Index}`,
+    [t],
   );
 
-  const subtitleStreams = useMemo(
+  const audioRows = useMemo(
     () =>
-      // Order like jellyfin-web (embedded first, externals last, forced/default up).
-      [
-        ...(selectedOptions.mediaSource?.MediaStreams?.filter(
-          (x) => x.Type === "Subtitle",
-        ) || []),
-      ].sort(compareTracksForMenu),
-    [selectedOptions.mediaSource],
+      buildAudioMenu(selectedOptions.mediaSource?.MediaStreams, {
+        selectedIndex: selectedOptions.audioIndex,
+        isTranscoding: Boolean(selectedOptions.mediaSource?.TranscodingUrl),
+        formatLabel: trackLabel,
+      }),
+    [selectedOptions.mediaSource, selectedOptions.audioIndex, trackLabel],
+  );
+
+  const subtitleRows = useMemo(
+    () =>
+      buildSubtitleMenu(selectedOptions.mediaSource?.MediaStreams, {
+        selectedIndex: selectedOptions.subtitleIndex ?? SUBTITLES_OFF,
+        offLabel: t("common.none"),
+        isTranscoding: Boolean(selectedOptions.mediaSource?.TranscodingUrl),
+        formatLabel: trackLabel,
+      }),
+    [selectedOptions.mediaSource, selectedOptions.subtitleIndex, trackLabel, t],
   );
 
   const optionGroups: OptionGroup[] = useMemo(() => {
@@ -106,43 +118,49 @@ export const MediaSourceButton: React.FC<Props> = ({
       });
     }
 
-    // Audio track group
-    if (audioStreams.length > 0) {
+    // A pick here is as deliberate as one made inside the player, so it feeds
+    // the per-series memory the same way — otherwise the next episode comes
+    // back on the server's default track.
+    if (audioRows.length > 0) {
       groups.push({
         title: t("item_card.audio"),
-        options: audioStreams.map((stream) => ({
+        options: audioRows.map((row) => ({
           type: "radio" as const,
-          label: stream.DisplayTitle || `${t("common.track")} ${stream.Index}`,
-          value: stream.Index,
-          selected: stream.Index === selectedOptions.audioIndex,
-          onPress: () =>
+          label: row.label,
+          value: row.index,
+          selected: row.selected,
+          onPress: () => {
             setSelectedOptions(
-              (prev) => prev && { ...prev, audioIndex: stream.Index ?? 0 },
-            ),
+              (prev) => prev && { ...prev, audioIndex: row.index },
+            );
+            rememberSeriesTrackFromRow({
+              item,
+              kind: "audio",
+              row,
+              settings,
+            });
+          },
         })),
       });
     }
 
-    // Subtitle track group (with None option)
-    if (subtitleStreams.length > 0) {
-      const noneOption = {
+    if (subtitleRows.some((r) => r.kind === "server")) {
+      const [noneOption, ...subtitleOptions] = subtitleRows.map((row) => ({
         type: "radio" as const,
-        label: t("common.none"),
-        value: -1,
-        selected: selectedOptions.subtitleIndex === -1,
-        onPress: () =>
-          setSelectedOptions((prev) => prev && { ...prev, subtitleIndex: -1 }),
-      };
-
-      const subtitleOptions = subtitleStreams.map((stream) => ({
-        type: "radio" as const,
-        label: stream.DisplayTitle || `${t("common.track")} ${stream.Index}`,
-        value: stream.Index,
-        selected: stream.Index === selectedOptions.subtitleIndex,
-        onPress: () =>
+        label: row.label,
+        value: row.index,
+        selected: row.selected,
+        onPress: () => {
           setSelectedOptions(
-            (prev) => prev && { ...prev, subtitleIndex: stream.Index ?? -1 },
-          ),
+            (prev) => prev && { ...prev, subtitleIndex: row.index },
+          );
+          rememberSeriesTrackFromRow({
+            item,
+            kind: "subtitle",
+            row,
+            settings,
+          });
+        },
       }));
 
       groups.push({
@@ -155,11 +173,12 @@ export const MediaSourceButton: React.FC<Props> = ({
   }, [
     item,
     selectedOptions,
-    audioStreams,
-    subtitleStreams,
+    audioRows,
+    subtitleRows,
     getMediaSourceDisplayName,
     t,
     setSelectedOptions,
+    settings,
   ]);
 
   const trigger = (

--- a/components/SubtitleTrackSelector.tsx
+++ b/components/SubtitleTrackSelector.tsx
@@ -2,7 +2,8 @@ import type { MediaSourceInfo } from "@jellyfin/sdk/lib/generated-client/models"
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Platform, TouchableOpacity, View } from "react-native";
-import { compareTracksForMenu } from "@/utils/jellyfin/subtitleUtils";
+import { SUBTITLES_OFF } from "@/utils/subtitles/subtitleIndex";
+import { buildSubtitleMenu } from "@/utils/subtitles/trackMenu";
 import { tc } from "@/utils/textTools";
 import { Text } from "./common/Text";
 import { type OptionGroup, PlatformDropdown } from "./PlatformDropdown";
@@ -22,57 +23,42 @@ export const SubtitleTrackSelector: React.FC<Props> = ({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
-  const subtitleStreams = useMemo(() => {
-    const subs = source?.MediaStreams?.filter((x) => x.Type === "Subtitle");
-    // Order like jellyfin-web (embedded first, externals last, forced/default up).
-    return subs ? [...subs].sort(compareTracksForMenu) : subs;
-  }, [source]);
-
-  const selectedSubtitleSteam = useMemo(
-    () => subtitleStreams?.find((x) => x.Index === selected),
-    [subtitleStreams, selected],
+  const rows = useMemo(
+    () =>
+      buildSubtitleMenu(source?.MediaStreams, {
+        selectedIndex: selected ?? SUBTITLES_OFF,
+        offLabel: t("item_card.none"),
+        isTranscoding: Boolean(source?.TranscodingUrl),
+        formatLabel: (s) => s.DisplayTitle || `Subtitle Stream ${s.Index}`,
+      }),
+    [source, selected, t],
   );
 
-  const optionGroups: OptionGroup[] = useMemo(() => {
-    const options = [
-      {
-        type: "radio" as const,
-        label: t("item_card.none"),
-        value: -1,
-        selected: selected === -1,
-        onPress: () => onChange(-1),
-      },
-      ...(subtitleStreams?.map((subtitle, idx) => ({
-        type: "radio" as const,
-        label: subtitle.DisplayTitle || `Subtitle Stream ${idx + 1}`,
-        value: subtitle.Index,
-        selected: subtitle.Index === selected,
-        onPress: () => onChange(subtitle.Index ?? -1),
-      })) || []),
-    ];
+  const selectedRow = useMemo(
+    () => rows.find((r) => r.kind === "server" && r.selected),
+    [rows],
+  );
 
-    return [
+  const optionGroups: OptionGroup[] = useMemo(
+    () => [
       {
-        options,
+        options: rows.map((row) => ({
+          type: "radio" as const,
+          label: row.label,
+          value: row.index,
+          selected: row.selected,
+          onPress: () => onChange(row.index),
+        })),
       },
-    ];
-  }, [subtitleStreams, selected, t, onChange]);
+    ],
+    [rows, onChange],
+  );
 
+  // Row indexes are the identity, so the id round-trips without the old
+  // `Index || idx` fallback — which collapsed index 0 onto the array position.
   const handleOptionSelect = (optionId: string) => {
-    if (optionId === "none") {
-      onChange(-1);
-    } else {
-      const selectedStream = subtitleStreams?.find(
-        (subtitle, idx) => `${subtitle.Index || idx}` === optionId,
-      );
-      if (
-        selectedStream &&
-        selectedStream.Index !== undefined &&
-        selectedStream.Index !== null
-      ) {
-        onChange(selectedStream.Index);
-      }
-    }
+    const row = rows.find((r) => String(r.index) === optionId);
+    if (row) onChange(row.index);
     setOpen(false);
   };
 
@@ -86,15 +72,14 @@ export const SubtitleTrackSelector: React.FC<Props> = ({
         onPress={() => setOpen(true)}
       >
         <Text>
-          {selectedSubtitleSteam
-            ? tc(selectedSubtitleSteam?.DisplayTitle, 7)
-            : t("item_card.none")}
+          {selectedRow ? tc(selectedRow.label, 7) : t("item_card.none")}
         </Text>
       </TouchableOpacity>
     </View>
   );
 
-  if (Platform.isTV || subtitleStreams?.length === 0) return null;
+  // "Off" is always present, so emptiness is about the server tracks.
+  if (Platform.isTV || !rows.some((r) => r.kind === "server")) return null;
 
   return (
     <PlatformDropdown

--- a/components/settings/MediaContext.tsx
+++ b/components/settings/MediaContext.tsx
@@ -1,24 +1,12 @@
 import type {
   CultureDto,
-  PublicSystemInfo,
-  UserConfiguration,
   UserDto,
 } from "@jellyfin/sdk/lib/generated-client/models";
-import {
-  getLocalizationApi,
-  getSystemApi,
-  getUserApi,
-} from "@jellyfin/sdk/lib/utils/api";
-import { useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
-import { createContext, type ReactNode, useContext, useEffect } from "react";
-import { useNetworkAwareQueryClient } from "@/hooks/useNetworkAwareQueryClient";
+import { createContext, type ReactNode, useContext } from "react";
+import { useMediaPreferences } from "@/hooks/useMediaPreferences";
 import { apiAtom } from "@/providers/JellyfinProvider";
-import { type Settings, useSettings } from "@/utils/atoms/settings";
-import {
-  ORIGINAL_LANGUAGE,
-  supportsOriginalAudioLanguage,
-} from "@/utils/jellyfin/serverVersion";
+import type { Settings } from "@/utils/atoms/settings";
 
 interface MediaContextType {
   settings: Settings | null;
@@ -28,37 +16,6 @@ interface MediaContextType {
   supportsOriginalAudioLanguage: boolean;
   isReady: boolean;
 }
-
-/**
- * Translate a settings update into the matching `UserConfiguration` fields.
- *
- * Only the keys actually present in the update are carried: everything else is
- * left to the server copy the caller merges on top of. Rebuilding the whole
- * configuration from local state would let an unrelated write clear a
- * preference the app never had a value for.
- */
-const toUserConfiguration = (update: Partial<Settings>) => {
-  const configuration: Partial<UserConfiguration> = {};
-  if ("subtitleMode" in update)
-    configuration.SubtitleMode = update.subtitleMode;
-  if ("playDefaultAudioTrack" in update)
-    configuration.PlayDefaultAudioTrack = update.playDefaultAudioTrack;
-  if ("rememberAudioSelections" in update)
-    configuration.RememberAudioSelections = update.rememberAudioSelections;
-  if ("rememberSubtitleSelections" in update)
-    configuration.RememberSubtitleSelections =
-      update.rememberSubtitleSelections;
-  if ("defaultAudioLanguage" in update)
-    configuration.AudioLanguagePreference =
-      update.defaultAudioLanguage?.ThreeLetterISOLanguageName ?? "";
-  if ("defaultSubtitleLanguage" in update)
-    configuration.SubtitleLanguagePreference =
-      update.defaultSubtitleLanguage?.ThreeLetterISOLanguageName ?? "";
-  return configuration;
-};
-
-// Stable reference so a pending cultures query does not churn effect deps.
-const EMPTY_CULTURES: CultureDto[] = [];
 
 const MediaContext = createContext<MediaContextType | undefined>(undefined);
 
@@ -70,182 +27,21 @@ export const useMedia = () => {
   return context;
 };
 
+/**
+ * Context wrapper over {@link useMediaPreferences} for the mobile settings
+ * screens. The sync itself lives in the hook so the TV settings screen — which
+ * has no provider — shares one implementation instead of a second copy.
+ */
 export const MediaProvider = ({ children }: { children: ReactNode }) => {
-  const { settings, updateSettings, pluginSettings } = useSettings();
   const api = useAtomValue(apiAtom);
-  const queryClient = useNetworkAwareQueryClient();
-
-  const { data: user } = useQuery({
-    queryKey: ["authUser"],
-    queryFn: async () => {
-      if (!api) return;
-      const userApi = await getUserApi(api).getCurrentUser();
-      return userApi.data;
-    },
-    enabled: !!api,
-    staleTime: 0,
-  });
-
-  // Kept aligned with the other consumers of this key (useJellyfinServerId,
-  // the Streamystats components): same shape, same nullable contract.
-  const { data: serverInfo, isSuccess: isServerInfoAvailable } = useQuery({
-    queryKey: ["jellyfin", "serverInfo"],
-    queryFn: async (): Promise<PublicSystemInfo | null> => {
-      if (!api) return null;
-      return (await getSystemApi(api).getPublicSystemInfo()).data;
-    },
-    enabled: !!api,
-    staleTime: 43200000, // 12 hours
-  });
-  const supportsOriginalLanguage =
-    isServerInfoAvailable && supportsOriginalAudioLanguage(serverInfo?.Version);
-
-  const { data: cultures = EMPTY_CULTURES, isSuccess: areCulturesAvailable } =
-    useQuery({
-      queryKey: ["cultures"],
-      queryFn: async () => {
-        if (!api) return EMPTY_CULTURES;
-        const localizationApi = await getLocalizationApi(api).getCultures();
-        const cultures = localizationApi.data;
-        return cultures;
-      },
-      enabled: !!api,
-      staleTime: 43200000, // 12 hours
-    });
-
-  // Keyed on the queries having answered, not on the payload being non-empty:
-  // a server legitimately returning no culture would otherwise pin the audio
-  // settings in their loading state forever.
-  const isReady = !!user && isServerInfoAvailable && areCulturesAvailable;
-
-  /**
-   * Apply a partial configuration on top of the server's own copy, so
-   * preferences this client did not touch are never overwritten.
-   */
-  const updateUserConfiguration = async (
-    configuration: Partial<UserConfiguration>,
-    { invalidateItems = false }: { invalidateItems?: boolean } = {},
-  ) => {
-    if (!api || !user) return;
-    try {
-      await getUserApi(api).updateUserConfiguration({
-        userConfiguration: {
-          ...user.Configuration,
-          ...configuration,
-        },
-      });
-      queryClient.invalidateQueries({ queryKey: ["authUser"] });
-      if (invalidateItems) {
-        // Audio/subtitle preferences feed the server-computed
-        // DefaultAudio/SubtitleStreamIndex carried by each item's MediaSources.
-        queryClient.invalidateQueries({ queryKey: ["item"] });
-      }
-    } catch (_error) {}
-  };
-
-  const updateSettingsWrapper = (update: Partial<Settings>) => {
-    // Admin-locked audio keys must reach neither local storage nor the server.
-    if (
-      ("defaultAudioLanguage" in update &&
-        (pluginSettings?.defaultAudioLanguage?.locked ||
-          pluginSettings?.playDefaultAudioTrack?.locked)) ||
-      ("playDefaultAudioTrack" in update &&
-        pluginSettings?.playDefaultAudioTrack?.locked)
-    ) {
-      return;
-    }
-
-    // The audio-language write depends on the cultures list and on the server
-    // version gate, so it waits for them. Every other setting, including the
-    // client-only subtitle appearance ones, stays writable meanwhile.
-    if ("defaultAudioLanguage" in update && !isReady) return;
-
-    let nextUpdate = update;
-    if ("defaultAudioLanguage" in update) {
-      const picksOriginal =
-        update.defaultAudioLanguage?.ThreeLetterISOLanguageName ===
-        ORIGINAL_LANGUAGE;
-      const clearsPreference = update.defaultAudioLanguage === null;
-      const leavesOriginal =
-        !picksOriginal &&
-        supportsOriginalLanguage &&
-        settings?.defaultAudioLanguage?.ThreeLetterISOLanguageName ===
-          ORIGINAL_LANGUAGE;
-
-      // Jellyfin short-circuits to the default-flagged stream when
-      // PlayDefaultAudioTrack is set, which defeats the original-language pick
-      // (MediaStreamSelector.GetDefaultAudioStreamIndex).
-      if (picksOriginal) {
-        nextUpdate = { ...update, playDefaultAudioTrack: false };
-      } else if (leavesOriginal && clearsPreference) {
-        // Restore the Jellyfin default only when the preference is cleared for
-        // good. Switching straight to a real language keeps the flag off, since
-        // turning it back on would send the server back to the default-flagged
-        // stream and ignore the language that was just picked.
-        nextUpdate = { ...update, playDefaultAudioTrack: true };
-      }
-    }
-
-    updateSettings(nextUpdate);
-
-    const configuration = toUserConfiguration(nextUpdate);
-    if (Object.keys(configuration).length === 0) return;
-
-    updateUserConfiguration(configuration, { invalidateItems: true });
-  };
-
-  // Seed the local settings from the server-side user configuration.
-  useEffect(() => {
-    if (!isReady || !user) return;
-    const userSubtitlePreference =
-      user.Configuration?.SubtitleLanguagePreference;
-    const userAudioPreference = user.Configuration?.AudioLanguagePreference;
-
-    const subtitlePreference = cultures.find(
-      (x) => x.ThreeLetterISOLanguageName === userSubtitlePreference,
-    );
-    const audioPreference =
-      userAudioPreference === ORIGINAL_LANGUAGE && supportsOriginalLanguage
-        ? { ThreeLetterISOLanguageName: ORIGINAL_LANGUAGE }
-        : cultures.find(
-            (x) => x.ThreeLetterISOLanguageName === userAudioPreference,
-          );
-
-    // A server carrying both the original-language preference and
-    // PlayDefaultAudioTrack keeps falling back to the default-flagged stream.
-    // Correct it server-side, but never at the cost of the other preferences:
-    // the write below only carries that single field.
-    const correctsPlayDefaultAudioTrack =
-      supportsOriginalLanguage &&
-      userAudioPreference === ORIGINAL_LANGUAGE &&
-      user.Configuration?.PlayDefaultAudioTrack === true &&
-      !pluginSettings?.playDefaultAudioTrack?.locked;
-
-    updateSettings({
-      defaultSubtitleLanguage: subtitlePreference,
-      defaultAudioLanguage: audioPreference,
-      subtitleMode: user.Configuration?.SubtitleMode,
-      playDefaultAudioTrack: correctsPlayDefaultAudioTrack
-        ? false
-        : user.Configuration?.PlayDefaultAudioTrack,
-      rememberAudioSelections: user.Configuration?.RememberAudioSelections,
-      rememberSubtitleSelections:
-        user.Configuration?.RememberSubtitleSelections,
-    });
-
-    if (correctsPlayDefaultAudioTrack) {
-      updateUserConfiguration(
-        { PlayDefaultAudioTrack: false },
-        { invalidateItems: true },
-      );
-    }
-  }, [
+  const {
+    settings,
+    updateMediaSettings,
     user,
-    isReady,
     cultures,
-    supportsOriginalLanguage,
-    pluginSettings?.playDefaultAudioTrack?.locked,
-  ]);
+    supportsOriginalAudioLanguage,
+    isReady,
+  } = useMediaPreferences();
 
   if (!api) return null;
 
@@ -253,10 +49,10 @@ export const MediaProvider = ({ children }: { children: ReactNode }) => {
     <MediaContext.Provider
       value={{
         settings,
-        updateSettings: updateSettingsWrapper,
+        updateSettings: updateMediaSettings,
         user,
         cultures,
-        supportsOriginalAudioLanguage: supportsOriginalLanguage,
+        supportsOriginalAudioLanguage,
         isReady,
       }}
     >

--- a/components/tv/settings/TVSettingsOptionButton.tsx
+++ b/components/tv/settings/TVSettingsOptionButton.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Animated, Pressable, View } from "react-native";
 import { Text } from "@/components/common/Text";
 import { useScaledTVTypography } from "@/constants/TVTypography";
@@ -12,6 +13,12 @@ export interface TVSettingsOptionButtonProps {
   onPress: () => void;
   isFirst?: boolean;
   disabled?: boolean;
+  /**
+   * Locked by the Streamyfin plugin. Distinct from `disabled` because the row
+   * has to say *why*: an admin-locked setting is dropped on write and overridden
+   * on read, so without a visible reason it just looks like a broken control.
+   */
+  disabledByAdmin?: boolean;
 }
 
 export const TVSettingsOptionButton: React.FC<TVSettingsOptionButtonProps> = ({
@@ -20,7 +27,10 @@ export const TVSettingsOptionButton: React.FC<TVSettingsOptionButtonProps> = ({
   onPress,
   isFirst,
   disabled,
+  disabledByAdmin,
 }) => {
+  const { t } = useTranslation();
+  const isDisabled = disabled || disabledByAdmin;
   const typography = useScaledTVTypography();
   const { focused, handleFocus, handleBlur, animatedStyle } =
     useTVFocusAnimation({ scaleAmount: 1.02 });
@@ -30,9 +40,9 @@ export const TVSettingsOptionButton: React.FC<TVSettingsOptionButtonProps> = ({
       onPress={onPress}
       onFocus={handleFocus}
       onBlur={handleBlur}
-      hasTVPreferredFocus={isFirst && !disabled}
-      disabled={disabled}
-      focusable={!disabled}
+      hasTVPreferredFocus={isFirst && !isDisabled}
+      disabled={isDisabled}
+      focusable={!isDisabled}
     >
       <Animated.View
         style={[
@@ -48,13 +58,26 @@ export const TVSettingsOptionButton: React.FC<TVSettingsOptionButtonProps> = ({
             flexDirection: "row",
             alignItems: "center",
             justifyContent: "space-between",
-            opacity: disabled ? 0.4 : 1,
+            opacity: isDisabled ? 0.4 : 1,
           },
         ]}
       >
-        <Text style={{ fontSize: typography.body, color: "#FFFFFF" }}>
-          {label}
-        </Text>
+        <View>
+          <Text style={{ fontSize: typography.body, color: "#FFFFFF" }}>
+            {label}
+          </Text>
+          {disabledByAdmin && (
+            <Text
+              style={{
+                fontSize: typography.callout,
+                color: "#EF4444",
+                marginTop: scaleSize(2),
+              }}
+            >
+              {t("home.settings.disabled_by_admin")}
+            </Text>
+          )}
+        </View>
         <View style={{ flexDirection: "row", alignItems: "center" }}>
           <Text
             style={{

--- a/components/tv/settings/TVSettingsStepper.tsx
+++ b/components/tv/settings/TVSettingsStepper.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Animated, Pressable, View } from "react-native";
 import { Text } from "@/components/common/Text";
 import { useScaledTVTypography } from "@/constants/TVTypography";
@@ -14,6 +15,8 @@ export interface TVSettingsStepperProps {
   formatValue?: (value: number) => string;
   isFirst?: boolean;
   disabled?: boolean;
+  /** Locked by the Streamyfin plugin; dims the row and says so. */
+  disabledByAdmin?: boolean;
 }
 
 export const TVSettingsStepper: React.FC<TVSettingsStepperProps> = ({
@@ -24,7 +27,10 @@ export const TVSettingsStepper: React.FC<TVSettingsStepperProps> = ({
   formatValue,
   isFirst,
   disabled,
+  disabledByAdmin,
 }) => {
+  const { t } = useTranslation();
+  const isDisabled = disabled || disabledByAdmin;
   const typography = useScaledTVTypography();
   const labelAnim = useTVFocusAnimation({ scaleAmount: 1.02 });
   const minusAnim = useTVFocusAnimation({ scaleAmount: 1.1 });
@@ -46,20 +52,32 @@ export const TVSettingsStepper: React.FC<TVSettingsStepperProps> = ({
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "space-between",
+        opacity: isDisabled ? 0.4 : 1,
       }}
     >
       <Pressable
         style={{ flex: 1 }}
         onFocus={labelAnim.handleFocus}
         onBlur={labelAnim.handleBlur}
-        hasTVPreferredFocus={isFirst && !disabled}
-        disabled={disabled}
-        focusable={!disabled}
+        hasTVPreferredFocus={isFirst && !isDisabled}
+        disabled={isDisabled}
+        focusable={!isDisabled}
       >
         <Animated.View style={labelAnim.animatedStyle}>
           <Text style={{ fontSize: typography.body, color: "#FFFFFF" }}>
             {label}
           </Text>
+          {disabledByAdmin && (
+            <Text
+              style={{
+                fontSize: typography.callout,
+                color: "#EF4444",
+                marginTop: scaleSize(2),
+              }}
+            >
+              {t("home.settings.disabled_by_admin")}
+            </Text>
+          )}
         </Animated.View>
       </Pressable>
       <View style={{ flexDirection: "row", alignItems: "center" }}>

--- a/components/tv/settings/TVSettingsTextInput.tsx
+++ b/components/tv/settings/TVSettingsTextInput.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { Animated, Pressable, TextInput } from "react-native";
 import { Text } from "@/components/common/Text";
 import { useScaledTVTypography } from "@/constants/TVTypography";
@@ -13,6 +14,8 @@ export interface TVSettingsTextInputProps {
   onBlur?: () => void;
   secureTextEntry?: boolean;
   disabled?: boolean;
+  /** Locked by the Streamyfin plugin; dims the row and says so. */
+  disabledByAdmin?: boolean;
 }
 
 export const TVSettingsTextInput: React.FC<TVSettingsTextInputProps> = ({
@@ -23,7 +26,10 @@ export const TVSettingsTextInput: React.FC<TVSettingsTextInputProps> = ({
   onBlur,
   secureTextEntry,
   disabled,
+  disabledByAdmin,
 }) => {
+  const { t } = useTranslation();
+  const isDisabled = disabled || disabledByAdmin;
   const typography = useScaledTVTypography();
   const inputRef = useRef<TextInput>(null);
   const { focused, handleFocus, handleBlur, animatedStyle } =
@@ -39,8 +45,8 @@ export const TVSettingsTextInput: React.FC<TVSettingsTextInputProps> = ({
       onPress={() => inputRef.current?.focus()}
       onFocus={handleFocus}
       onBlur={handleInputBlur}
-      disabled={disabled}
-      focusable={!disabled}
+      disabled={isDisabled}
+      focusable={!isDisabled}
     >
       <Animated.View
         style={[
@@ -53,6 +59,7 @@ export const TVSettingsTextInput: React.FC<TVSettingsTextInputProps> = ({
             paddingVertical: scaleSize(16),
             paddingHorizontal: scaleSize(24),
             marginBottom: scaleSize(8),
+            opacity: isDisabled ? 0.4 : 1,
           },
         ]}
       >
@@ -65,6 +72,17 @@ export const TVSettingsTextInput: React.FC<TVSettingsTextInputProps> = ({
         >
           {label}
         </Text>
+        {disabledByAdmin && (
+          <Text
+            style={{
+              fontSize: typography.callout,
+              color: "#EF4444",
+              marginBottom: scaleSize(8),
+            }}
+          >
+            {t("home.settings.disabled_by_admin")}
+          </Text>
+        )}
         <TextInput
           ref={inputRef}
           value={value}

--- a/components/tv/settings/TVSettingsToggle.tsx
+++ b/components/tv/settings/TVSettingsToggle.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Animated, Pressable, View } from "react-native";
 import { Text } from "@/components/common/Text";
 import { useScaledTVTypography } from "@/constants/TVTypography";
@@ -11,6 +12,12 @@ export interface TVSettingsToggleProps {
   onToggle: (value: boolean) => void;
   isFirst?: boolean;
   disabled?: boolean;
+  /**
+   * Locked by the Streamyfin plugin. Distinct from `disabled` because the row
+   * has to say *why*: an admin-locked setting is dropped on write and overridden
+   * on read, so without a visible reason it just looks like a broken toggle.
+   */
+  disabledByAdmin?: boolean;
 }
 
 export const TVSettingsToggle: React.FC<TVSettingsToggleProps> = ({
@@ -19,7 +26,10 @@ export const TVSettingsToggle: React.FC<TVSettingsToggleProps> = ({
   onToggle,
   isFirst,
   disabled,
+  disabledByAdmin,
 }) => {
+  const { t } = useTranslation();
+  const isDisabled = disabled || disabledByAdmin;
   const typography = useScaledTVTypography();
   const { focused, handleFocus, handleBlur, animatedStyle } =
     useTVFocusAnimation({ scaleAmount: 1.02 });
@@ -29,9 +39,9 @@ export const TVSettingsToggle: React.FC<TVSettingsToggleProps> = ({
       onPress={() => onToggle(!value)}
       onFocus={handleFocus}
       onBlur={handleBlur}
-      hasTVPreferredFocus={isFirst && !disabled}
-      disabled={disabled}
-      focusable={!disabled}
+      hasTVPreferredFocus={isFirst && !isDisabled}
+      disabled={isDisabled}
+      focusable={!isDisabled}
     >
       <Animated.View
         style={[
@@ -47,12 +57,26 @@ export const TVSettingsToggle: React.FC<TVSettingsToggleProps> = ({
             flexDirection: "row",
             alignItems: "center",
             justifyContent: "space-between",
+            opacity: isDisabled ? 0.4 : 1,
           },
         ]}
       >
-        <Text style={{ fontSize: typography.body, color: "#FFFFFF" }}>
-          {label}
-        </Text>
+        <View>
+          <Text style={{ fontSize: typography.body, color: "#FFFFFF" }}>
+            {label}
+          </Text>
+          {disabledByAdmin && (
+            <Text
+              style={{
+                fontSize: typography.callout,
+                color: "#EF4444",
+                marginTop: scaleSize(2),
+              }}
+            >
+              {t("home.settings.disabled_by_admin")}
+            </Text>
+          )}
+        </View>
         <View
           style={{
             width: scaleSize(56),

--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -396,15 +396,10 @@ export const Controls: FC<Props> = ({
         mediaSource: newMediaSource,
         audioIndex: defaultAudioIndex,
         subtitleIndex: defaultSubtitleIndex,
-      } = getDefaultPlaySettings(
-        item,
-        settings,
-        {
-          indexes: previousIndexes,
-          source: mediaSource ?? undefined,
-        },
-        { applyLanguagePreferences: true },
-      );
+      } = getDefaultPlaySettings(item, settings, {
+        indexes: previousIndexes,
+        source: mediaSource ?? undefined,
+      });
 
       // Use setParams instead of replace to avoid unmounting/remounting the player,
       // which would create a new MPV native view and crash with "mp_initialize already initialized".

--- a/components/video-player/controls/Controls.tv.tsx
+++ b/components/video-player/controls/Controls.tv.tsx
@@ -52,7 +52,8 @@ import { useOfflineMode } from "@/providers/OfflineModeProvider";
 import { useSettings } from "@/utils/atoms/settings";
 import type { TVOptionItem } from "@/utils/atoms/tvOptionModal";
 import { getDefaultPlaySettings } from "@/utils/jellyfin/getDefaultPlaySettings";
-import { compareTracksForMenu } from "@/utils/jellyfin/subtitleUtils";
+import { SUBTITLES_OFF } from "@/utils/subtitles/subtitleIndex";
+import { buildAudioMenu, buildSubtitleMenu } from "@/utils/subtitles/trackMenu";
 import { formatTimeString, msToTicks, ticksToMs } from "@/utils/time";
 import { CONTROLS_CONSTANTS } from "./constants";
 import { useVideoContext } from "./contexts/VideoContext";
@@ -282,24 +283,20 @@ export const Controls: FC<Props> = ({
   // Ref for the invisible focus-stealing overlay (prevents hidden buttons from receiving select events)
   const focusOverlayRef = useRef<View>(null);
 
-  const audioTracks = useMemo(() => {
-    return mediaSource?.MediaStreams?.filter((s) => s.Type === "Audio") ?? [];
-  }, [mediaSource]);
-
-  const _subtitleTracks = useMemo(() => {
-    return (
-      mediaSource?.MediaStreams?.filter((s) => s.Type === "Subtitle") ?? []
-    );
-  }, [mediaSource]);
-
-  const audioOptions: TVOptionItem<number>[] = useMemo(() => {
-    return audioTracks.map((track) => ({
-      label:
-        track.DisplayTitle || `${track.Language || "Unknown"} (${track.Codec})`,
-      value: track.Index!,
-      selected: track.Index === audioIndex,
-    }));
-  }, [audioTracks, audioIndex]);
+  const audioOptions: TVOptionItem<number>[] = useMemo(
+    () =>
+      buildAudioMenu(mediaSource?.MediaStreams, {
+        selectedIndex: audioIndex,
+        isTranscoding: Boolean(mediaSource?.TranscodingUrl),
+        formatLabel: (s) =>
+          s.DisplayTitle || `${s.Language || "Unknown"} (${s.Codec})`,
+      }).map((row) => ({
+        label: row.label,
+        value: row.index,
+        selected: row.selected,
+      })),
+    [mediaSource, audioIndex],
+  );
 
   const handleAudioChange = useCallback(
     (index: number) => {
@@ -339,22 +336,22 @@ export const Controls: FC<Props> = ({
   const refreshSubtitleTracks = useCallback(async (): Promise<Track[]> => {
     try {
       const streams = (await onRefreshSubtitleTracks?.()) ?? [];
-      // Skip streams without a real index: `?? -1` would alias them to the
-      // "disable subtitles" sentinel and mis-route selection. Order like
-      // jellyfin-web (embedded first, externals last, forced/default up).
-      return [...streams]
-        .sort(compareTracksForMenu)
-        .filter((stream) => typeof stream.Index === "number")
-        .map((stream) => {
-          const index = stream.Index as number;
-          return {
-            name:
-              stream.DisplayTitle ||
-              `${stream.Language || "Unknown"} (${stream.Codec})`,
-            index,
-            setTrack: () => onSubtitleIndexChange?.(index),
-          };
-        });
+      // Streams with no Index are dropped by the builder rather than aliased
+      // onto the "disable subtitles" sentinel. The modal supplies its own
+      // "None", so the off row is left out here.
+      return buildSubtitleMenu(streams, {
+        selectedIndex: subtitleIndex ?? SUBTITLES_OFF,
+        offLabel: "",
+        isTranscoding: Boolean(mediaSource?.TranscodingUrl),
+        formatLabel: (s) =>
+          s.DisplayTitle || `${s.Language || "Unknown"} (${s.Codec})`,
+      })
+        .filter((row) => row.kind !== "off")
+        .map((row) => ({
+          name: row.label,
+          index: row.index,
+          setTrack: () => onSubtitleIndexChange?.(row.index),
+        }));
     } catch {
       return [];
     }

--- a/components/video-player/controls/Controls.tv.tsx
+++ b/components/video-player/controls/Controls.tv.tsx
@@ -52,8 +52,13 @@ import { useOfflineMode } from "@/providers/OfflineModeProvider";
 import { useSettings } from "@/utils/atoms/settings";
 import type { TVOptionItem } from "@/utils/atoms/tvOptionModal";
 import { getDefaultPlaySettings } from "@/utils/jellyfin/getDefaultPlaySettings";
+import { rememberSeriesTrackFromRow } from "@/utils/seriesTrackMemory";
 import { SUBTITLES_OFF } from "@/utils/subtitles/subtitleIndex";
-import { buildAudioMenu, buildSubtitleMenu } from "@/utils/subtitles/trackMenu";
+import {
+  buildAudioMenu,
+  buildSubtitleMenu,
+  type TrackMenuRow,
+} from "@/utils/subtitles/trackMenu";
 import { formatTimeString, msToTicks, ticksToMs } from "@/utils/time";
 import { CONTROLS_CONSTANTS } from "./constants";
 import { useVideoContext } from "./contexts/VideoContext";
@@ -283,7 +288,10 @@ export const Controls: FC<Props> = ({
   // Ref for the invisible focus-stealing overlay (prevents hidden buttons from receiving select events)
   const focusOverlayRef = useRef<View>(null);
 
-  const audioOptions: TVOptionItem<number>[] = useMemo(
+  // The row travels as the option value (same shape the TV item page uses) so
+  // the selection handler can persist the pick without re-deriving its language
+  // from a stream list that may have been refetched since the menu was built.
+  const audioOptions: TVOptionItem<TrackMenuRow>[] = useMemo(
     () =>
       buildAudioMenu(mediaSource?.MediaStreams, {
         selectedIndex: audioIndex,
@@ -292,17 +300,18 @@ export const Controls: FC<Props> = ({
           s.DisplayTitle || `${s.Language || "Unknown"} (${s.Codec})`,
       }).map((row) => ({
         label: row.label,
-        value: row.index,
+        value: row,
         selected: row.selected,
       })),
     [mediaSource, audioIndex],
   );
 
   const handleAudioChange = useCallback(
-    (index: number) => {
-      onAudioIndexChange?.(index);
+    (row: TrackMenuRow) => {
+      rememberSeriesTrackFromRow({ item, kind: "audio", row, settings });
+      onAudioIndexChange?.(row.index);
     },
-    [onAudioIndexChange],
+    [onAudioIndexChange, item, settings],
   );
 
   // Quality options mirror the mobile menu: value is the max bitrate as a
@@ -321,13 +330,6 @@ export const Controls: FC<Props> = ({
       onBitrateChange?.(value ? Number.parseInt(value, 10) : undefined);
     },
     [onBitrateChange],
-  );
-
-  const _handleSubtitleChange = useCallback(
-    (index: number) => {
-      onSubtitleIndexChange?.(index);
-    },
-    [onSubtitleIndexChange],
   );
 
   // Re-fetch subtitle streams from the server (e.g. after a server-side
@@ -350,12 +352,22 @@ export const Controls: FC<Props> = ({
         .map((row) => ({
           name: row.label,
           index: row.index,
-          setTrack: () => onSubtitleIndexChange?.(row.index),
+          setTrack: () => {
+            // These rows are built here rather than in VideoContext, so they do
+            // not pass through the write it performs — persist them directly.
+            rememberSeriesTrackFromRow({
+              item,
+              kind: "subtitle",
+              row,
+              settings,
+            });
+            onSubtitleIndexChange?.(row.index);
+          },
         }));
     } catch {
       return [];
     }
-  }, [onRefreshSubtitleTracks, onSubtitleIndexChange]);
+  }, [onRefreshSubtitleTracks, onSubtitleIndexChange, item, settings]);
 
   const {
     trickPlayUrl,

--- a/components/video-player/controls/contexts/VideoContext.tsx
+++ b/components/video-player/controls/contexts/VideoContext.tsx
@@ -63,14 +63,14 @@ import { useOfflineMode } from "@/providers/OfflineModeProvider";
 import { getSubtitlesForItem } from "@/utils/atoms/downloadedSubtitles";
 import {
   applyMpvSubtitleSelection,
-  compareTracksForMenu,
   getExternalSubtitleUrl,
   isImageBasedSubtitle,
 } from "@/utils/jellyfin/subtitleUtils";
 import {
   isLocalSubtitleIndex,
-  localSubtitleIndex,
+  SUBTITLES_OFF,
 } from "@/utils/subtitles/subtitleIndex";
+import { buildAudioMenu, buildSubtitleMenu } from "@/utils/subtitles/trackMenu";
 import type { Track } from "../types";
 import { usePlayerContext, usePlayerControls } from "./PlayerContext";
 
@@ -109,6 +109,23 @@ export const VideoProvider: React.FC<{ children: ReactNode }> = ({
     mediaSource?.MediaStreams?.filter((s) => s.Type === "Audio") || [];
 
   const isTranscoding = Boolean(mediaSource?.TranscodingUrl);
+
+  // Route params are strings; a missing/blank one parses to NaN, which must not
+  // be read as a real selection.
+  const asIndex = (raw: string | undefined): number | undefined => {
+    const parsed = Number.parseInt(raw ?? "", 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  };
+  const currentSubtitleIndex = asIndex(subtitleIndex) ?? SUBTITLES_OFF;
+  const currentAudioIndex = asIndex(audioIndex);
+
+  /** Client-side downloads that still exist on disk (the cache may be cleared). */
+  const localSubFiles = useMemo(() => {
+    if (!Platform.isTV || !itemId) return [];
+    return getSubtitlesForItem(itemId)
+      .filter((s) => new File(s.filePath).exists)
+      .map((s) => ({ name: s.name, filePath: s.filePath }));
+  }, [itemId]);
 
   /**
    * Check if the currently selected subtitle is image-based.
@@ -197,69 +214,40 @@ export const VideoProvider: React.FC<{ children: ReactNode }> = ({
           commitAudioTracks([]);
         }
 
-        // For subtitles in transcoded offline content:
-        // - Text-based subs may still be embedded
-        // - Image-based subs were burned in during transcoding
-        const downloadedSubtitleIndex =
-          downloadedItem.userData.subtitleStreamIndex;
-        const subs: Track[] = [];
-
-        // If an IMAGE subtitle was burned into the transcoded download it's in the
-        // video pixels — it can't be turned off or swapped. Show only that entry
-        // instead of advertising "Disable"/text controls that can't affect it.
-        const burnedInSub = allSubs.find(
-          (s) => s.Index === downloadedSubtitleIndex,
-        );
-        if (burnedInSub && isImageBasedSubtitle(burnedInSub)) {
-          commitSubtitleTracks([
-            {
-              name: `${burnedInSub.DisplayTitle || "Unknown"} (burned in)`,
-              index: burnedInSub.Index ?? -1,
-              mpvIndex: -1,
-              setTrack: () => {},
-            },
-          ]);
-          return;
-        }
-
-        // Add "Disable" option
-        subs.push({
-          name: "Disable",
-          index: -1,
+        // A transcoded download carries only text subs; an image sub chosen at
+        // download time was burned into the video and is inert — the builder
+        // returns it as the sole row rather than advertising "Disable" and
+        // alternatives that cannot affect pixels.
+        const subs: Track[] = buildSubtitleMenu(allSubs, {
+          selectedIndex: currentSubtitleIndex,
+          offLabel: "Disable",
+          isTranscoding: false,
+          offlineTranscoded: {
+            burnedInIndex: downloadedItem.userData.subtitleStreamIndex,
+          },
+          formatLabel: (s) => s.DisplayTitle || "Unknown",
+        }).map((row) => ({
+          name: row.label,
+          index: row.index,
           mpvIndex: -1,
           setTrack: () => {
-            playerControls.setSubtitleTrack(-1);
-            router.setParams({ subtitleIndex: "-1" });
-          },
-        });
-
-        // Text subs are muxed into the transcoded file and switchable; resolve by
-        // identity against MPV's real track list (same as online). Order matches web.
-        // Image subs aren't in the transcoded file (only the burned one was, handled
-        // above), so skip them here.
-        for (const sub of [...allSubs].sort(compareTracksForMenu)) {
-          if (!isImageBasedSubtitle(sub)) {
-            subs.push({
-              name: sub.DisplayTitle || "Unknown",
-              index: sub.Index ?? -1,
-              mpvIndex: -1,
-              setTrack: () => {
-                router.setParams({ subtitleIndex: String(sub.Index) });
-                void applyMpvSubtitleSelection(playerControls, {
-                  subtitleStreams: allSubs,
-                  jellyfinSubtitleIndex: sub.Index ?? -1,
-                  getExpectedExternalUrl: (s) => {
-                    if (!s.DeliveryUrl) return undefined;
-                    if (offline) return s.DeliveryUrl;
-                    return api?.basePath
-                      ? `${api.basePath}${s.DeliveryUrl}`
-                      : undefined;
-                  },
-                });
-              },
+            // Inert by construction — the row exists only to show what is
+            // baked into the file.
+            if (row.kind === "burnedIn") return;
+            if (row.kind === "off") {
+              playerControls.setSubtitleTrack(-1);
+              router.setParams({ subtitleIndex: "-1" });
+              return;
+            }
+            router.setParams({ subtitleIndex: String(row.index) });
+            void applyMpvSubtitleSelection(playerControls, {
+              subtitleStreams: allSubs,
+              jellyfinSubtitleIndex: row.index,
+              getExpectedExternalUrl: (s) =>
+                getExternalSubtitleUrl(s, { offline, basePath: api?.basePath }),
             });
-          }
-        }
+          },
+        }));
 
         commitSubtitleTracks(subs);
         return;
@@ -270,116 +258,86 @@ export const VideoProvider: React.FC<{ children: ReactNode }> = ({
       if (cancelled) return;
       const playerAudio = (audioData as MpvAudioTrack[]) ?? [];
 
-      const subs: Track[] = [];
-
-      // Process all Jellyfin subtitles. Selection resolves against MPV's real
-      // track list by identity (applyMpvSubtitleSelection) — never positional
-      // index math, which mis-selects across external/embedded reordering and
-      // server-hidden embedded subs (#954/#1690/#618/#1467/#976/#1451).
-      // Order matches jellyfin-web (embedded first, externals last, forced/default up).
-      for (const sub of [...allSubs].sort(compareTracksForMenu)) {
-        // Image-based subs during transcoding are burned into the video by the
-        // server; both switching TO one and switching AWAY from a currently
-        // active one require a player refresh (re-transcode), not a track change.
-        const needsReplace =
-          isTranscoding &&
-          (isImageBasedSubtitle(sub) || isCurrentSubImageBased);
-
-        subs.push({
-          name: sub.DisplayTitle || "Unknown",
-          index: sub.Index ?? -1,
-          mpvIndex: -1,
-          setTrack: () => {
-            if (needsReplace) {
-              replacePlayer({ subtitleIndex: String(sub.Index) });
-              return;
-            }
-            router.setParams({ subtitleIndex: String(sub.Index) });
-            void applyMpvSubtitleSelection(playerControls, {
-              subtitleStreams: allSubs,
-              jellyfinSubtitleIndex: sub.Index ?? -1,
-              // Mirror how external subs are loaded into MPV (online: basePath +
-              // DeliveryUrl, offline: local DeliveryUrl) so identity matching by
-              // external-filename lines up.
-              getExpectedExternalUrl: (s) =>
-                getExternalSubtitleUrl(s, { offline, basePath: api?.basePath }),
-            }).then((result) => {
-              // Safety net: a menu-listed sub the player can't select (server-
-              // burned Encode, sidecar never sub-added) only shows up after the
-              // server re-processes the stream with it.
-              if (result.kind === "notFound" || result.kind === "burnedIn") {
-                replacePlayer({ subtitleIndex: String(sub.Index) });
-              }
-            });
-          },
-        });
-      }
-
-      // Add "Disable" option at the beginning
-      subs.unshift({
-        name: "Disable",
-        index: -1,
+      // Selection resolves against MPV's real track list by identity
+      // (applyMpvSubtitleSelection) — never positional index math, which
+      // mis-selects across external/embedded reordering and server-hidden
+      // embedded subs (#954/#1690/#618/#1467/#976/#1451).
+      const subs: Track[] = buildSubtitleMenu(allSubs, {
+        selectedIndex: currentSubtitleIndex,
+        offLabel: "Disable",
+        isTranscoding,
+        // TV is the only surface that can download a sidecar mid-playback.
+        localSubs: Platform.isTV ? localSubFiles : undefined,
+        formatLabel: (s) => s.DisplayTitle || "Unknown",
+      }).map((row) => ({
+        name: row.label,
+        index: row.index,
         mpvIndex: -1,
+        isLocal: row.kind === "sidecar",
+        localPath: row.localPath,
         setTrack: () => {
-          if (isTranscoding && isCurrentSubImageBased) {
-            replacePlayer({ subtitleIndex: "-1" });
-          } else {
+          if (row.kind === "sidecar" && row.localPath) {
+            playerControls.addSubtitleFile(row.localPath, true);
+            router.setParams({ subtitleIndex: String(row.index) });
+            return;
+          }
+          // Burned-in image subs are pixels: switching to one, and switching
+          // away from an active one, both need the server to re-process.
+          if (row.requiresReload) {
+            replacePlayer({ subtitleIndex: String(row.index) });
+            return;
+          }
+          if (row.kind === "off") {
             playerControls.setSubtitleTrack(-1);
             router.setParams({ subtitleIndex: "-1" });
+            return;
           }
+          router.setParams({ subtitleIndex: String(row.index) });
+          void applyMpvSubtitleSelection(playerControls, {
+            subtitleStreams: allSubs,
+            jellyfinSubtitleIndex: row.index,
+            // Mirror how external subs are loaded into MPV (online: basePath +
+            // DeliveryUrl, offline: local DeliveryUrl) so identity matching by
+            // external-filename lines up.
+            getExpectedExternalUrl: (s) =>
+              getExternalSubtitleUrl(s, { offline, basePath: api?.basePath }),
+          }).then((result) => {
+            // Safety net: a menu-listed sub the player can't select (server-
+            // burned Encode, sidecar never sub-added) only shows up after the
+            // server re-processes the stream with it.
+            if (result.kind === "notFound" || result.kind === "burnedIn") {
+              replacePlayer({ subtitleIndex: String(row.index) });
+            }
+          });
         },
-      });
+      }));
 
-      // Process audio tracks
-      const audio: Track[] = allAudio.map((a, idx) => {
-        const playerTrack = playerAudio[idx];
-        const mpvId = playerTrack?.id ?? idx + 1;
+      const audio: Track[] = buildAudioMenu(allAudio, {
+        selectedIndex: currentAudioIndex,
+        isTranscoding,
+        formatLabel: (a) => a.DisplayTitle || "Unknown",
+      }).map((row) => {
+        // mpv ids come from the player's own enumeration, so position against
+        // the unfiltered stream list — not the row list, which drops streams
+        // with no Index and would shift every id below the gap.
+        const position = allAudio.findIndex((a) => a.Index === row.index);
+        const mpvId = playerAudio[position]?.id ?? position + 1;
 
         return {
-          name: a.DisplayTitle || "Unknown",
-          index: a.Index ?? -1,
+          name: row.label,
+          index: row.index,
           mpvIndex: mpvId,
           setTrack: () => {
-            if (isTranscoding) {
-              replacePlayer({ audioIndex: String(a.Index) });
+            if (row.requiresReload) {
+              replacePlayer({ audioIndex: String(row.index) });
               return;
             }
             playerControls.setAudioTrack(mpvId);
-            router.setParams({ audioIndex: String(a.Index) });
+            router.setParams({ audioIndex: String(row.index) });
           },
         };
       });
 
-      // TV only: Merge locally downloaded subtitles (from OpenSubtitles)
-      if (Platform.isTV && itemId) {
-        const localSubs = getSubtitlesForItem(itemId);
-        let localIdx = 0;
-        for (const localSub of localSubs) {
-          // Verify file still exists (cache may have been cleared)
-          const subtitleFile = new File(localSub.filePath);
-          if (!subtitleFile.exists) {
-            continue;
-          }
-
-          const localIndex = localSubtitleIndex(localIdx);
-          subs.push({
-            name: localSub.name,
-            index: localIndex,
-            mpvIndex: -1, // Will be loaded dynamically via addSubtitleFile
-            isLocal: true,
-            localPath: localSub.filePath,
-            setTrack: () => {
-              // Add the subtitle file to MPV and select it
-              playerControls.addSubtitleFile(localSub.filePath, true);
-              router.setParams({ subtitleIndex: String(localIndex) });
-            },
-          });
-          localIdx++;
-        }
-      }
-
-      // Already in jellyfin-web order (sorted iteration above); "Disable" stays
-      // at the front (unshifted), local downloaded subs at the end.
       commitSubtitleTracks(subs);
       commitAudioTracks(audio);
     };
@@ -400,6 +358,9 @@ export const VideoProvider: React.FC<{ children: ReactNode }> = ({
     itemId,
     api?.basePath,
     isCurrentSubImageBased,
+    localSubFiles,
+    currentSubtitleIndex,
+    currentAudioIndex,
   ]);
 
   return (

--- a/components/video-player/controls/contexts/VideoContext.tsx
+++ b/components/video-player/controls/contexts/VideoContext.tsx
@@ -67,7 +67,11 @@ import {
   getExternalSubtitleUrl,
   isImageBasedSubtitle,
 } from "@/utils/jellyfin/subtitleUtils";
-import { LOCAL_SUBTITLE_INDEX_START, type Track } from "../types";
+import {
+  isLocalSubtitleIndex,
+  localSubtitleIndex,
+} from "@/utils/subtitles/subtitleIndex";
+import type { Track } from "../types";
 import { usePlayerContext, usePlayerControls } from "./PlayerContext";
 
 interface VideoContextProps {
@@ -129,10 +133,11 @@ export const VideoProvider: React.FC<{ children: ReactNode }> = ({
     // The URL param can hold a local-sub sentinel (selected via setParams) that
     // only exists in the dying player — the server must get "none" (-1) instead.
     // NaN (missing/blank param) fails the comparison and passes through as-is.
-    const fallbackSubtitleIndex =
-      Number.parseInt(subtitleIndex, 10) <= LOCAL_SUBTITLE_INDEX_START
-        ? "-1"
-        : subtitleIndex;
+    const fallbackSubtitleIndex = isLocalSubtitleIndex(
+      Number.parseInt(subtitleIndex, 10),
+    )
+      ? "-1"
+      : subtitleIndex;
     const queryParams = new URLSearchParams({
       itemId: itemId ?? "",
       audioIndex: params.audioIndex ?? audioIndex,
@@ -356,7 +361,7 @@ export const VideoProvider: React.FC<{ children: ReactNode }> = ({
             continue;
           }
 
-          const localIndex = LOCAL_SUBTITLE_INDEX_START - localIdx;
+          const localIndex = localSubtitleIndex(localIdx);
           subs.push({
             name: localSub.name,
             index: localIndex,

--- a/components/video-player/controls/contexts/VideoContext.tsx
+++ b/components/video-player/controls/contexts/VideoContext.tsx
@@ -53,6 +53,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { Platform } from "react-native";
@@ -61,16 +62,22 @@ import type { MpvAudioTrack } from "@/modules";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { useOfflineMode } from "@/providers/OfflineModeProvider";
 import { getSubtitlesForItem } from "@/utils/atoms/downloadedSubtitles";
+import { useSettings } from "@/utils/atoms/settings";
 import {
   applyMpvSubtitleSelection,
   getExternalSubtitleUrl,
   isImageBasedSubtitle,
 } from "@/utils/jellyfin/subtitleUtils";
+import { rememberSeriesTrackFromRow } from "@/utils/seriesTrackMemory";
 import {
   isLocalSubtitleIndex,
   SUBTITLES_OFF,
 } from "@/utils/subtitles/subtitleIndex";
-import { buildAudioMenu, buildSubtitleMenu } from "@/utils/subtitles/trackMenu";
+import {
+  buildAudioMenu,
+  buildSubtitleMenu,
+  type TrackMenuRow,
+} from "@/utils/subtitles/trackMenu";
 import type { Track } from "../types";
 import { usePlayerContext, usePlayerControls } from "./PlayerContext";
 
@@ -87,11 +94,28 @@ export const VideoProvider: React.FC<{ children: ReactNode }> = ({
   const [subtitleTracks, setSubtitleTracks] = useState<Track[] | null>(null);
   const [audioTracks, setAudioTracks] = useState<Track[] | null>(null);
 
-  const { tracksReady, mediaSource, downloadedItem } = usePlayerContext();
+  const { tracksReady, mediaSource, downloadedItem, item } = usePlayerContext();
   const playerControls = usePlayerControls();
   const offline = useOfflineMode();
   const api = useAtomValue(apiAtom);
   const router = useRouter();
+  const { settings } = useSettings();
+
+  /**
+   * Persist a deliberate pick as the series preference, exactly as the native
+   * player and the item pages do — a menu that changes the track but remembers
+   * nothing is why the next episode used to come back on the server's default.
+   *
+   * Held in a ref rather than read directly by the effect below: `settings` gets
+   * a new identity on every settings write, and depending on it would re-run the
+   * whole track fetch (an async bridge round-trip) and briefly blank the menus
+   * every time an unrelated toggle moved.
+   */
+  const rememberRef = useRef<
+    (kind: "audio" | "subtitle", row: TrackMenuRow) => void
+  >(() => {});
+  rememberRef.current = (kind, row) =>
+    rememberSeriesTrackFromRow({ item, kind, row, settings });
 
   const { itemId, audioIndex, bitrateValue, subtitleIndex, playbackPosition } =
     useLocalSearchParams<{
@@ -234,6 +258,7 @@ export const VideoProvider: React.FC<{ children: ReactNode }> = ({
             // Inert by construction — the row exists only to show what is
             // baked into the file.
             if (row.kind === "burnedIn") return;
+            rememberRef.current("subtitle", row);
             if (row.kind === "off") {
               playerControls.setSubtitleTrack(-1);
               router.setParams({ subtitleIndex: "-1" });
@@ -276,6 +301,7 @@ export const VideoProvider: React.FC<{ children: ReactNode }> = ({
         isLocal: row.kind === "sidecar",
         localPath: row.localPath,
         setTrack: () => {
+          rememberRef.current("subtitle", row);
           if (row.kind === "sidecar" && row.localPath) {
             playerControls.addSubtitleFile(row.localPath, true);
             router.setParams({ subtitleIndex: String(row.index) });
@@ -328,6 +354,7 @@ export const VideoProvider: React.FC<{ children: ReactNode }> = ({
           index: row.index,
           mpvIndex: mpvId,
           setTrack: () => {
+            rememberRef.current("audio", row);
             if (row.requiresReload) {
               replacePlayer({ audioIndex: String(row.index) });
               return;

--- a/components/video-player/controls/types.ts
+++ b/components/video-player/controls/types.ts
@@ -28,20 +28,4 @@ type Track = {
   localPath?: string;
 };
 
-/**
- * Synthetic `Track.index` base for client-side downloaded subtitles (loaded via
- * `addSubtitleFile`, no matching Jellyfin MediaStream). Local sub k gets
- * `LOCAL_SUBTITLE_INDEX_START - k`, so `index <= LOCAL_SUBTITLE_INDEX_START`
- * identifies a local track.
- */
-export const LOCAL_SUBTITLE_INDEX_START = -100;
-
-/**
- * Map a client-side subtitle index to what the Jellyfin stream API understands.
- * Local sentinel indexes have no matching MediaStream on the server, which
- * expects -1 ("no subtitles") when re-negotiating a stream.
- */
-export const toServerSubtitleIndex = (index: number): number =>
-  index <= LOCAL_SUBTITLE_INDEX_START ? -1 : index;
-
 export type { EmbeddedSubtitle, ExternalSubtitle, Track, TranscodedSubtitle };

--- a/hooks/useDefaultPlaySettings.ts
+++ b/hooks/useDefaultPlaySettings.ts
@@ -1,10 +1,7 @@
 import { type BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
 import { useMemo } from "react";
 import type { Settings } from "@/utils/atoms/settings";
-import {
-  getDefaultPlaySettings,
-  type PlaySettingsOptions,
-} from "@/utils/jellyfin/getDefaultPlaySettings";
+import { getDefaultPlaySettings } from "@/utils/jellyfin/getDefaultPlaySettings";
 
 /**
  * React hook wrapper for getDefaultPlaySettings.
@@ -12,16 +9,14 @@ import {
  *
  * @param item - The media item to play
  * @param settings - User settings (language preferences, bitrate, etc.)
- * @param options - Optional flags to control behavior (e.g., applyLanguagePreferences for TV)
  */
 const useDefaultPlaySettings = (
   item: BaseItemDto | null | undefined,
   settings: Settings | null,
-  options?: PlaySettingsOptions,
 ) =>
   useMemo(() => {
     const { mediaSource, audioIndex, subtitleIndex, bitrate } =
-      getDefaultPlaySettings(item, settings, undefined, options);
+      getDefaultPlaySettings(item, settings);
 
     return {
       defaultMediaSource: mediaSource,
@@ -29,6 +24,6 @@ const useDefaultPlaySettings = (
       defaultSubtitleIndex: subtitleIndex,
       defaultBitrate: bitrate,
     };
-  }, [item, settings, options]);
+  }, [item, settings]);
 
 export default useDefaultPlaySettings;

--- a/hooks/useMediaPreferences.ts
+++ b/hooks/useMediaPreferences.ts
@@ -19,6 +19,7 @@ import {
   ORIGINAL_LANGUAGE,
   supportsOriginalAudioLanguage,
 } from "@/utils/jellyfin/serverVersion";
+import { buildUserConfigurationPayload } from "@/utils/jellyfin/userConfiguration";
 
 /**
  * The settings that are not really Streamyfin's own: they mirror fields of the
@@ -45,34 +46,6 @@ const SERVER_BACKED_KEYS = [
 ] as const;
 
 export type ServerBackedSetting = (typeof SERVER_BACKED_KEYS)[number];
-
-/**
- * Translate a settings update into the matching `UserConfiguration` fields.
- *
- * Only the keys actually present in the update are carried: everything else is
- * left to the server copy the caller merges on top of. Rebuilding the whole
- * configuration from local state would let an unrelated write clear a
- * preference the app never had a value for.
- */
-export function buildUserConfigurationPayload(
-  update: Partial<Settings>,
-): Partial<UserConfiguration> {
-  const configuration: Partial<UserConfiguration> = {};
-  if ("subtitleMode" in update) configuration.SubtitleMode = update.subtitleMode;
-  if ("playDefaultAudioTrack" in update)
-    configuration.PlayDefaultAudioTrack = update.playDefaultAudioTrack;
-  if ("rememberAudioSelections" in update)
-    configuration.RememberAudioSelections = update.rememberAudioSelections;
-  if ("rememberSubtitleSelections" in update)
-    configuration.RememberSubtitleSelections = update.rememberSubtitleSelections;
-  if ("defaultAudioLanguage" in update)
-    configuration.AudioLanguagePreference =
-      update.defaultAudioLanguage?.ThreeLetterISOLanguageName ?? "";
-  if ("defaultSubtitleLanguage" in update)
-    configuration.SubtitleLanguagePreference =
-      update.defaultSubtitleLanguage?.ThreeLetterISOLanguageName ?? "";
-  return configuration;
-}
 
 // Stable reference so a pending cultures query does not churn effect deps.
 const EMPTY_CULTURES: CultureDto[] = [];
@@ -220,7 +193,7 @@ export function useMediaPreferences(): MediaPreferences {
 
       updateSettings(nextUpdate);
 
-      const configuration = buildUserConfigurationPayload(nextUpdate);
+      const configuration = buildUserConfigurationPayload(nextUpdate, settings);
       if (Object.keys(configuration).length === 0) return;
       void updateUserConfiguration(configuration, { invalidateItems: true });
     },
@@ -228,7 +201,7 @@ export function useMediaPreferences(): MediaPreferences {
       isReady,
       pluginSettings?.defaultAudioLanguage?.locked,
       pluginSettings?.playDefaultAudioTrack?.locked,
-      settings?.defaultAudioLanguage?.ThreeLetterISOLanguageName,
+      settings,
       supportsOriginalLanguage,
       updateSettings,
       updateUserConfiguration,

--- a/hooks/useMediaPreferences.ts
+++ b/hooks/useMediaPreferences.ts
@@ -120,31 +120,53 @@ export function useMediaPreferences(): MediaPreferences {
   const isReady = !!user && isServerInfoAvailable && areCulturesAvailable;
 
   /**
+   * Our running belief about what the server's configuration holds.
+   *
+   * Jellyfin replaces the whole configuration on write, so each PATCH has to
+   * merge onto a baseline. Reading that baseline straight off `user` is wrong:
+   * `user` only refreshes once the invalidation round-trips, so two edits inside
+   * that window both merge onto the same pre-edit snapshot and the second
+   * silently reverts the first — toggle two settings quickly and one of them
+   * comes back on its own. Folding each write into the baseline keeps a burst of
+   * edits additive.
+   */
+  const serverConfigRef = useRef<UserConfiguration | undefined>(undefined);
+  useEffect(() => {
+    if (user?.Configuration) serverConfigRef.current = user.Configuration;
+  }, [user]);
+
+  /**
    * Apply a partial configuration on top of the server's own copy, so
    * preferences this client did not touch are never overwritten.
+   *
+   * Resolves true when the server accepted the write.
    */
   const updateUserConfiguration = useCallback(
     async (
       configuration: Partial<UserConfiguration>,
       { invalidateItems = false }: { invalidateItems?: boolean } = {},
-    ) => {
-      if (!api || !user) return;
+    ): Promise<boolean> => {
+      if (!api) return false;
+      const merged = { ...serverConfigRef.current, ...configuration };
       try {
         await getUserApi(api).updateUserConfiguration({
-          userConfiguration: { ...user.Configuration, ...configuration },
+          userConfiguration: merged,
         });
+        serverConfigRef.current = merged;
         queryClient.invalidateQueries({ queryKey: ["authUser"] });
         if (invalidateItems) {
           // Audio/subtitle preferences feed the server-computed
           // DefaultAudio/SubtitleStreamIndex carried by each item's MediaSources.
           queryClient.invalidateQueries({ queryKey: ["item"] });
         }
+        return true;
       } catch {
         // Offline or a server that rejects the write: the local copy still
         // applies, and the next mount re-seeds from whatever the server has.
+        return false;
       }
     },
-    [api, user, queryClient],
+    [api, queryClient],
   );
 
   const updateMediaSettings = useCallback(
@@ -217,18 +239,22 @@ export function useMediaPreferences(): MediaPreferences {
   // snaps back, which is indistinguishable from a dead control. Seeding is a
   // session-start concern, so it keys off the user's identity instead.
   //
-  // The lock state is part of the key because unlocking `playDefaultAudioTrack`
-  // is what makes the original-language correction below permissible: without it
-  // an admin unlocking the key mid-session would leave the server uncorrected
-  // until the next launch.
+  // The server-side correction below is deliberately NOT under that guard. The
+  // two are separate concerns with separate lifetimes: seeding is once per
+  // session, while the correction is a convergence step whose own condition is
+  // self-extinguishing — once the server is fixed, `PlayDefaultAudioTrack` reads
+  // false and it stops matching. Gating both on one key means widening that key
+  // by hand for every input the correction reads, and missing one silently
+  // disables the correction: keyed on the admin lock alone, a `serverInfo`
+  // refetch that flips `supportsOriginalLanguage` on — which any of the five
+  // other consumers of that query key can trigger — would re-run this effect,
+  // hit the unchanged key, and return before the correction was even evaluated.
   const playDefaultAudioTrackLocked =
     pluginSettings?.playDefaultAudioTrack?.locked;
-  const seededFor = useRef<string | null>(null);
+  const seededForUserId = useRef<string | null>(null);
+  const correctedForUserId = useRef<string | null>(null);
   useEffect(() => {
     if (!isReady || !user?.Id) return;
-    const seedKey = `${user.Id}:${playDefaultAudioTrackLocked ?? false}`;
-    if (seededFor.current === seedKey) return;
-    seededFor.current = seedKey;
 
     const config = user.Configuration;
     const userAudioPreference = config?.AudioLanguagePreference;
@@ -247,45 +273,67 @@ export function useMediaPreferences(): MediaPreferences {
       config?.PlayDefaultAudioTrack === true &&
       !playDefaultAudioTrackLocked;
 
-    // Only keys the server actually sent. Spreading an absent field in as
-    // `undefined` would blank a perfectly good local value — and a toggle whose
-    // value is `undefined` renders off and refuses to stay on.
-    const seed: Partial<Settings> = {};
-    if (config?.SubtitleLanguagePreference !== undefined) {
-      seed.defaultSubtitleLanguage = findCulture(
-        config.SubtitleLanguagePreference,
-      );
-    }
-    if (userAudioPreference !== undefined) {
-      // The original-language sentinel is not an ISO code and so is absent from
-      // the cultures list — it has to be carried through as-is.
-      seed.defaultAudioLanguage =
-        userAudioPreference === ORIGINAL_LANGUAGE && supportsOriginalLanguage
-          ? ({ ThreeLetterISOLanguageName: ORIGINAL_LANGUAGE } as CultureDto)
-          : findCulture(userAudioPreference);
-    }
-    if (config?.SubtitleMode !== undefined) {
-      seed.subtitleMode = config.SubtitleMode;
-    }
-    if (config?.PlayDefaultAudioTrack !== undefined) {
-      seed.playDefaultAudioTrack = correctsPlayDefaultAudioTrack
-        ? false
-        : config.PlayDefaultAudioTrack;
-    }
-    if (config?.RememberAudioSelections !== undefined) {
-      seed.rememberAudioSelections = config.RememberAudioSelections;
-    }
-    if (config?.RememberSubtitleSelections !== undefined) {
-      seed.rememberSubtitleSelections = config.RememberSubtitleSelections;
+    if (seededForUserId.current !== user.Id) {
+      seededForUserId.current = user.Id;
+
+      // Only keys the server actually sent. Spreading an absent field in as
+      // `undefined` would blank a perfectly good local value — and a toggle
+      // whose value is `undefined` renders off and refuses to stay on.
+      const seed: Partial<Settings> = {};
+      if (config?.SubtitleLanguagePreference !== undefined) {
+        seed.defaultSubtitleLanguage = findCulture(
+          config.SubtitleLanguagePreference,
+        );
+      }
+      if (userAudioPreference !== undefined) {
+        // The original-language sentinel is not an ISO code and so is absent
+        // from the cultures list — it has to be carried through as-is.
+        seed.defaultAudioLanguage =
+          userAudioPreference === ORIGINAL_LANGUAGE && supportsOriginalLanguage
+            ? ({ ThreeLetterISOLanguageName: ORIGINAL_LANGUAGE } as CultureDto)
+            : findCulture(userAudioPreference);
+      }
+      if (config?.SubtitleMode !== undefined) {
+        seed.subtitleMode = config.SubtitleMode;
+      }
+      if (config?.PlayDefaultAudioTrack !== undefined) {
+        // Seeded from the correction decision, not the raw server field: track
+        // resolution reads this local copy and cannot wait for the round trip,
+        // so seeding the uncorrected `true` would pick the default-flagged
+        // stream for as long as the PATCH is in flight.
+        seed.playDefaultAudioTrack = correctsPlayDefaultAudioTrack
+          ? false
+          : config.PlayDefaultAudioTrack;
+      }
+      if (config?.RememberAudioSelections !== undefined) {
+        seed.rememberAudioSelections = config.RememberAudioSelections;
+      }
+      if (config?.RememberSubtitleSelections !== undefined) {
+        seed.rememberSubtitleSelections = config.RememberSubtitleSelections;
+      }
+
+      if (Object.keys(seed).length > 0) updateSettings(seed);
     }
 
-    if (Object.keys(seed).length > 0) updateSettings(seed);
-
-    if (correctsPlayDefaultAudioTrack) {
+    // Runs on any pass, not just the seeding one — an admin unlock or a server
+    // version that only now reports support both surface here. The ref is a
+    // de-duplicator, not a lifetime guard: the write is fire-and-forget, so
+    // without it a re-run before the refetch lands would PATCH twice. Cleared
+    // on failure so a rejected write is retried rather than lost.
+    if (
+      correctsPlayDefaultAudioTrack &&
+      correctedForUserId.current !== user.Id
+    ) {
+      correctedForUserId.current = user.Id;
+      // Keep the local copy in step immediately, for the same reason the seed
+      // above does — the round trip is not something track resolution can wait on.
+      updateSettings({ playDefaultAudioTrack: false });
       void updateUserConfiguration(
         { PlayDefaultAudioTrack: false },
         { invalidateItems: true },
-      );
+      ).then((ok) => {
+        if (!ok) correctedForUserId.current = null;
+      });
     }
     // updateSettings is intentionally omitted: it is recreated on every settings
     // write, and depending on it would re-run this effect on our own writes.

--- a/hooks/useMediaPreferences.ts
+++ b/hooks/useMediaPreferences.ts
@@ -193,7 +193,7 @@ export function useMediaPreferences(): MediaPreferences {
 
       updateSettings(nextUpdate);
 
-      const configuration = buildUserConfigurationPayload(nextUpdate, settings);
+      const configuration = buildUserConfigurationPayload(nextUpdate);
       if (Object.keys(configuration).length === 0) return;
       void updateUserConfiguration(configuration, { invalidateItems: true });
     },

--- a/hooks/useMediaPreferences.ts
+++ b/hooks/useMediaPreferences.ts
@@ -1,0 +1,336 @@
+import type {
+  CultureDto,
+  PublicSystemInfo,
+  UserConfiguration,
+  UserDto,
+} from "@jellyfin/sdk/lib/generated-client/models";
+import {
+  getLocalizationApi,
+  getSystemApi,
+  getUserApi,
+} from "@jellyfin/sdk/lib/utils/api";
+import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+import { useCallback, useEffect, useRef } from "react";
+import { useNetworkAwareQueryClient } from "@/hooks/useNetworkAwareQueryClient";
+import { apiAtom } from "@/providers/JellyfinProvider";
+import { type Settings, useSettings } from "@/utils/atoms/settings";
+import {
+  ORIGINAL_LANGUAGE,
+  supportsOriginalAudioLanguage,
+} from "@/utils/jellyfin/serverVersion";
+
+/**
+ * The settings that are not really Streamyfin's own: they mirror fields of the
+ * Jellyfin user profile.
+ *
+ * Streamyfin keeps a local copy because it resolves tracks client-side — for
+ * offline downloads, on the item page before any stream is negotiated, and
+ * across three playback engines — none of which can wait on the server's
+ * PlaybackInfo answer. jellyfin-web needs no local copy because it does no
+ * selection of its own; it just renders whatever DefaultAudioStreamIndex /
+ * DefaultSubtitleStreamIndex the server computed.
+ *
+ * The local copy is therefore a cache, not a second setting, and everything
+ * that writes one of these keys must write through {@link useMediaPreferences}
+ * so the two stay in step.
+ */
+const SERVER_BACKED_KEYS = [
+  "subtitleMode",
+  "playDefaultAudioTrack",
+  "rememberAudioSelections",
+  "rememberSubtitleSelections",
+  "defaultAudioLanguage",
+  "defaultSubtitleLanguage",
+] as const;
+
+export type ServerBackedSetting = (typeof SERVER_BACKED_KEYS)[number];
+
+/**
+ * Translate a settings update into the matching `UserConfiguration` fields.
+ *
+ * Only the keys actually present in the update are carried: everything else is
+ * left to the server copy the caller merges on top of. Rebuilding the whole
+ * configuration from local state would let an unrelated write clear a
+ * preference the app never had a value for.
+ */
+export function buildUserConfigurationPayload(
+  update: Partial<Settings>,
+): Partial<UserConfiguration> {
+  const configuration: Partial<UserConfiguration> = {};
+  if ("subtitleMode" in update) configuration.SubtitleMode = update.subtitleMode;
+  if ("playDefaultAudioTrack" in update)
+    configuration.PlayDefaultAudioTrack = update.playDefaultAudioTrack;
+  if ("rememberAudioSelections" in update)
+    configuration.RememberAudioSelections = update.rememberAudioSelections;
+  if ("rememberSubtitleSelections" in update)
+    configuration.RememberSubtitleSelections = update.rememberSubtitleSelections;
+  if ("defaultAudioLanguage" in update)
+    configuration.AudioLanguagePreference =
+      update.defaultAudioLanguage?.ThreeLetterISOLanguageName ?? "";
+  if ("defaultSubtitleLanguage" in update)
+    configuration.SubtitleLanguagePreference =
+      update.defaultSubtitleLanguage?.ThreeLetterISOLanguageName ?? "";
+  return configuration;
+}
+
+// Stable reference so a pending cultures query does not churn effect deps.
+const EMPTY_CULTURES: CultureDto[] = [];
+
+export interface MediaPreferences {
+  settings: Settings | null;
+  /** Writes locally *and* mirrors the change to the Jellyfin user profile. */
+  updateMediaSettings: (update: Partial<Settings>) => void;
+  user: UserDto | undefined;
+  cultures: CultureDto[];
+  /** The server is new enough to resolve the original-language audio track. */
+  supportsOriginalAudioLanguage: boolean;
+  /** Every query the audio-language controls depend on has answered. */
+  isReady: boolean;
+}
+
+/**
+ * Two-way binding between the local settings atom and the Jellyfin user
+ * profile: seeds the local copy from the server on mount, and mirrors local
+ * edits back.
+ *
+ * Shared by the mobile settings screens (via MediaProvider) and the TV settings
+ * screen, which has no provider of its own — without a single owner the two
+ * platforms drift, which is exactly how an Apple TV ends up resolving tracks
+ * from a preference the phone had already set on the server.
+ */
+export function useMediaPreferences(): MediaPreferences {
+  const { settings, updateSettings, pluginSettings } = useSettings();
+  const api = useAtomValue(apiAtom);
+  const queryClient = useNetworkAwareQueryClient();
+
+  const { data: user } = useQuery({
+    queryKey: ["authUser"],
+    queryFn: async () => {
+      if (!api) return;
+      const res = await getUserApi(api).getCurrentUser();
+      return res.data;
+    },
+    enabled: !!api,
+    staleTime: 0,
+  });
+
+  // Kept aligned with the other consumers of this key (useJellyfinServerId,
+  // the Streamystats components): same shape, same nullable contract.
+  const { data: serverInfo, isSuccess: isServerInfoAvailable } = useQuery({
+    queryKey: ["jellyfin", "serverInfo"],
+    queryFn: async (): Promise<PublicSystemInfo | null> => {
+      if (!api) return null;
+      return (await getSystemApi(api).getPublicSystemInfo()).data;
+    },
+    enabled: !!api,
+    staleTime: 43200000, // 12 hours
+  });
+  const supportsOriginalLanguage =
+    isServerInfoAvailable && supportsOriginalAudioLanguage(serverInfo?.Version);
+
+  const { data: cultures = EMPTY_CULTURES, isSuccess: areCulturesAvailable } =
+    useQuery({
+      queryKey: ["cultures"],
+      queryFn: async () => {
+        if (!api) return EMPTY_CULTURES;
+        const res = await getLocalizationApi(api).getCultures();
+        return res.data;
+      },
+      enabled: !!api,
+      staleTime: 43200000, // 12 hours
+    });
+
+  // Keyed on the queries having answered, not on the payload being non-empty:
+  // a server legitimately returning no culture would otherwise pin the audio
+  // settings in their loading state forever.
+  const isReady = !!user && isServerInfoAvailable && areCulturesAvailable;
+
+  /**
+   * Apply a partial configuration on top of the server's own copy, so
+   * preferences this client did not touch are never overwritten.
+   */
+  const updateUserConfiguration = useCallback(
+    async (
+      configuration: Partial<UserConfiguration>,
+      { invalidateItems = false }: { invalidateItems?: boolean } = {},
+    ) => {
+      if (!api || !user) return;
+      try {
+        await getUserApi(api).updateUserConfiguration({
+          userConfiguration: { ...user.Configuration, ...configuration },
+        });
+        queryClient.invalidateQueries({ queryKey: ["authUser"] });
+        if (invalidateItems) {
+          // Audio/subtitle preferences feed the server-computed
+          // DefaultAudio/SubtitleStreamIndex carried by each item's MediaSources.
+          queryClient.invalidateQueries({ queryKey: ["item"] });
+        }
+      } catch {
+        // Offline or a server that rejects the write: the local copy still
+        // applies, and the next mount re-seeds from whatever the server has.
+      }
+    },
+    [api, user, queryClient],
+  );
+
+  const updateMediaSettings = useCallback(
+    (update: Partial<Settings>) => {
+      // Admin-locked audio keys must reach neither local storage nor the server.
+      if (
+        ("defaultAudioLanguage" in update &&
+          (pluginSettings?.defaultAudioLanguage?.locked ||
+            pluginSettings?.playDefaultAudioTrack?.locked)) ||
+        ("playDefaultAudioTrack" in update &&
+          pluginSettings?.playDefaultAudioTrack?.locked)
+      ) {
+        return;
+      }
+
+      // The audio-language write depends on the cultures list and on the server
+      // version gate, so it waits for them. Every other setting, including the
+      // client-only subtitle appearance ones, stays writable meanwhile.
+      if ("defaultAudioLanguage" in update && !isReady) return;
+
+      let nextUpdate = update;
+      if ("defaultAudioLanguage" in update) {
+        const picksOriginal =
+          update.defaultAudioLanguage?.ThreeLetterISOLanguageName ===
+          ORIGINAL_LANGUAGE;
+        const clearsPreference = update.defaultAudioLanguage === null;
+        const leavesOriginal =
+          !picksOriginal &&
+          supportsOriginalLanguage &&
+          settings?.defaultAudioLanguage?.ThreeLetterISOLanguageName ===
+            ORIGINAL_LANGUAGE;
+
+        // Jellyfin short-circuits to the default-flagged stream when
+        // PlayDefaultAudioTrack is set, which defeats the original-language pick
+        // (MediaStreamSelector.GetDefaultAudioStreamIndex).
+        if (picksOriginal) {
+          nextUpdate = { ...update, playDefaultAudioTrack: false };
+        } else if (leavesOriginal && clearsPreference) {
+          // Restore the Jellyfin default only when the preference is cleared for
+          // good. Switching straight to a real language keeps the flag off, since
+          // turning it back on would send the server back to the default-flagged
+          // stream and ignore the language that was just picked.
+          nextUpdate = { ...update, playDefaultAudioTrack: true };
+        }
+      }
+
+      updateSettings(nextUpdate);
+
+      const configuration = buildUserConfigurationPayload(nextUpdate);
+      if (Object.keys(configuration).length === 0) return;
+      void updateUserConfiguration(configuration, { invalidateItems: true });
+    },
+    [
+      isReady,
+      pluginSettings?.defaultAudioLanguage?.locked,
+      pluginSettings?.playDefaultAudioTrack?.locked,
+      settings?.defaultAudioLanguage?.ThreeLetterISOLanguageName,
+      supportsOriginalLanguage,
+      updateSettings,
+      updateUserConfiguration,
+    ],
+  );
+
+  // Seed the local copy from the server profile — once per user, not once per
+  // refetch.
+  //
+  // `updateMediaSettings` invalidates ["authUser"], so every edit produces a
+  // fresh `user` object moments later. Seeding on that would write the server's
+  // value back over the change the user just made: the control flips and then
+  // snaps back, which is indistinguishable from a dead control. Seeding is a
+  // session-start concern, so it keys off the user's identity instead.
+  //
+  // The lock state is part of the key because unlocking `playDefaultAudioTrack`
+  // is what makes the original-language correction below permissible: without it
+  // an admin unlocking the key mid-session would leave the server uncorrected
+  // until the next launch.
+  const playDefaultAudioTrackLocked =
+    pluginSettings?.playDefaultAudioTrack?.locked;
+  const seededFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isReady || !user?.Id) return;
+    const seedKey = `${user.Id}:${playDefaultAudioTrackLocked ?? false}`;
+    if (seededFor.current === seedKey) return;
+    seededFor.current = seedKey;
+
+    const config = user.Configuration;
+    const userAudioPreference = config?.AudioLanguagePreference;
+    const findCulture = (code: string | null | undefined) =>
+      code
+        ? cultures.find((c) => c.ThreeLetterISOLanguageName === code)
+        : undefined;
+
+    // A server carrying both the original-language preference and
+    // PlayDefaultAudioTrack keeps falling back to the default-flagged stream.
+    // Correct it server-side, but never at the cost of the other preferences:
+    // the write below only carries that single field.
+    const correctsPlayDefaultAudioTrack =
+      supportsOriginalLanguage &&
+      userAudioPreference === ORIGINAL_LANGUAGE &&
+      config?.PlayDefaultAudioTrack === true &&
+      !playDefaultAudioTrackLocked;
+
+    // Only keys the server actually sent. Spreading an absent field in as
+    // `undefined` would blank a perfectly good local value — and a toggle whose
+    // value is `undefined` renders off and refuses to stay on.
+    const seed: Partial<Settings> = {};
+    if (config?.SubtitleLanguagePreference !== undefined) {
+      seed.defaultSubtitleLanguage = findCulture(
+        config.SubtitleLanguagePreference,
+      );
+    }
+    if (userAudioPreference !== undefined) {
+      // The original-language sentinel is not an ISO code and so is absent from
+      // the cultures list — it has to be carried through as-is.
+      seed.defaultAudioLanguage =
+        userAudioPreference === ORIGINAL_LANGUAGE && supportsOriginalLanguage
+          ? ({ ThreeLetterISOLanguageName: ORIGINAL_LANGUAGE } as CultureDto)
+          : findCulture(userAudioPreference);
+    }
+    if (config?.SubtitleMode !== undefined) {
+      seed.subtitleMode = config.SubtitleMode;
+    }
+    if (config?.PlayDefaultAudioTrack !== undefined) {
+      seed.playDefaultAudioTrack = correctsPlayDefaultAudioTrack
+        ? false
+        : config.PlayDefaultAudioTrack;
+    }
+    if (config?.RememberAudioSelections !== undefined) {
+      seed.rememberAudioSelections = config.RememberAudioSelections;
+    }
+    if (config?.RememberSubtitleSelections !== undefined) {
+      seed.rememberSubtitleSelections = config.RememberSubtitleSelections;
+    }
+
+    if (Object.keys(seed).length > 0) updateSettings(seed);
+
+    if (correctsPlayDefaultAudioTrack) {
+      void updateUserConfiguration(
+        { PlayDefaultAudioTrack: false },
+        { invalidateItems: true },
+      );
+    }
+    // updateSettings is intentionally omitted: it is recreated on every settings
+    // write, and depending on it would re-run this effect on our own writes.
+  }, [
+    user,
+    isReady,
+    cultures,
+    supportsOriginalLanguage,
+    playDefaultAudioTrackLocked,
+    updateUserConfiguration,
+  ]);
+
+  return {
+    settings,
+    updateMediaSettings,
+    user,
+    cultures,
+    supportsOriginalAudioLanguage: supportsOriginalLanguage,
+    isReady,
+  };
+}

--- a/hooks/useShuffleQueue.ts
+++ b/hooks/useShuffleQueue.ts
@@ -45,9 +45,7 @@ export const useShuffleQueue = () => {
 
       const first = items[0];
       const { mediaSource, audioIndex, subtitleIndex, bitrate } =
-        getDefaultPlaySettings(first, settings, undefined, {
-          applyLanguagePreferences: true,
-        });
+        getDefaultPlaySettings(first, settings);
 
       // The queue was just set — the chooser must not clear it.
       void playMedia(

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "doctor": "expo-doctor",
     "i18n:check": "bun scripts/check-i18n-keys.ts",
     "i18n:fix-unused": "bun scripts/check-i18n-keys.ts --fix-unused",
-    "test": "bun run typecheck && bun run lint && bun run format && bun run i18n:check && bun run doctor"
+    "test:unit": "bun test",
+    "test": "bun run typecheck && bun run test:unit && bun run lint && bun run format && bun run i18n:check && bun run doctor"
   },
   "overrides": {
     "uuid": "11.1.1"

--- a/providers/NativePlayerProvider.tsx
+++ b/providers/NativePlayerProvider.tsx
@@ -87,7 +87,6 @@ import {
   buildNativePlayerConfig,
   buildNativePlayerStrings,
   buildTrackMenus,
-  LOCAL_SUBTITLE_MENU_INDEX,
   type NativePlayerSessionSeed,
 } from "@/utils/nativePlayer/buildNativePlayerConfig";
 import {
@@ -96,6 +95,10 @@ import {
 } from "@/utils/nativePlayer/playRequest";
 import { fetchAndParseSegments, getSegmentsForItem } from "@/utils/segments";
 import { rememberSeriesTrack } from "@/utils/seriesTrackMemory";
+import {
+  isLocalSubtitleIndex,
+  localSubtitleIndex,
+} from "@/utils/subtitles/subtitleIndex";
 import { msToTicks, ticksToSeconds } from "@/utils/time";
 
 const PROGRESS_REPORT_INTERVAL = 10_000;
@@ -187,7 +190,9 @@ const rememberSeriesSelection = (
 ) => {
   const item = session.item;
   if (item?.Type !== "Episode" || !item.SeriesId) return;
-  if (jellyfinIndex === LOCAL_SUBTITLE_MENU_INDEX) return;
+  // A sidecar has no server-side stream to read a language off, so there is
+  // nothing to remember for the next episode.
+  if (isLocalSubtitleIndex(jellyfinIndex)) return;
   const streams = session.stream.mediaSource.MediaStreams;
   if (kind === "audio") {
     if (!settings?.rememberAudioSelections) return;
@@ -837,9 +842,9 @@ const NativePlayerProviderInner: React.FC<{
           mediaSource: session.stream.mediaSource,
           audioIndex: session.currentAudioIndex,
           // While the local sidecar is active no server stream (nor "Off")
-          // may show a checkmark — the sentinel matches nothing.
+          // may show a checkmark — a sidecar index matches no server row.
           subtitleIndex: session.localSubtitle?.active
-            ? LOCAL_SUBTITLE_MENU_INDEX
+            ? localSubtitleIndex(0)
             : session.currentSubtitleIndex,
           offline: session.offline,
           downloadedItem: session.downloadedItem,
@@ -931,7 +936,7 @@ const NativePlayerProviderInner: React.FC<{
       jellyfinIndex: number,
       positionSec: number,
     ) => {
-      if (jellyfinIndex === LOCAL_SUBTITLE_MENU_INDEX) {
+      if (isLocalSubtitleIndex(jellyfinIndex)) {
         // Re-activating the client-side sidecar — an mpv-only selection.
         if (session.localSubtitle) {
           session.localSubtitle.active = true;

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -275,6 +275,7 @@
         "audio_language": "Ljudspråk",
         "audio_hint": "Välj ett standardspråk för ljud.",
         "none": "Inga",
+        "original_language": "Originalspråk",
         "language": "Språk",
         "transcode_mode": {
           "title": "Omkodning av ljud",

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -15,6 +15,11 @@ import * as ScreenOrientation from "@/packages/expo-screen-orientation";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { writeInfoLog } from "@/utils/log";
 import { storage } from "../mmkv";
+import {
+  type AppliedPluginDefaults,
+  pendingPluginDefaults,
+  resolveEffectiveSettings,
+} from "./settingsOverrides";
 
 const _STREAMYFIN_PLUGIN_ID = "1e9e5d386e6746158719e98a5c34f004";
 const STREAMYFIN_PLUGIN_SETTINGS = "STREAMYFIN_PLUGIN_SETTINGS";
@@ -555,8 +560,15 @@ export const pluginSettingsAtom = atom<PluginLockableSettings | undefined>(
   loadPluginSettings(),
 );
 
-const hasMeaningfulSettingValue = (value: unknown) =>
-  value !== undefined && value !== null && value !== "";
+const PLUGIN_APPLIED_DEFAULTS = "STREAMYFIN_PLUGIN_APPLIED_DEFAULTS";
+
+const loadAppliedPluginDefaults = (): AppliedPluginDefaults => {
+  try {
+    return storage.get<AppliedPluginDefaults>(PLUGIN_APPLIED_DEFAULTS) ?? {};
+  } catch {
+    return {};
+  }
+};
 
 export const useSettings = () => {
   const api = useAtomValue(apiAtom);
@@ -591,19 +603,34 @@ export const useSettings = () => {
     );
     setPluginSettings(newPluginSettings);
 
-    // Locked/unlocked values are handled by the settings memo, which
-    // applies locked values at runtime without overwriting user storage.
-    // We only handle auto-enabling Streamystats here.
+    // Locked values are pinned at read time by resolveEffectiveSettings and
+    // never written to storage. Unlocked values are only the admin's *default*,
+    // so they are seeded into storage once here — after which the setting
+    // behaves like any other and the user's choice sticks.
     if (newPluginSettings && _settings) {
+      const applied = loadAppliedPluginDefaults();
+      const pending = pendingPluginDefaults(
+        newPluginSettings,
+        applied,
+        normalizePluginValue,
+      );
+
       const streamyStatsUrl = newPluginSettings.streamyStatsServerUrl;
-      if (streamyStatsUrl?.value && _settings.searchEngine !== "Streamystats") {
+      const enableStreamystats =
+        streamyStatsUrl?.value && _settings.searchEngine !== "Streamystats";
+
+      if (Object.keys(pending).length > 0 || enableStreamystats) {
         const newSettings = {
           ...defaultValues,
           ..._settings,
-          searchEngine: "Streamystats",
+          ...pending,
+          ...(enableStreamystats ? { searchEngine: "Streamystats" } : {}),
         } as Settings;
         setSettings(newSettings);
         saveSettings(newSettings);
+        if (Object.keys(pending).length > 0) {
+          storage.setAny(PLUGIN_APPLIED_DEFAULTS, { ...applied, ...pending });
+        }
       }
     }
 
@@ -640,50 +667,16 @@ export const useSettings = () => {
     }
   };
 
-  // We do not want to save over users pre-existing settings in case admin ever removes/unlocks a setting.
-  // If admin sets locked to false but provides a value,
-  // use persisted settings first, then app defaults, and only fallback on the
-  // plugin value when neither provides a meaningful value.
-  const settings: Settings = useMemo(() => {
-    const overrideSettings = Object.entries(pluginSettings ?? {}).reduce<
-      Partial<Settings>
-    >((acc, [key, setting]) => {
-      if (setting) {
-        let { value } = setting;
-        const { locked } = setting;
-        const settingsKey = key as keyof Settings;
-
-        // Normalize object-typed settings from plugin (plain primitive → { key, value })
-        value = normalizePluginValue(settingsKey, value);
-
-        // When unlocked, keep the user's value only if they explicitly diverged
-        // from the app default. Otherwise the plugin value is the admin's
-        // default and must win over the hardcoded app default — e.g. a toggle
-        // that was always locked then unlocked should reflect the plugin
-        // default, not the app's `false`. Object-typed settings compare by
-        // reference, so their behaviour is unchanged.
-        const userValue = _settings?.[settingsKey];
-        const userDiverged =
-          hasMeaningfulSettingValue(userValue) &&
-          userValue !== defaultValues[settingsKey];
-
-        (acc as any)[settingsKey] = locked
-          ? value
-          : userDiverged
-            ? userValue
-            : hasMeaningfulSettingValue(value)
-              ? value
-              : defaultValues[settingsKey];
-      }
-      return acc;
-    }, {});
-
-    return {
-      ...defaultValues,
-      ..._settings,
-      ...overrideSettings,
-    };
-  }, [_settings, pluginSettings]);
+  const settings: Settings = useMemo(
+    () =>
+      resolveEffectiveSettings(
+        _settings,
+        pluginSettings,
+        defaultValues,
+        normalizePluginValue,
+      ),
+    [_settings, pluginSettings],
+  );
 
   return {
     settings,

--- a/utils/atoms/settingsOverrides.test.ts
+++ b/utils/atoms/settingsOverrides.test.ts
@@ -63,6 +63,55 @@ describe("resolveEffectiveSettings", () => {
     );
     expect(effective.rememberSubtitleSelections).toBe(true);
   });
+
+  test("an unlocked plugin value fills a key the user has nothing for", () => {
+    // Regression: the Streamystats watchlists tab is gated on
+    // streamyStatsServerUrl, which only the plugin supplies. Requiring a plugin
+    // refresh to seed it first made the tab vanish after a reload.
+    const effective = resolveEffectiveSettings(
+      {},
+      plugin({
+        streamyStatsServerUrl: {
+          locked: false,
+          value: "https://stats.example",
+        },
+      }),
+      defaults,
+      identity,
+    );
+    expect((effective as Record<string, unknown>).streamyStatsServerUrl).toBe(
+      "https://stats.example",
+    );
+  });
+
+  test("a user's own value still beats the unlocked fallback", () => {
+    const effective = resolveEffectiveSettings(
+      { streamyStatsServerUrl: "https://mine.example" } as Partial<Settings>,
+      plugin({
+        streamyStatsServerUrl: {
+          locked: false,
+          value: "https://admin.example",
+        },
+      }),
+      defaults,
+      identity,
+    );
+    expect((effective as Record<string, unknown>).streamyStatsServerUrl).toBe(
+      "https://mine.example",
+    );
+  });
+
+  test("false counts as a value, so the fallback cannot re-enable a toggle", () => {
+    // The original bug in one line: a stored `false` must not be read as
+    // "nothing here" and replaced by the plugin's `true`.
+    const effective = resolveEffectiveSettings(
+      { rememberAudioSelections: false },
+      plugin({ rememberAudioSelections: { locked: false, value: true } }),
+      defaults,
+      identity,
+    );
+    expect(effective.rememberAudioSelections).toBe(false);
+  });
 });
 
 describe("pendingPluginDefaults", () => {

--- a/utils/atoms/settingsOverrides.test.ts
+++ b/utils/atoms/settingsOverrides.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import type { PluginLockableSettings, Settings } from "./settings";
+import {
+  pendingPluginDefaults,
+  resolveEffectiveSettings,
+} from "./settingsOverrides";
+
+const defaults = {
+  rememberAudioSelections: true,
+  rememberSubtitleSelections: true,
+  subtitlesOnMute: false,
+} as unknown as Settings;
+
+const plugin = (
+  entries: Record<string, { locked: boolean; value: unknown }>,
+): PluginLockableSettings => entries as unknown as PluginLockableSettings;
+
+/** The real normalizer only reshapes object-typed settings; identity is enough here. */
+const identity = (_key: keyof Settings, value: unknown) => value;
+
+describe("resolveEffectiveSettings", () => {
+  test("an unlocked plugin value never overrides the stored value", () => {
+    // The regression this rule exists for: the plugin shipped
+    // rememberAudioSelections=false unlocked while the app default was true.
+    // The old read-time override pinned it, so the toggle showed off, pressing
+    // it wrote the value already in storage, and the write was dropped as a
+    // no-op — an unlocked setting that could never be changed.
+    const effective = resolveEffectiveSettings(
+      { rememberAudioSelections: true },
+      plugin({ rememberAudioSelections: { locked: false, value: false } }),
+      defaults,
+      identity,
+    );
+    expect(effective.rememberAudioSelections).toBe(true);
+  });
+
+  test("a locked plugin value wins over the stored value", () => {
+    const effective = resolveEffectiveSettings(
+      { rememberAudioSelections: true },
+      plugin({ rememberAudioSelections: { locked: true, value: false } }),
+      defaults,
+      identity,
+    );
+    expect(effective.rememberAudioSelections).toBe(false);
+  });
+
+  test("stored values win over app defaults", () => {
+    const effective = resolveEffectiveSettings(
+      { subtitlesOnMute: true },
+      undefined,
+      defaults,
+      identity,
+    );
+    expect(effective.subtitlesOnMute).toBe(true);
+  });
+
+  test("app defaults fill in keys the user never stored", () => {
+    const effective = resolveEffectiveSettings(
+      {},
+      undefined,
+      defaults,
+      identity,
+    );
+    expect(effective.rememberSubtitleSelections).toBe(true);
+  });
+});
+
+describe("pendingPluginDefaults", () => {
+  test("seeds an unlocked default that has not been applied yet", () => {
+    const pending = pendingPluginDefaults(
+      plugin({ rememberAudioSelections: { locked: false, value: false } }),
+      {},
+      identity,
+    );
+    expect(pending.rememberAudioSelections).toBe(false);
+  });
+
+  test("does not re-seed a default already applied", () => {
+    // Without this the admin default is written back on every plugin refresh,
+    // silently reverting whatever the user chose in between.
+    const pending = pendingPluginDefaults(
+      plugin({ rememberAudioSelections: { locked: false, value: false } }),
+      { rememberAudioSelections: false },
+      identity,
+    );
+    expect(pending).toEqual({});
+  });
+
+  test("re-seeds when the admin changes the default", () => {
+    const pending = pendingPluginDefaults(
+      plugin({ rememberAudioSelections: { locked: false, value: true } }),
+      { rememberAudioSelections: false },
+      identity,
+    );
+    expect(pending.rememberAudioSelections).toBe(true);
+  });
+
+  test("compares object-typed values structurally, not by reference", () => {
+    // normalize rebuilds { key, value } objects on every call, so reference
+    // equality would re-seed defaultBitrate on every refresh forever.
+    const pending = pendingPluginDefaults(
+      plugin({
+        defaultBitrate: { locked: false, value: { key: "Max", value: 0 } },
+      }),
+      { defaultBitrate: { key: "Max", value: 0 } },
+      identity,
+    );
+    expect(pending).toEqual({});
+  });
+
+  test("ignores locked keys — those are pinned at read time, never stored", () => {
+    const pending = pendingPluginDefaults(
+      plugin({ rememberAudioSelections: { locked: true, value: false } }),
+      {},
+      identity,
+    );
+    expect(pending).toEqual({});
+  });
+
+  test("ignores values with nothing meaningful in them", () => {
+    const pending = pendingPluginDefaults(
+      plugin({
+        rememberAudioSelections: { locked: false, value: undefined },
+        rememberSubtitleSelections: { locked: false, value: "" },
+      }),
+      {},
+      identity,
+    );
+    expect(pending).toEqual({});
+  });
+});

--- a/utils/atoms/settingsOverrides.ts
+++ b/utils/atoms/settingsOverrides.ts
@@ -1,0 +1,78 @@
+/**
+ * How admin (Streamyfin plugin) settings combine with the user's own.
+ *
+ * The rule, in one line: **locked pins a value, unlocked only supplies a
+ * default.** An unlocked setting is one the admin left the user free to change,
+ * so it may seed storage once and must never win at read time.
+ *
+ * Kept free of runtime imports (types only) so the policy is unit-testable
+ * without dragging in i18n, the settings atom or React.
+ */
+import type { PluginLockableSettings, Settings } from "./settings";
+
+export type AppliedPluginDefaults = Partial<Record<keyof Settings, unknown>>;
+
+/** Coerce a raw plugin value into the shape a given setting expects. */
+export type NormalizePluginValue = (
+  key: keyof Settings,
+  value: unknown,
+) => unknown;
+
+export const hasMeaningfulSettingValue = (value: unknown): boolean =>
+  value !== undefined && value !== null && value !== "";
+
+/**
+ * Effective settings = app defaults, then the user's stored values, then any
+ * admin-**locked** plugin values pinned on top.
+ *
+ * Unlocked plugin values are deliberately absent. They used to be applied here,
+ * guarded by a "did the user diverge from the app default" heuristic — but
+ * `updateSettings` backfills every default into storage on the first write, so
+ * that heuristic could not tell "the user chose this" from "never touched". Any
+ * setting whose plugin value differed from the app default became permanently
+ * unchangeable despite being unlocked: the displayed value came from the
+ * plugin, so pressing a toggle wrote the value already in storage, and the
+ * write was discarded as a no-op.
+ */
+export const resolveEffectiveSettings = (
+  raw: Partial<Settings> | null,
+  plugin: PluginLockableSettings | undefined,
+  defaults: Settings,
+  normalize: NormalizePluginValue,
+): Settings => {
+  const lockedOverrides: Record<string, unknown> = {};
+  for (const [key, setting] of Object.entries(plugin ?? {})) {
+    if (!setting?.locked) continue;
+    const settingsKey = key as keyof Settings;
+    lockedOverrides[key] = normalize(settingsKey, setting.value);
+  }
+  return { ...defaults, ...raw, ...lockedOverrides } as Settings;
+};
+
+/**
+ * Unlocked plugin values that still need seeding into user storage.
+ *
+ * Seeded once per distinct admin default: `applied` records what was last
+ * written, so re-running this is a no-op and a user's later change is never
+ * reverted — while an admin *changing* the default does propagate.
+ */
+export const pendingPluginDefaults = (
+  plugin: PluginLockableSettings | undefined,
+  applied: AppliedPluginDefaults,
+  normalize: NormalizePluginValue,
+): Partial<Settings> => {
+  const pending: Record<string, unknown> = {};
+  for (const [key, setting] of Object.entries(plugin ?? {})) {
+    if (!setting || setting.locked) continue;
+    const settingsKey = key as keyof Settings;
+    const value = normalize(settingsKey, setting.value);
+    if (!hasMeaningfulSettingValue(value)) continue;
+    // Structural compare: object-typed settings ({ key, value }) are rebuilt by
+    // normalize on every call, so reference equality would re-seed forever.
+    if (JSON.stringify(applied[settingsKey]) === JSON.stringify(value)) {
+      continue;
+    }
+    pending[key] = value;
+  }
+  return pending as Partial<Settings>;
+};

--- a/utils/atoms/settingsOverrides.ts
+++ b/utils/atoms/settingsOverrides.ts
@@ -22,17 +22,27 @@ export const hasMeaningfulSettingValue = (value: unknown): boolean =>
   value !== undefined && value !== null && value !== "";
 
 /**
- * Effective settings = app defaults, then the user's stored values, then any
- * admin-**locked** plugin values pinned on top.
+ * Effective settings, in precedence order:
  *
- * Unlocked plugin values are deliberately absent. They used to be applied here,
- * guarded by a "did the user diverge from the app default" heuristic — but
- * `updateSettings` backfills every default into storage on the first write, so
- * that heuristic could not tell "the user chose this" from "never touched". Any
- * setting whose plugin value differed from the app default became permanently
- * unchangeable despite being unlocked: the displayed value came from the
- * plugin, so pressing a toggle wrote the value already in storage, and the
- * write was discarded as a no-op.
+ *   app defaults → unlocked plugin values (fallback only) → the user's stored
+ *   values → admin-**locked** plugin values (pinned on top)
+ *
+ * An unlocked plugin value may only *fill a gap*. It applies when the user has
+ * nothing meaningful of their own for that key — an admin-supplied server URL
+ * has to work before the user has ever touched it — but it must never win over
+ * a value the user holds, or the setting is unlocked in name only.
+ *
+ * The rule used to be "unlocked wins unless the user diverged from the app
+ * default", which could not work: `updateSettings` backfills every default into
+ * storage on the first write, so it could not tell "the user chose this" from
+ * "never touched". Any setting whose plugin value differed from the app default
+ * became permanently unchangeable — the displayed value came from the plugin,
+ * so pressing a toggle wrote the value already in storage and the write was
+ * discarded as a no-op.
+ *
+ * Briefly it was "unlocked never applies at read time", which broke the other
+ * way: a plugin-supplied value was invisible until a plugin refresh seeded it,
+ * so the Streamystats watchlists tab disappeared after a reload.
  */
 export const resolveEffectiveSettings = (
   raw: Partial<Settings> | null,
@@ -40,13 +50,26 @@ export const resolveEffectiveSettings = (
   defaults: Settings,
   normalize: NormalizePluginValue,
 ): Settings => {
+  const merged = { ...defaults, ...raw } as Record<string, unknown>;
+  const unlockedFallbacks: Record<string, unknown> = {};
   const lockedOverrides: Record<string, unknown> = {};
+
   for (const [key, setting] of Object.entries(plugin ?? {})) {
-    if (!setting?.locked) continue;
+    if (!setting) continue;
     const settingsKey = key as keyof Settings;
-    lockedOverrides[key] = normalize(settingsKey, setting.value);
+    const value = normalize(settingsKey, setting.value);
+
+    if (setting.locked) {
+      lockedOverrides[key] = value;
+    } else if (
+      !hasMeaningfulSettingValue(merged[key]) &&
+      hasMeaningfulSettingValue(value)
+    ) {
+      unlockedFallbacks[key] = value;
+    }
   }
-  return { ...defaults, ...raw, ...lockedOverrides } as Settings;
+
+  return { ...merged, ...unlockedFallbacks, ...lockedOverrides } as Settings;
 };
 
 /**

--- a/utils/jellyfin/getDefaultPlaySettings.test.ts
+++ b/utils/jellyfin/getDefaultPlaySettings.test.ts
@@ -213,6 +213,42 @@ describe("subtitle mode", () => {
     );
     expect(result.subtitleIndex).toBe(0);
   });
+
+  test("Smart disables subtitles when 639-1 audio (sv) matches 639-2/T subtitle preference (swe)", () => {
+    const svAudioStreams = [sub(0, "swe"), audio(1, "sv")];
+    const result = getDefaultPlaySettings(
+      episode(source(svAudioStreams, { audio: 1 })),
+      settingsWith({
+        subtitleMode: "Smart" as never,
+        defaultSubtitleLanguage: lang("swe"),
+      }),
+    );
+    expect(result.subtitleIndex).toBe(-1);
+  });
+
+  test("Smart disables subtitles when 639-2/B audio (ger) matches 639-2/T subtitle preference (deu)", () => {
+    const gerAudioStreams = [sub(0, "deu"), audio(1, "ger")];
+    const result = getDefaultPlaySettings(
+      episode(source(gerAudioStreams, { audio: 1 })),
+      settingsWith({
+        subtitleMode: "Smart" as never,
+        defaultSubtitleLanguage: lang("deu"),
+      }),
+    );
+    expect(result.subtitleIndex).toBe(-1);
+  });
+
+  test("Smart does not disable subtitles for Swahili (swa) audio when subtitle preference is Swedish (swe)", () => {
+    const swaAudioStreams = [sub(0, "swe"), audio(1, "swa")];
+    const result = getDefaultPlaySettings(
+      episode(source(swaAudioStreams, { audio: 1 })),
+      settingsWith({
+        subtitleMode: "Smart" as never,
+        defaultSubtitleLanguage: lang("swe"),
+      }),
+    );
+    expect(result.subtitleIndex).toBe(0);
+  });
 });
 
 describe("precedence", () => {

--- a/utils/jellyfin/getDefaultPlaySettings.test.ts
+++ b/utils/jellyfin/getDefaultPlaySettings.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+  BaseItemDto,
+  MediaSourceInfo,
+  MediaStream,
+} from "@jellyfin/sdk/lib/generated-client";
+import type { Settings } from "@/utils/atoms/settings";
+
+// react-native-mmkv needs a native module. Back it with a Map so the per-series
+// memory under test is exercised for real rather than stubbed out.
+const store = new Map<string, string>();
+mock.module("react-native-mmkv", () => ({
+  createMMKV: () => ({
+    getString: (key: string) => store.get(key),
+    set: (key: string, value: string) => void store.set(key, value),
+    delete: (key: string) => void store.delete(key),
+  }),
+}));
+
+// BitrateSelector is a React component module; only the BITRATES table matters.
+mock.module("@/components/BitrateSelector", () => ({
+  BITRATES: [{ key: "Max", value: undefined }],
+}));
+
+// Imported after the mocks are registered — static ESM imports would evaluate
+// the real modules first.
+const { getDefaultPlaySettings } = await import("./getDefaultPlaySettings");
+const { rememberSeriesTrack } = await import("@/utils/seriesTrackMemory");
+
+const audio = (
+  index: number,
+  language: string,
+  extra: Partial<MediaStream> = {},
+): MediaStream => ({
+  Type: "Audio",
+  Index: index,
+  Language: language,
+  ...extra,
+});
+
+const sub = (
+  index: number,
+  language: string,
+  extra: Partial<MediaStream> = {},
+): MediaStream => ({
+  Type: "Subtitle",
+  Index: index,
+  Language: language,
+  ...extra,
+});
+
+const source = (
+  streams: MediaStream[],
+  defaults: { audio?: number; subtitle?: number } = {},
+): MediaSourceInfo => ({
+  Id: "src-1",
+  MediaStreams: streams,
+  DefaultAudioStreamIndex: defaults.audio,
+  DefaultSubtitleStreamIndex: defaults.subtitle,
+});
+
+const episode = (mediaSource: MediaSourceInfo): BaseItemDto => ({
+  Id: "ep-1",
+  Type: "Episode",
+  SeriesId: "series-1",
+  MediaSources: [mediaSource],
+});
+
+const settingsWith = (patch: Partial<Settings>): Settings =>
+  ({
+    rememberAudioSelections: true,
+    rememberSubtitleSelections: true,
+    ...patch,
+  }) as Settings;
+
+const lang = (code: string) => ({ ThreeLetterISOLanguageName: code }) as never;
+
+beforeEach(() => store.clear());
+
+describe("language preferences apply on every path", () => {
+  // Regression: this block used to be gated behind an `applyLanguagePreferences`
+  // option that the item pages passed and every TV / native-player next-episode
+  // handler forgot, so advancing an episode on Apple TV kept the server's
+  // default track while the same show on the phone resolved correctly.
+  test("subtitle preference is honoured with no options argument", () => {
+    const item = episode(
+      source([sub(0, "tur"), sub(1, "eng")], { subtitle: 0 }),
+    );
+    const result = getDefaultPlaySettings(
+      item,
+      settingsWith({ defaultSubtitleLanguage: lang("eng") }),
+    );
+    expect(result.subtitleIndex).toBe(1);
+  });
+
+  test("audio preference is honoured with no options argument", () => {
+    const item = episode(
+      source([audio(0, "tur"), audio(1, "eng")], { audio: 0 }),
+    );
+    const result = getDefaultPlaySettings(
+      item,
+      settingsWith({ defaultAudioLanguage: lang("eng") }),
+    );
+    expect(result.audioIndex).toBe(1);
+  });
+
+  test("no preference set leaves the server defaults untouched", () => {
+    // Making the block unconditional must be a no-op for users who never
+    // configured a language, or it would silently re-pick everyone's tracks.
+    const item = episode(
+      source([sub(0, "tur"), sub(1, "eng")], { subtitle: 0 }),
+    );
+    const result = getDefaultPlaySettings(item, settingsWith({}));
+    expect(result.subtitleIndex).toBe(0);
+  });
+});
+
+describe("findTrackByLanguage — ISO 639 variants", () => {
+  test("matches a 639-2/B stream against a 639-2/T preference", () => {
+    // CultureDto gives .NET-style /T ("deu"); streams are tagged /B ("ger").
+    // Plain string equality never matched, so German preferences did nothing.
+    const item = episode(source([sub(0, "tur"), sub(1, "ger")]));
+    const result = getDefaultPlaySettings(
+      item,
+      settingsWith({ defaultSubtitleLanguage: lang("deu") }),
+    );
+    expect(result.subtitleIndex).toBe(1);
+  });
+
+  test("matches a 639-1 stream against a 639-2 preference", () => {
+    const item = episode(source([sub(0, "tur"), sub(1, "sv")]));
+    const result = getDefaultPlaySettings(
+      item,
+      settingsWith({ defaultSubtitleLanguage: lang("swe") }),
+    );
+    expect(result.subtitleIndex).toBe(1);
+  });
+
+  test("does not match Swahili for a Swedish preference", () => {
+    // The old `substring(0, 2)` fallback turned "swe" into "sw" — Swahili.
+    const item = episode(
+      source([sub(0, "swa"), sub(1, "sw")], { subtitle: -1 }),
+    );
+    const result = getDefaultPlaySettings(
+      item,
+      settingsWith({ defaultSubtitleLanguage: lang("swe") }),
+    );
+    expect(result.subtitleIndex).toBe(-1);
+  });
+
+  test("prefers the default track when several share the language", () => {
+    const item = episode(
+      source([sub(0, "eng"), sub(1, "eng", { IsDefault: true })]),
+    );
+    const result = getDefaultPlaySettings(
+      item,
+      settingsWith({ defaultSubtitleLanguage: lang("eng") }),
+    );
+    expect(result.subtitleIndex).toBe(1);
+  });
+});
+
+describe("subtitle mode", () => {
+  const streams = [
+    sub(0, "eng"),
+    sub(1, "swe", { IsForced: true }),
+    sub(2, "swe"),
+    audio(3, "eng"),
+  ];
+
+  test("None disables subtitles even with a preference set", () => {
+    const result = getDefaultPlaySettings(
+      episode(source(streams, { subtitle: 0 })),
+      settingsWith({
+        subtitleMode: "None" as never,
+        defaultSubtitleLanguage: lang("swe"),
+      }),
+    );
+    expect(result.subtitleIndex).toBe(-1);
+  });
+
+  test("OnlyForced picks the forced track in the preferred language", () => {
+    const result = getDefaultPlaySettings(
+      episode(source(streams)),
+      settingsWith({
+        subtitleMode: "OnlyForced" as never,
+        defaultSubtitleLanguage: lang("swe"),
+      }),
+    );
+    expect(result.subtitleIndex).toBe(1);
+  });
+
+  test("Smart disables subtitles when audio already matches the preference", () => {
+    const result = getDefaultPlaySettings(
+      episode(source(streams, { audio: 3 })),
+      settingsWith({
+        subtitleMode: "Smart" as never,
+        defaultSubtitleLanguage: lang("eng"),
+        defaultAudioLanguage: lang("eng"),
+      }),
+    );
+    expect(result.subtitleIndex).toBe(-1);
+  });
+
+  test("Smart enables subtitles when audio is a different language", () => {
+    const jpAudio = [sub(0, "eng"), audio(1, "jpn")];
+    const result = getDefaultPlaySettings(
+      episode(source(jpAudio, { audio: 1 })),
+      settingsWith({
+        subtitleMode: "Smart" as never,
+        defaultSubtitleLanguage: lang("eng"),
+      }),
+    );
+    expect(result.subtitleIndex).toBe(0);
+  });
+});
+
+describe("precedence", () => {
+  test("previous-episode carry-over beats the language preference", () => {
+    // The ranker match is the freshest signal — a deliberate pick on the last
+    // episode must not be overwritten by a standing preference. The new episode
+    // numbers its tracks differently, which is the whole reason the ranker
+    // exists rather than a plain index carry-over.
+    const prev = source([sub(0, "eng"), sub(1, "tur")]);
+    const item = episode(source([sub(0, "fre"), sub(1, "eng"), sub(2, "tur")]));
+    const result = getDefaultPlaySettings(
+      item,
+      settingsWith({ defaultSubtitleLanguage: lang("eng") }),
+      { indexes: { subtitleIndex: 1 }, source: prev },
+    );
+    expect(result.subtitleIndex).toBe(2);
+  });
+
+  test("series memory beats the language preference", () => {
+    rememberSeriesTrack("series-1", { subtitleLang: "tur" });
+    const item = episode(source([sub(0, "eng"), sub(1, "tur")]));
+    const result = getDefaultPlaySettings(
+      item,
+      settingsWith({ defaultSubtitleLanguage: lang("eng") }),
+    );
+    expect(result.subtitleIndex).toBe(1);
+  });
+
+  test("a remembered 'off' survives the language preference", () => {
+    rememberSeriesTrack("series-1", { subtitleLang: "off" });
+    const item = episode(source([sub(0, "eng")], { subtitle: 0 }));
+    const result = getDefaultPlaySettings(
+      item,
+      settingsWith({ defaultSubtitleLanguage: lang("eng") }),
+    );
+    expect(result.subtitleIndex).toBe(-1);
+  });
+
+  test("series memory is ignored when the toggle is off", () => {
+    rememberSeriesTrack("series-1", { subtitleLang: "tur" });
+    const item = episode(source([sub(0, "eng"), sub(1, "tur")]));
+    const result = getDefaultPlaySettings(
+      item,
+      settingsWith({
+        rememberSubtitleSelections: false,
+        defaultSubtitleLanguage: lang("eng"),
+      }),
+    );
+    expect(result.subtitleIndex).toBe(0);
+  });
+});

--- a/utils/jellyfin/getDefaultPlaySettings.ts
+++ b/utils/jellyfin/getDefaultPlaySettings.ts
@@ -16,6 +16,7 @@ import type {
 } from "@jellyfin/sdk/lib/generated-client";
 import { SubtitlePlaybackMode } from "@jellyfin/sdk/lib/generated-client";
 import { BITRATES } from "@/components/BitrateSelector";
+import { langEq } from "@/utils/jellyfin/subtitleUtils";
 import { getSeriesTrackMemory } from "@/utils/seriesTrackMemory";
 import { type Settings } from "../atoms/settings";
 import {
@@ -38,19 +39,17 @@ export interface PreviousIndexes {
   subtitleIndex?: number;
 }
 
-export interface PlaySettingsOptions {
-  /** Apply language preferences from settings (used on TV) */
-  applyLanguagePreferences?: boolean;
-}
-
 /**
  * Find a track by language code.
  *
- * @param streams - Available media streams
- * @param languageCode - ISO 639-2 three-letter language code (e.g., "eng", "swe")
- * @param streamType - Type of stream to search ("Audio" or "Subtitle")
+ * Comparison goes through {@link langEq} rather than string equality: the stored
+ * preference is a Jellyfin CultureDto code (.NET-style 639-2/T — "deu", "fra",
+ * "swe") while MediaStreams carry 639-2/B ("ger", "fre") or bare 639-1 ("de",
+ * "sv"). The previous `substring(0, 2)` fallback was not a language mapping at
+ * all — it turned "swe" into "sw", which is Swahili, so a Swedish preference
+ * matched Swahili tracks and missed "sv"-tagged Swedish ones.
+ *
  * @param forcedOnly - If true, only match forced subtitles
- * @returns The stream index if found, undefined otherwise
  */
 function findTrackByLanguage(
   streams: MediaStream[],
@@ -63,12 +62,7 @@ function findTrackByLanguage(
   const candidates = streams.filter((s) => {
     if (s.Type !== streamType) return false;
     if (forcedOnly && !s.IsForced) return false;
-    // Match on ThreeLetterISOLanguageName (ISO 639-2)
-    return (
-      s.Language?.toLowerCase() === languageCode.toLowerCase() ||
-      // Fallback: some Jellyfin servers use two-letter codes in Language field
-      s.Language?.toLowerCase() === languageCode.substring(0, 2).toLowerCase()
-    );
+    return langEq(s.Language, languageCode);
   });
 
   // Prefer default track if multiple match
@@ -169,13 +163,11 @@ function applySubtitleMode(
  * @param item - The media item to play
  * @param settings - User settings (language preferences, bitrate, etc.)
  * @param previous - Optional previous track selections to carry over (for sequential play)
- * @param options - Optional flags to control behavior (e.g., applyLanguagePreferences for TV)
  */
 export function getDefaultPlaySettings(
   item: BaseItemDto | null | undefined,
   settings: Settings | null,
   previous?: { indexes?: PreviousIndexes; source?: MediaSourceInfo },
-  options?: PlaySettingsOptions,
 ): PlaySettings {
   const bitrate = settings?.defaultBitrate ?? BITRATES[0];
 
@@ -281,8 +273,20 @@ export function getDefaultPlaySettings(
     }
   }
 
-  // Apply language preferences when enabled (TV) and no previous selection matched
-  if (options?.applyLanguagePreferences && settings) {
+  // Language preferences + subtitle mode, applied on every path.
+  //
+  // This used to be opt-in per caller, and the callers disagreed: the item pages
+  // and the mobile next-episode handler passed the flag while every TV and
+  // native-player next-episode handler did not. The result was that advancing an
+  // episode on Apple TV kept the *server's* DefaultSubtitleStreamIndex — which
+  // comes from the server-side user profile, a different setting the user likely
+  // never touched — and could land on a track in an unrelated language while the
+  // same show on the phone resolved correctly.
+  //
+  // Unconditional is safe: with no preference set and subtitleMode Default, both
+  // blocks below are no-ops, so only users who configured a preference see any
+  // change. The carry-over still wins where it matched (the matched* guards).
+  if (settings) {
     const preferredAudioLanguage =
       settings.defaultAudioLanguage?.ThreeLetterISOLanguageName ?? undefined;
     // The original-language preference is not an ISO code: the server already

--- a/utils/jellyfin/getDefaultPlaySettings.ts
+++ b/utils/jellyfin/getDefaultPlaySettings.ts
@@ -124,14 +124,8 @@ function applySubtitleMode(
     case SubtitlePlaybackMode.Smart: {
       // Enable subtitles only when audio language differs from subtitle preference
       if (audioLanguage && subtitleLanguageCode) {
-        const audioLang = audioLanguage.toLowerCase();
-        const subLang = subtitleLanguageCode.toLowerCase();
         // If audio matches subtitle preference, disable subtitles
-        if (
-          audioLang === subLang ||
-          audioLang.startsWith(subLang.substring(0, 2)) ||
-          subLang.startsWith(audioLang.substring(0, 2))
-        ) {
+        if (langEq(audioLanguage, subtitleLanguageCode)) {
           return -1;
         }
       }

--- a/utils/jellyfin/subtitleUtils.ts
+++ b/utils/jellyfin/subtitleUtils.ts
@@ -359,13 +359,21 @@ const LANG_CANONICAL: Record<string, string> = {
 };
 
 /** Canonicalize a language tag: lowercase, primary subtag ("en-US" → "en"), 639-2/B. */
-const canonicalLang = (raw: string): string => {
+export const canonicalLang = (raw: string): string => {
   const primary = raw.trim().toLowerCase().split("-")[0];
   return LANG_CANONICAL[primary] ?? primary;
 };
 
-/** Language-tag comparison across ISO 639-1 / 639-2 B/T / IETF variants. */
-const langEq = (a?: string | null, b?: string | null): boolean =>
+/**
+ * Language-tag comparison across ISO 639-1 / 639-2 B/T / IETF variants.
+ *
+ * Exported because track *selection* needs the same comparison as track
+ * *identity*: the user's stored preference comes from Jellyfin's CultureDto,
+ * which carries .NET-style 639-2/T codes ("deu", "fra"), while MediaStreams are
+ * tagged 639-2/B ("ger", "fre"). Anything comparing those two by string
+ * equality — or by truncating to two letters — silently never matches.
+ */
+export const langEq = (a?: string | null, b?: string | null): boolean =>
   !!a && !!b && canonicalLang(a) === canonicalLang(b);
 
 /** Match an embedded player track to a Jellyfin stream by language/title (codec-agnostic). */

--- a/utils/jellyfin/userConfiguration.test.ts
+++ b/utils/jellyfin/userConfiguration.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import type { Settings } from "@/utils/atoms/settings";
+
+import { buildUserConfigurationPayload } from "@/utils/jellyfin/userConfiguration";
+
+const culture = (code: string) =>
+  ({ ThreeLetterISOLanguageName: code }) as never;
+
+const settings = {
+  subtitleMode: "Smart",
+  playDefaultAudioTrack: true,
+  rememberAudioSelections: true,
+  rememberSubtitleSelections: true,
+  defaultAudioLanguage: culture("eng"),
+  defaultSubtitleLanguage: culture("swe"),
+} as unknown as Settings;
+
+describe("buildUserConfigurationPayload", () => {
+  test("carries an updated language through", () => {
+    const payload = buildUserConfigurationPayload(
+      { defaultSubtitleLanguage: culture("ger") },
+      settings,
+    );
+    expect(payload.SubtitleLanguagePreference).toBe("ger");
+  });
+
+  test("keeps the current value for keys not being updated", () => {
+    // Every write sends all six fields, so an omitted key must fall back to what
+    // the user already has — not to empty, which would clear it server-side.
+    const payload = buildUserConfigurationPayload(
+      { subtitleMode: "None" as never },
+      settings,
+    );
+    expect(payload.AudioLanguagePreference).toBe("eng");
+    expect(payload.SubtitleLanguagePreference).toBe("swe");
+    expect(payload.RememberAudioSelections).toBe(true);
+  });
+
+  test("clears a language when it is explicitly set to null", () => {
+    // "No preference" is the picker's first row. It arrives as null and must be
+    // sent as "" — undefined would fall through to the current value and make
+    // the choice impossible to express.
+    const payload = buildUserConfigurationPayload(
+      { defaultSubtitleLanguage: null },
+      settings,
+    );
+    expect(payload.SubtitleLanguagePreference).toBe("");
+    expect(payload.AudioLanguagePreference).toBe("eng");
+  });
+
+  test("preserves an explicit false rather than treating it as unset", () => {
+    // `??` not `||`: turning a remember toggle off must survive the round trip.
+    const payload = buildUserConfigurationPayload(
+      { rememberAudioSelections: false },
+      settings,
+    );
+    expect(payload.RememberAudioSelections).toBe(false);
+    expect(payload.RememberSubtitleSelections).toBe(true);
+  });
+
+  test("sends empty strings when nothing is set anywhere", () => {
+    const payload = buildUserConfigurationPayload({}, {} as Settings);
+    expect(payload.AudioLanguagePreference).toBe("");
+    expect(payload.SubtitleLanguagePreference).toBe("");
+  });
+
+  test("tolerates a null settings object", () => {
+    const payload = buildUserConfigurationPayload(
+      { defaultAudioLanguage: culture("jpn") },
+      null,
+    );
+    expect(payload.AudioLanguagePreference).toBe("jpn");
+    expect(payload.SubtitleLanguagePreference).toBe("");
+  });
+});

--- a/utils/jellyfin/userConfiguration.test.ts
+++ b/utils/jellyfin/userConfiguration.test.ts
@@ -1,75 +1,56 @@
 import { describe, expect, test } from "bun:test";
-import type { Settings } from "@/utils/atoms/settings";
 
 import { buildUserConfigurationPayload } from "@/utils/jellyfin/userConfiguration";
 
 const culture = (code: string) =>
   ({ ThreeLetterISOLanguageName: code }) as never;
 
-const settings = {
-  subtitleMode: "Smart",
-  playDefaultAudioTrack: true,
-  rememberAudioSelections: true,
-  rememberSubtitleSelections: true,
-  defaultAudioLanguage: culture("eng"),
-  defaultSubtitleLanguage: culture("swe"),
-} as unknown as Settings;
-
 describe("buildUserConfigurationPayload", () => {
   test("carries an updated language through", () => {
-    const payload = buildUserConfigurationPayload(
-      { defaultSubtitleLanguage: culture("ger") },
-      settings,
-    );
+    const payload = buildUserConfigurationPayload({
+      defaultSubtitleLanguage: culture("ger"),
+    });
     expect(payload.SubtitleLanguagePreference).toBe("ger");
+    expect(payload.AudioLanguagePreference).toBeUndefined();
   });
 
-  test("keeps the current value for keys not being updated", () => {
-    // Every write sends all six fields, so an omitted key must fall back to what
-    // the user already has — not to empty, which would clear it server-side.
-    const payload = buildUserConfigurationPayload(
-      { subtitleMode: "None" as never },
-      settings,
-    );
-    expect(payload.AudioLanguagePreference).toBe("eng");
-    expect(payload.SubtitleLanguagePreference).toBe("swe");
-    expect(payload.RememberAudioSelections).toBe(true);
+  test("only emits keys present in update", () => {
+    // Only keys in update are sent, so spreading onto user.Configuration keeps
+    // existing server preferences intact (e.g. before local seeding completes).
+    const payload = buildUserConfigurationPayload({
+      subtitleMode: "None" as never,
+    });
+    expect(payload.SubtitleMode).toBe("None");
+    expect(payload.AudioLanguagePreference).toBeUndefined();
+    expect(payload.SubtitleLanguagePreference).toBeUndefined();
+    expect(payload.RememberAudioSelections).toBeUndefined();
   });
 
   test("clears a language when it is explicitly set to null", () => {
     // "No preference" is the picker's first row. It arrives as null and must be
-    // sent as "" — undefined would fall through to the current value and make
-    // the choice impossible to express.
-    const payload = buildUserConfigurationPayload(
-      { defaultSubtitleLanguage: null },
-      settings,
-    );
+    // sent as "" — undefined would omit it from payload and keep the old value.
+    const payload = buildUserConfigurationPayload({
+      defaultSubtitleLanguage: null,
+    });
     expect(payload.SubtitleLanguagePreference).toBe("");
-    expect(payload.AudioLanguagePreference).toBe("eng");
+    expect(payload.AudioLanguagePreference).toBeUndefined();
   });
 
   test("preserves an explicit false rather than treating it as unset", () => {
-    // `??` not `||`: turning a remember toggle off must survive the round trip.
-    const payload = buildUserConfigurationPayload(
-      { rememberAudioSelections: false },
-      settings,
-    );
+    const payload = buildUserConfigurationPayload({
+      rememberAudioSelections: false,
+    });
     expect(payload.RememberAudioSelections).toBe(false);
-    expect(payload.RememberSubtitleSelections).toBe(true);
+    expect(payload.RememberSubtitleSelections).toBeUndefined();
   });
 
-  test("sends empty strings when nothing is set anywhere", () => {
-    const payload = buildUserConfigurationPayload({}, {} as Settings);
-    expect(payload.AudioLanguagePreference).toBe("");
-    expect(payload.SubtitleLanguagePreference).toBe("");
-  });
+  test("emits an empty payload when update is empty or contains no mirrored keys", () => {
+    const emptyPayload = buildUserConfigurationPayload({});
+    expect(emptyPayload).toEqual({});
 
-  test("tolerates a null settings object", () => {
-    const payload = buildUserConfigurationPayload(
-      { defaultAudioLanguage: culture("jpn") },
-      null,
-    );
-    expect(payload.AudioLanguagePreference).toBe("jpn");
-    expect(payload.SubtitleLanguagePreference).toBe("");
+    const unmirroredPayload = buildUserConfigurationPayload({
+      preferedLanguage: "en",
+    } as never);
+    expect(unmirroredPayload).toEqual({});
   });
 });

--- a/utils/jellyfin/userConfiguration.ts
+++ b/utils/jellyfin/userConfiguration.ts
@@ -12,41 +12,45 @@ import type { Settings } from "@/utils/atoms/settings";
  * Translate a Streamyfin settings patch into a Jellyfin user-configuration
  * patch.
  *
- * Every write sends all six mirrored fields, so a key absent from `update`
- * falls back to the user's current value rather than being cleared. The one
- * exception is an explicit `null` language — the picker's "None" row — which
- * must be sent as `""`; letting it fall through would make "no preference"
- * impossible to express.
+ * Only fields present in `update` are emitted in the payload. Omitted keys
+ * are left out so spreading the payload onto `user.Configuration` preserves
+ * existing server values — avoiding wiping preferences if an edit occurs
+ * before local seeding completes.
+ *
+ * An explicit `null` language (the picker's "None" row) is mapped to `""`
+ * to clear the preference on the server.
  */
 export function buildUserConfigurationPayload(
   update: Partial<Settings>,
-  settings: Settings | null,
 ): Partial<UserConfiguration> {
-  const payload: Partial<UserConfiguration> = {
-    SubtitleMode: update?.subtitleMode ?? settings?.subtitleMode,
-    PlayDefaultAudioTrack:
-      update?.playDefaultAudioTrack ?? settings?.playDefaultAudioTrack,
-    // `??` not `||`: turning a remember toggle off must survive the round trip.
-    RememberAudioSelections:
-      update?.rememberAudioSelections ?? settings?.rememberAudioSelections,
-    RememberSubtitleSelections:
-      update?.rememberSubtitleSelections ??
-      settings?.rememberSubtitleSelections,
-  };
+  const payload: Partial<UserConfiguration> = {};
 
-  payload.AudioLanguagePreference =
-    update?.defaultAudioLanguage === null
-      ? ""
-      : update?.defaultAudioLanguage?.ThreeLetterISOLanguageName ||
-        settings?.defaultAudioLanguage?.ThreeLetterISOLanguageName ||
-        "";
+  if (update?.subtitleMode !== undefined) {
+    payload.SubtitleMode = update.subtitleMode;
+  }
+  if (update?.playDefaultAudioTrack !== undefined) {
+    payload.PlayDefaultAudioTrack = update.playDefaultAudioTrack;
+  }
+  if (update?.rememberAudioSelections !== undefined) {
+    payload.RememberAudioSelections = update.rememberAudioSelections;
+  }
+  if (update?.rememberSubtitleSelections !== undefined) {
+    payload.RememberSubtitleSelections = update.rememberSubtitleSelections;
+  }
 
-  payload.SubtitleLanguagePreference =
-    update?.defaultSubtitleLanguage === null
-      ? ""
-      : update?.defaultSubtitleLanguage?.ThreeLetterISOLanguageName ||
-        settings?.defaultSubtitleLanguage?.ThreeLetterISOLanguageName ||
-        "";
+  if (update?.defaultAudioLanguage !== undefined) {
+    payload.AudioLanguagePreference =
+      update.defaultAudioLanguage === null
+        ? ""
+        : (update.defaultAudioLanguage?.ThreeLetterISOLanguageName ?? "");
+  }
+
+  if (update?.defaultSubtitleLanguage !== undefined) {
+    payload.SubtitleLanguagePreference =
+      update.defaultSubtitleLanguage === null
+        ? ""
+        : (update.defaultSubtitleLanguage?.ThreeLetterISOLanguageName ?? "");
+  }
 
   return payload;
 }

--- a/utils/jellyfin/userConfiguration.ts
+++ b/utils/jellyfin/userConfiguration.ts
@@ -1,0 +1,52 @@
+/**
+ * Mapping between Streamyfin's local settings and the Jellyfin user profile.
+ *
+ * Types-only imports so the mapping is unit-testable: the hook that uses it
+ * pulls in the Jellyfin SDK, react-query and jotai, which is more than a test
+ * runner can load.
+ */
+import type { UserConfiguration } from "@jellyfin/sdk/lib/generated-client/models";
+import type { Settings } from "@/utils/atoms/settings";
+
+/**
+ * Translate a Streamyfin settings patch into a Jellyfin user-configuration
+ * patch.
+ *
+ * Every write sends all six mirrored fields, so a key absent from `update`
+ * falls back to the user's current value rather than being cleared. The one
+ * exception is an explicit `null` language — the picker's "None" row — which
+ * must be sent as `""`; letting it fall through would make "no preference"
+ * impossible to express.
+ */
+export function buildUserConfigurationPayload(
+  update: Partial<Settings>,
+  settings: Settings | null,
+): Partial<UserConfiguration> {
+  const payload: Partial<UserConfiguration> = {
+    SubtitleMode: update?.subtitleMode ?? settings?.subtitleMode,
+    PlayDefaultAudioTrack:
+      update?.playDefaultAudioTrack ?? settings?.playDefaultAudioTrack,
+    // `??` not `||`: turning a remember toggle off must survive the round trip.
+    RememberAudioSelections:
+      update?.rememberAudioSelections ?? settings?.rememberAudioSelections,
+    RememberSubtitleSelections:
+      update?.rememberSubtitleSelections ??
+      settings?.rememberSubtitleSelections,
+  };
+
+  payload.AudioLanguagePreference =
+    update?.defaultAudioLanguage === null
+      ? ""
+      : update?.defaultAudioLanguage?.ThreeLetterISOLanguageName ||
+        settings?.defaultAudioLanguage?.ThreeLetterISOLanguageName ||
+        "";
+
+  payload.SubtitleLanguagePreference =
+    update?.defaultSubtitleLanguage === null
+      ? ""
+      : update?.defaultSubtitleLanguage?.ThreeLetterISOLanguageName ||
+        settings?.defaultSubtitleLanguage?.ThreeLetterISOLanguageName ||
+        "";
+
+  return payload;
+}

--- a/utils/nativePlayer/buildNativePlayerConfig.ts
+++ b/utils/nativePlayer/buildNativePlayerConfig.ts
@@ -44,6 +44,7 @@ import {
 import { ticksToSeconds } from "@/utils/time";
 import { getTrickplayInfo } from "@/utils/trickplay";
 import type { PlayRequest } from "./playRequest";
+import { resolveTrackIndexes } from "./resolveTrackIndexes";
 
 export interface NativePlayerStreamSeed {
   url: string;
@@ -404,10 +405,22 @@ export async function buildNativePlayerConfig(params: {
   if (!item?.Id) return null;
 
   const startTicks = resolveStartTicks(req.playbackPositionTicks, item);
-  const audioIndex =
-    req.audioIndex ??
-    (offline ? downloadedItem?.userData?.audioStreamIndex : undefined);
-  const subtitleIndex = req.subtitleIndex ?? -1;
+  // Callers that already resolved tracks (the item pages) pass them in; the
+  // ones that can't — top shelf, WebSocket Play commands, any bare
+  // playMedia({ itemId }) — would otherwise fall through to the server's
+  // defaults, silently bypassing the per-series memory and the language
+  // preferences. Offline, the download record outranks any such resolution.
+  const { audioIndex, subtitleIndex } = resolveTrackIndexes({
+    item,
+    settings,
+    offline,
+    downloaded: downloadedItem?.userData,
+    requested: {
+      audioIndex: req.audioIndex,
+      subtitleIndex: req.subtitleIndex,
+      mediaSourceId: req.mediaSourceId,
+    },
+  });
   const bitrateValue = req.bitrateValue ?? BITRATES[0].value;
 
   // 2. Stream (offline: local file; online: PlaybackInfo negotiation with the

--- a/utils/nativePlayer/buildNativePlayerConfig.ts
+++ b/utils/nativePlayer/buildNativePlayerConfig.ts
@@ -31,14 +31,16 @@ import {
   parseTranscodeReasons,
 } from "@/utils/jellyfin/playMethod";
 import {
-  compareTracksForMenu,
   getExternalSubtitleUrl,
   getMpvAudioId,
-  isImageBasedSubtitle,
 } from "@/utils/jellyfin/subtitleUtils";
 import { COMMON_SUBTITLE_LANGUAGES } from "@/utils/opensubtitles/api";
 import { generateDeviceProfile } from "@/utils/profiles/native";
-import { localSubtitleIndex } from "@/utils/subtitles/subtitleIndex";
+import {
+  buildAudioMenu,
+  buildSubtitleMenu,
+  type TrackMenuRow,
+} from "@/utils/subtitles/trackMenu";
 import { ticksToSeconds } from "@/utils/time";
 import { getTrickplayInfo } from "@/utils/trickplay";
 import type { PlayRequest } from "./playRequest";
@@ -263,18 +265,17 @@ const ISO_639_2_T_TO_B: Record<string, string> = {
 };
 
 /**
- * The native session carries at most one client-side sidecar at a time
- * (`session.localSubtitle` is singular), so it always occupies position 0 of the
- * shared sidecar block. Encoded rather than hard-coded so a second sidecar can
- * be added later without inventing another sentinel.
- */
-const NATIVE_LOCAL_SUBTITLE_INDEX = localSubtitleIndex(0);
-
-/**
  * Menu display models for the native track menus. Selection stays in JS —
  * these only carry labels, Jellyfin indices and the requiresReload flag
  * (burned-in subtitle / audio-under-transcode → stream re-negotiation).
  */
+/** Native menu labels: DisplayTitle, else language, else the raw index. */
+const nativeLabel = (s: {
+  DisplayTitle?: string | null;
+  Language?: string | null;
+  Index?: number | null;
+}) => s.DisplayTitle ?? s.Language ?? `#${s.Index}`;
+
 export const buildTrackMenus = (options: {
   mediaSource: MediaSourceInfo;
   audioIndex: number | undefined;
@@ -290,46 +291,42 @@ export const buildTrackMenus = (options: {
   const isTranscoding = Boolean(options.mediaSource.TranscodingUrl);
   const streams = options.mediaSource.MediaStreams ?? [];
 
-  const subtitleItems: NativePlayerTrackMenuItem[] = [
-    {
-      label: options.offLabel,
-      jellyfinIndex: -1,
-      selected: options.subtitleIndex === -1,
-    },
-    ...streams
-      .filter((s) => s.Type === "Subtitle")
-      .sort(compareTracksForMenu)
-      .map((s) => ({
-        label: s.DisplayTitle ?? s.Language ?? `#${s.Index}`,
-        jellyfinIndex: s.Index ?? -1,
-        selected: s.Index === options.subtitleIndex,
-        // Burned-in image subs are pixels, not tracks: switching to (or away
-        // from) one while transcoding re-processes the stream server-side.
-        requiresReload: isTranscoding && isImageBasedSubtitle(s),
-      })),
-  ];
-  if (options.localSubtitle) {
-    subtitleItems.push({
-      label: options.localSubtitle.label,
-      jellyfinIndex: NATIVE_LOCAL_SUBTITLE_INDEX,
-      selected: options.localSubtitle.selected,
-    });
-  }
-
   // A transcoded stream (and a transcoded download) only carries the audio
   // track that was encoded into it — other tracks require re-negotiation
   // (online) or simply don't exist (offline download).
   const offlineTranscoded =
     options.offline && options.downloadedItem?.userData?.isTranscoded === true;
-  const audioItems: NativePlayerTrackMenuItem[] = streams
-    .filter((s) => s.Type === "Audio")
-    .filter((s) => !offlineTranscoded || s.Index === options.audioIndex)
-    .map((s) => ({
-      label: s.DisplayTitle ?? s.Language ?? `#${s.Index}`,
-      jellyfinIndex: s.Index ?? -1,
-      selected: s.Index === options.audioIndex,
-      requiresReload: isTranscoding,
-    }));
+
+  const toMenuItem = (row: TrackMenuRow): NativePlayerTrackMenuItem => ({
+    label: row.label,
+    jellyfinIndex: row.index,
+    selected: row.selected,
+    requiresReload: row.requiresReload,
+  });
+
+  const subtitleItems: NativePlayerTrackMenuItem[] = buildSubtitleMenu(
+    streams,
+    {
+      selectedIndex: options.subtitleIndex,
+      offLabel: options.offLabel,
+      isTranscoding,
+      formatLabel: nativeLabel,
+      localSubs: options.localSubtitle
+        ? // The native session carries at most one sidecar, so it always occupies
+          // position 0 of the shared block. The path is unused here — selection
+          // comes back over the bridge as an index and the coordinator owns the
+          // file — so an empty string keeps the row shape honest.
+          [{ name: options.localSubtitle.label, filePath: "" }]
+        : undefined,
+    },
+  ).map(toMenuItem);
+
+  const audioItems: NativePlayerTrackMenuItem[] = buildAudioMenu(streams, {
+    selectedIndex: options.audioIndex,
+    isTranscoding,
+    offlineTranscoded,
+    formatLabel: nativeLabel,
+  }).map(toMenuItem);
 
   // Quality/bitrate menu (JS DropdownView parity): online only; changing it
   // always re-negotiates the stream, so every entry is requiresReload.

--- a/utils/nativePlayer/buildNativePlayerConfig.ts
+++ b/utils/nativePlayer/buildNativePlayerConfig.ts
@@ -11,7 +11,6 @@ import { BITRATES } from "@/components/BitrateSelector";
 import type {
   NativePlayerConfig,
   NativePlayerStrings,
-  NativePlayerSubtitleStyle,
   NativePlayerTrackMenuItem,
   NativePlayerTrackMenus,
   NativePlayerTrickplay,
@@ -36,6 +35,7 @@ import {
 } from "@/utils/jellyfin/subtitleUtils";
 import { COMMON_SUBTITLE_LANGUAGES } from "@/utils/opensubtitles/api";
 import { generateDeviceProfile } from "@/utils/profiles/native";
+import { buildSubtitleStyle } from "@/utils/subtitles/subtitleStyle";
 import {
   buildAudioMenu,
   buildSubtitleMenu,
@@ -146,31 +146,6 @@ const mapOrientationLock = (
       // video playback defaults to landscape like the JS player route.
       return "landscape";
   }
-};
-
-/** Mirror of the subtitle-style effect at direct-player.tsx (mpvSubtitle*). */
-const buildSubtitleStyle = (settings: Settings): NativePlayerSubtitleStyle => {
-  const style: NativePlayerSubtitleStyle = {
-    scale: settings.mpvSubtitleScale,
-    marginY: settings.mpvSubtitleMarginY,
-    alignX: settings.mpvSubtitleAlignX,
-    alignY: settings.mpvSubtitleAlignY,
-  };
-  if (settings.mpvSubtitleBackgroundEnabled) {
-    const opacity = settings.mpvSubtitleBackgroundOpacity ?? 75;
-    const alphaHex = Math.round((opacity / 100) * 255)
-      .toString(16)
-      .padStart(2, "0")
-      .toUpperCase();
-    style.borderStyle = "background-box";
-    style.backgroundColor = `#000000${alphaHex}`;
-    style.assOverride = "force";
-  } else {
-    style.borderStyle = "outline-and-shadow";
-    style.backgroundColor = "#00000000";
-    style.assOverride = "no";
-  }
-  return style;
 };
 
 /** Mirror of hooks/usePlaybackSpeed.ts (media > series > default). */

--- a/utils/nativePlayer/buildNativePlayerConfig.ts
+++ b/utils/nativePlayer/buildNativePlayerConfig.ts
@@ -38,6 +38,7 @@ import {
 } from "@/utils/jellyfin/subtitleUtils";
 import { COMMON_SUBTITLE_LANGUAGES } from "@/utils/opensubtitles/api";
 import { generateDeviceProfile } from "@/utils/profiles/native";
+import { localSubtitleIndex } from "@/utils/subtitles/subtitleIndex";
 import { ticksToSeconds } from "@/utils/time";
 import { getTrickplayInfo } from "@/utils/trickplay";
 import type { PlayRequest } from "./playRequest";
@@ -262,12 +263,12 @@ const ISO_639_2_T_TO_B: Record<string, string> = {
 };
 
 /**
- * Sentinel jellyfinIndex for a client-side downloaded sidecar subtitle
- * (OpenSubtitles fallback). It exists only on the mpv handle, not in the
- * Jellyfin media source — the coordinator maps this index back to the local
- * file instead of a server stream.
+ * The native session carries at most one client-side sidecar at a time
+ * (`session.localSubtitle` is singular), so it always occupies position 0 of the
+ * shared sidecar block. Encoded rather than hard-coded so a second sidecar can
+ * be added later without inventing another sentinel.
  */
-export const LOCAL_SUBTITLE_MENU_INDEX = -1000;
+const NATIVE_LOCAL_SUBTITLE_INDEX = localSubtitleIndex(0);
 
 /**
  * Menu display models for the native track menus. Selection stays in JS —
@@ -310,7 +311,7 @@ export const buildTrackMenus = (options: {
   if (options.localSubtitle) {
     subtitleItems.push({
       label: options.localSubtitle.label,
-      jellyfinIndex: LOCAL_SUBTITLE_MENU_INDEX,
+      jellyfinIndex: NATIVE_LOCAL_SUBTITLE_INDEX,
       selected: options.localSubtitle.selected,
     });
   }

--- a/utils/nativePlayer/resolveTrackIndexes.test.ts
+++ b/utils/nativePlayer/resolveTrackIndexes.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+  BaseItemDto,
+  MediaStream,
+} from "@jellyfin/sdk/lib/generated-client";
+import type { Settings } from "@/utils/atoms/settings";
+
+const store = new Map<string, string>();
+mock.module("react-native-mmkv", () => ({
+  createMMKV: () => ({
+    getString: (k: string) => store.get(k),
+    set: (k: string, v: string) => void store.set(k, v),
+    delete: (k: string) => void store.delete(k),
+  }),
+}));
+mock.module("@/components/BitrateSelector", () => ({
+  BITRATES: [{ key: "Max", value: undefined }],
+}));
+
+const { resolveTrackIndexes } = await import("./resolveTrackIndexes");
+
+const stream = (
+  type: "Audio" | "Subtitle",
+  index: number,
+  language?: string,
+): MediaStream => ({ Type: type, Index: index, Language: language });
+
+const item = (
+  sources: { id: string; streams: MediaStream[]; defaultSub?: number }[],
+): BaseItemDto => ({
+  Id: "i1",
+  Type: "Movie",
+  MediaSources: sources.map((s) => ({
+    Id: s.id,
+    MediaStreams: s.streams,
+    DefaultSubtitleStreamIndex: s.defaultSub,
+  })),
+});
+
+const settings = {} as Settings;
+
+const simple = item([
+  {
+    id: "src-1",
+    streams: [stream("Audio", 1, "eng"), stream("Subtitle", 2, "eng")],
+    defaultSub: 2,
+  },
+]);
+
+beforeEach(() => store.clear());
+
+describe("offline", () => {
+  test("uses the download record rather than the server media source", () => {
+    // The regression this exists for: a downloaded item started with no
+    // subtitle regardless of what was chosen at download time, because the
+    // record was never consulted.
+    const result = resolveTrackIndexes({
+      item: simple,
+      settings,
+      offline: true,
+      downloaded: { audioStreamIndex: 3, subtitleStreamIndex: 4 },
+      requested: {},
+    });
+    expect(result).toEqual({ audioIndex: 3, subtitleIndex: 4 });
+  });
+
+  test("honours a download that pinned no subtitle", () => {
+    const result = resolveTrackIndexes({
+      item: simple,
+      settings,
+      offline: true,
+      downloaded: { audioStreamIndex: 1, subtitleStreamIndex: -1 },
+      requested: {},
+    });
+    expect(result.subtitleIndex).toBe(-1);
+  });
+
+  test("never resolves against the server source offline", () => {
+    // A transcoded download holds a subset of streams; the server's default
+    // could name one the local file does not contain.
+    const result = resolveTrackIndexes({
+      item: simple,
+      settings,
+      offline: true,
+      downloaded: {},
+      requested: {},
+    });
+    expect(result.subtitleIndex).toBe(-1);
+    expect(result.audioIndex).toBeUndefined();
+  });
+
+  test("an explicit request still wins over the record", () => {
+    const result = resolveTrackIndexes({
+      item: simple,
+      settings,
+      offline: true,
+      downloaded: { audioStreamIndex: 3, subtitleStreamIndex: 4 },
+      requested: { audioIndex: 9, subtitleIndex: 8 },
+    });
+    expect(result).toEqual({ audioIndex: 9, subtitleIndex: 8 });
+  });
+});
+
+describe("online", () => {
+  test("passes an explicit request straight through", () => {
+    const result = resolveTrackIndexes({
+      item: simple,
+      settings,
+      offline: false,
+      requested: { audioIndex: 1, subtitleIndex: 2 },
+    });
+    expect(result).toEqual({ audioIndex: 1, subtitleIndex: 2 });
+  });
+
+  test("resolves for a caller that supplied nothing", () => {
+    // Top shelf, WebSocket Play commands and bare playMedia({ itemId }) used to
+    // fall through to the server defaults, bypassing series memory entirely.
+    const result = resolveTrackIndexes({
+      item: simple,
+      settings,
+      offline: false,
+      requested: {},
+    });
+    expect(result.subtitleIndex).toBe(2);
+  });
+
+  test("resolves against the named media source, not always the first", () => {
+    // Stream indexes are per-source; version 1's numbering does not apply to
+    // version 2.
+    const multi = item([
+      { id: "src-1", streams: [stream("Subtitle", 2)], defaultSub: 2 },
+      { id: "src-2", streams: [stream("Subtitle", 7)], defaultSub: 7 },
+    ]);
+    const result = resolveTrackIndexes({
+      item: multi,
+      settings,
+      offline: false,
+      requested: { mediaSourceId: "src-2" },
+    });
+    expect(result.subtitleIndex).toBe(7);
+  });
+
+  test("falls back to subtitles off when nothing resolves", () => {
+    const bare = item([{ id: "src-1", streams: [] }]);
+    const result = resolveTrackIndexes({
+      item: bare,
+      settings,
+      offline: false,
+      requested: {},
+    });
+    expect(result.subtitleIndex).toBe(-1);
+  });
+});

--- a/utils/nativePlayer/resolveTrackIndexes.ts
+++ b/utils/nativePlayer/resolveTrackIndexes.ts
@@ -1,0 +1,74 @@
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
+import type { Settings } from "@/utils/atoms/settings";
+import { getDefaultPlaySettings } from "@/utils/jellyfin/getDefaultPlaySettings";
+import { SUBTITLES_OFF } from "@/utils/subtitles/subtitleIndex";
+
+/** The track indexes a download record pinned when the file was pulled down. */
+export interface DownloadedTrackIndexes {
+  audioStreamIndex?: number;
+  subtitleStreamIndex?: number;
+}
+
+/**
+ * Decide which audio/subtitle streams a playback session starts on.
+ *
+ * Precedence, highest first:
+ *  1. What the caller explicitly asked for. The item pages resolve tracks
+ *     themselves and an explicit pick must never be second-guessed.
+ *  2. Offline only: the download record. A download's track set is whatever was
+ *     pulled down, and only the record knows it — resolving against the server
+ *     media source would hand back an index for a stream the local file does
+ *     not contain (a transcoded download keeps one audio track and burns image
+ *     subs in), so the session would start on a track that cannot play.
+ *  3. A fresh resolution — series memory, then language preferences, then the
+ *     server defaults — for callers that cannot resolve: top shelf, WebSocket
+ *     Play commands, any bare playMedia({ itemId }).
+ *  4. Subtitles off.
+ */
+export function resolveTrackIndexes(params: {
+  item: BaseItemDto;
+  settings: Settings;
+  offline: boolean;
+  /** Present for offline sessions; the pinned indexes of the local file. */
+  downloaded?: DownloadedTrackIndexes | null;
+  requested: {
+    audioIndex?: number;
+    subtitleIndex?: number;
+    mediaSourceId?: string;
+  };
+}): { audioIndex: number | undefined; subtitleIndex: number } {
+  const { item, settings, offline, downloaded, requested } = params;
+
+  // getDefaultPlaySettings always reads MediaSources[0], so when the caller
+  // named a different version resolve against that one — stream indexes are
+  // per-source and version 1's numbering does not apply to version 2.
+  const requestedSource = requested.mediaSourceId
+    ? item.MediaSources?.find((s) => s.Id === requested.mediaSourceId)
+    : undefined;
+
+  // Never offline: see (2) above. The download record is the authority there,
+  // and a resolution against the server source would contradict it.
+  const needsResolve =
+    !offline &&
+    (requested.audioIndex === undefined ||
+      requested.subtitleIndex === undefined);
+
+  const resolved = needsResolve
+    ? getDefaultPlaySettings(
+        requestedSource ? { ...item, MediaSources: [requestedSource] } : item,
+        settings,
+      )
+    : null;
+
+  return {
+    audioIndex:
+      requested.audioIndex ??
+      (offline ? downloaded?.audioStreamIndex : undefined) ??
+      resolved?.audioIndex,
+    subtitleIndex:
+      requested.subtitleIndex ??
+      (offline ? downloaded?.subtitleStreamIndex : undefined) ??
+      resolved?.subtitleIndex ??
+      SUBTITLES_OFF,
+  };
+}

--- a/utils/profiles/chromecast.ts
+++ b/utils/profiles/chromecast.ts
@@ -1,4 +1,5 @@
 import type { DeviceProfile } from "@jellyfin/sdk/lib/generated-client/models";
+import { getSubtitleProfiles } from "./subtitles";
 
 export const chromecast: DeviceProfile = {
   Name: "Chromecast Video Profile",
@@ -79,14 +80,5 @@ export const chromecast: DeviceProfile = {
       MaxAudioChannels: "2",
     },
   ],
-  SubtitleProfiles: [
-    {
-      Format: "vtt",
-      Method: "Encode",
-    },
-    {
-      Format: "vtt",
-      Method: "Encode",
-    },
-  ],
+  SubtitleProfiles: getSubtitleProfiles({ target: "chromecast" }),
 };

--- a/utils/profiles/chromecasth265.ts
+++ b/utils/profiles/chromecasth265.ts
@@ -1,4 +1,5 @@
 import type { DeviceProfile } from "@jellyfin/sdk/lib/generated-client/models";
+import { getSubtitleProfiles } from "./subtitles";
 
 export const chromecasth265: DeviceProfile = {
   Name: "Chromecast Video Profile",
@@ -83,14 +84,5 @@ export const chromecasth265: DeviceProfile = {
       MaxAudioChannels: "2",
     },
   ],
-  SubtitleProfiles: [
-    {
-      Format: "vtt",
-      Method: "Encode",
-    },
-    {
-      Format: "vtt",
-      Method: "Encode",
-    },
-  ],
+  SubtitleProfiles: getSubtitleProfiles({ target: "chromecast" }),
 };

--- a/utils/profiles/download.ts
+++ b/utils/profiles/download.ts
@@ -3,45 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import type {
-  DeviceProfile,
-  SubtitleProfile,
-} from "@jellyfin/sdk/lib/generated-client/models";
+import type { DeviceProfile } from "@jellyfin/sdk/lib/generated-client/models";
 import { type AudioTranscodeModeType, generateDeviceProfile } from "./native";
-
-/**
- * Download-specific subtitle profiles.
- * These are more permissive than streaming profiles since we can embed subtitles.
- */
-const downloadSubtitleProfiles: SubtitleProfile[] = [
-  // Official formats
-  { Format: "vtt", Method: "Encode" },
-  { Format: "webvtt", Method: "Encode" },
-  { Format: "srt", Method: "Encode" },
-  { Format: "subrip", Method: "Encode" },
-  { Format: "ttml", Method: "Encode" },
-  { Format: "dvdsub", Method: "Encode" },
-  { Format: "ass", Method: "Encode" },
-  { Format: "idx", Method: "Encode" },
-  { Format: "pgs", Method: "Encode" },
-  { Format: "pgssub", Method: "Encode" },
-  { Format: "ssa", Method: "Encode" },
-  // Other formats
-  { Format: "microdvd", Method: "Encode" },
-  { Format: "mov_text", Method: "Encode" },
-  { Format: "mpl2", Method: "Encode" },
-  { Format: "pjs", Method: "Encode" },
-  { Format: "realtext", Method: "Encode" },
-  { Format: "scc", Method: "Encode" },
-  { Format: "smi", Method: "Encode" },
-  { Format: "stl", Method: "Encode" },
-  { Format: "sub", Method: "Encode" },
-  { Format: "subviewer", Method: "Encode" },
-  { Format: "teletext", Method: "Encode" },
-  { Format: "text", Method: "Encode" },
-  { Format: "vplayer", Method: "Encode" },
-  { Format: "xsub", Method: "Encode" },
-];
+import { getSubtitleProfiles } from "./subtitles";
 
 /**
  * Generates a device profile optimized for downloads.
@@ -60,8 +24,8 @@ export const generateDownloadProfile = (
     // Limit bitrate for downloads (20 Mbps)
     MaxStaticBitrate: 20_000_000,
     MaxStreamingBitrate: 20_000_000,
-    // Use download-specific subtitle profiles
-    SubtitleProfiles: downloadSubtitleProfiles,
+    // Use download-specific subtitle profiles (forces burn-in transcode for downloads)
+    SubtitleProfiles: getSubtitleProfiles({ target: "download" }),
     // Update transcoding profiles with download-specific settings
     TranscodingProfiles: baseProfile.TranscodingProfiles.map((profile) => {
       if (profile.Type === "Video") {

--- a/utils/profiles/native.ts
+++ b/utils/profiles/native.ts
@@ -287,12 +287,7 @@ export const generateDeviceProfile = (options: ProfileOptions = {}) => {
       ],
       // Text-only subtitles for direct play. PGS delivered as Encode
       // (burn-in) because Media3's PGS support is inconsistent.
-      SubtitleProfiles: [
-        { Format: "srt", Method: "External" },
-        { Format: "vtt", Method: "External" },
-        { Format: "ttml", Method: "External" },
-        { Format: "pgssub", Method: "Encode" },
-      ],
+      SubtitleProfiles: getSubtitleProfiles({ target: "exoplayer" }),
     } satisfies DeviceProfile;
   }
 
@@ -362,7 +357,7 @@ export const generateDeviceProfile = (options: ProfileOptions = {}) => {
         MaxAudioChannels: "2",
       },
     ],
-    SubtitleProfiles: getSubtitleProfiles(),
+    SubtitleProfiles: getSubtitleProfiles({ target: "mpv" }),
   } satisfies DeviceProfile;
 
   return profile;

--- a/utils/profiles/subtitles.test.ts
+++ b/utils/profiles/subtitles.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { getSubtitleProfiles } from "./subtitles";
+
+describe("getSubtitleProfiles", () => {
+  it("returns 52 entries for target mpv (default)", () => {
+    const profiles = getSubtitleProfiles({ target: "mpv" });
+    expect(profiles.length).toBe(52);
+
+    // Verify default call without args matches mpv
+    expect(getSubtitleProfiles()).toEqual(profiles);
+
+    // Check image sub sample
+    expect(profiles).toContainEqual({ Format: "pgs", Method: "Embed" });
+    expect(profiles).toContainEqual({ Format: "pgs", Method: "Encode" });
+
+    // Check text sub sample
+    expect(profiles).toContainEqual({ Format: "srt", Method: "Embed" });
+    expect(profiles).toContainEqual({ Format: "srt", Method: "External" });
+  });
+
+  it("returns 4 entries for target exoplayer", () => {
+    const profiles = getSubtitleProfiles({ target: "exoplayer" });
+    expect(profiles).toEqual([
+      { Format: "srt", Method: "External" },
+      { Format: "vtt", Method: "External" },
+      { Format: "ttml", Method: "External" },
+      { Format: "pgssub", Method: "Encode" },
+    ]);
+  });
+
+  it("returns 25 entries for target download (all Encode)", () => {
+    const profiles = getSubtitleProfiles({ target: "download" });
+    expect(profiles.length).toBe(25);
+    expect(profiles.every((p) => p.Method === "Encode")).toBe(true);
+    expect(profiles[0]).toEqual({ Format: "vtt", Method: "Encode" });
+  });
+
+  it("returns 1 entry for target chromecast (deduplicated vtt)", () => {
+    const profiles = getSubtitleProfiles({ target: "chromecast" });
+    expect(profiles).toEqual([{ Format: "vtt", Method: "Encode" }]);
+  });
+
+  it("returns empty array for target music", () => {
+    const profiles = getSubtitleProfiles({ target: "music" });
+    expect(profiles).toEqual([]);
+  });
+});

--- a/utils/profiles/subtitles.ts
+++ b/utils/profiles/subtitles.ts
@@ -5,6 +5,13 @@
  */
 import type { SubtitleProfile } from "@jellyfin/sdk/lib/generated-client/models";
 
+export type SubtitleProfileTarget =
+  | "mpv"
+  | "exoplayer"
+  | "download"
+  | "chromecast"
+  | "music";
+
 // Image-based formats - these need to be burned in by Jellyfin (Encode method)
 // because MPV cannot load them externally over HTTP
 const IMAGE_BASED_FORMATS = [
@@ -40,23 +47,83 @@ const TEXT_BASED_FORMATS = [
   "xsub",
 ] as const;
 
-export const getSubtitleProfiles = (): SubtitleProfile[] => {
-  const profiles: SubtitleProfile[] = [];
+// All known subtitle formats used for download profile transcode burn-in
+const DOWNLOAD_SUBTITLE_FORMATS = [
+  "vtt",
+  "webvtt",
+  "srt",
+  "subrip",
+  "ttml",
+  "dvdsub",
+  "ass",
+  "idx",
+  "pgs",
+  "pgssub",
+  "ssa",
+  "microdvd",
+  "mov_text",
+  "mpl2",
+  "pjs",
+  "realtext",
+  "scc",
+  "smi",
+  "stl",
+  "sub",
+  "subviewer",
+  "teletext",
+  "text",
+  "vplayer",
+  "xsub",
+] as const;
 
+const EXOPLAYER_SUBTITLE_PROFILES: SubtitleProfile[] = [
+  { Format: "srt", Method: "External" },
+  { Format: "vtt", Method: "External" },
+  { Format: "ttml", Method: "External" },
+  { Format: "pgssub", Method: "Encode" },
+];
+
+const CHROMECAST_SUBTITLE_PROFILES: SubtitleProfile[] = [
+  { Format: "vtt", Method: "Encode" },
+];
+
+// Note: Method "Encode" forces Jellyfin to burn subtitles into the downloaded stream.
+const DOWNLOAD_SUBTITLE_PROFILES: SubtitleProfile[] =
+  DOWNLOAD_SUBTITLE_FORMATS.map((format) => ({
+    Format: format,
+    Method: "Encode",
+  }));
+
+const buildMpvSubtitleProfiles = (): SubtitleProfile[] => {
+  const profiles: SubtitleProfile[] = [];
   // Image-based formats: Embed or Encode (burn-in), NOT External
   for (const format of IMAGE_BASED_FORMATS) {
     profiles.push({ Format: format, Method: "Embed" });
     profiles.push({ Format: format, Method: "Encode" });
   }
-
   // Text-based formats: Embed or External
   for (const format of TEXT_BASED_FORMATS) {
     profiles.push({ Format: format, Method: "Embed" });
     profiles.push({ Format: format, Method: "External" });
   }
-
   return profiles;
 };
 
-// Export for use in player filtering
-export const IMAGE_SUBTITLE_CODECS: readonly string[] = IMAGE_BASED_FORMATS;
+export const getSubtitleProfiles = (options?: {
+  target?: SubtitleProfileTarget;
+}): SubtitleProfile[] => {
+  const target = options?.target ?? "mpv";
+
+  switch (target) {
+    case "exoplayer":
+      return [...EXOPLAYER_SUBTITLE_PROFILES];
+    case "download":
+      return [...DOWNLOAD_SUBTITLE_PROFILES];
+    case "chromecast":
+      return [...CHROMECAST_SUBTITLE_PROFILES];
+    case "music":
+      return [];
+    default:
+      return buildMpvSubtitleProfiles();
+  }
+};

--- a/utils/profiles/trackplayer.ts
+++ b/utils/profiles/trackplayer.ts
@@ -11,6 +11,7 @@ import type {
 import { Platform } from "react-native";
 import MediaTypes from "../../constants/MediaTypes";
 import type { PlatformType } from "./native";
+import { getSubtitleProfiles } from "./subtitles";
 
 export interface TrackPlayerProfileOptions {
   /** Target platform */
@@ -86,7 +87,7 @@ export const generateTrackPlayerProfile = (
         MaxAudioChannels: "2",
       },
     ],
-    SubtitleProfiles: [],
+    SubtitleProfiles: getSubtitleProfiles({ target: "music" }),
   };
 };
 

--- a/utils/seriesTrackMemory.test.ts
+++ b/utils/seriesTrackMemory.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
+import type { TrackMenuRow } from "@/utils/subtitles/trackMenu";
+
+const store = new Map<string, string>();
+mock.module("react-native-mmkv", () => ({
+  createMMKV: () => ({
+    getString: (key: string) => store.get(key),
+    set: (key: string, value: string) => void store.set(key, value),
+    delete: (key: string) => void store.delete(key),
+  }),
+}));
+mock.module("@/utils/log", () => ({ writeInfoLog: () => undefined }));
+
+const { getSeriesTrackMemory, rememberSeriesTrackFromRow } = await import(
+  "./seriesTrackMemory"
+);
+
+const episode = { Id: "e1", Type: "Episode", SeriesId: "s1" } as BaseItemDto;
+const on = { rememberAudioSelections: true, rememberSubtitleSelections: true };
+
+const row = (patch: Partial<TrackMenuRow>): TrackMenuRow => ({
+  index: 1,
+  label: "row",
+  selected: false,
+  kind: "server",
+  requiresReload: false,
+  ...patch,
+});
+
+beforeEach(() => store.clear());
+
+describe("rememberSeriesTrackFromRow", () => {
+  test("stores the language carried on the row", () => {
+    // The language travels with the row precisely so this never has to consult
+    // a stream list that may have been refetched since the menu was built.
+    rememberSeriesTrackFromRow({
+      item: episode,
+      kind: "subtitle",
+      row: row({ language: "swe" }),
+      settings: on,
+    });
+    expect(getSeriesTrackMemory("s1")?.subtitleLang).toBe("swe");
+  });
+
+  test("stores an explicit off", () => {
+    rememberSeriesTrackFromRow({
+      item: episode,
+      kind: "subtitle",
+      row: row({ kind: "off", index: -1 }),
+      settings: on,
+    });
+    expect(getSeriesTrackMemory("s1")?.subtitleLang).toBe("off");
+  });
+
+  test("ignores a sidecar — it has no server-side identity", () => {
+    rememberSeriesTrackFromRow({
+      item: episode,
+      kind: "subtitle",
+      row: row({ kind: "sidecar", language: "swe" }),
+      settings: on,
+    });
+    expect(getSeriesTrackMemory("s1")).toBeUndefined();
+  });
+
+  test("ignores a burned-in row — it is inert", () => {
+    // This row's press does nothing, so it must not rewrite the preference.
+    rememberSeriesTrackFromRow({
+      item: episode,
+      kind: "subtitle",
+      row: row({ kind: "burnedIn", language: "tur" }),
+      settings: on,
+    });
+    expect(getSeriesTrackMemory("s1")).toBeUndefined();
+  });
+
+  test("stores nothing when the stream had no language", () => {
+    rememberSeriesTrackFromRow({
+      item: episode,
+      kind: "audio",
+      row: row({ language: undefined }),
+      settings: on,
+    });
+    expect(getSeriesTrackMemory("s1")).toBeUndefined();
+  });
+
+  test("respects the per-kind toggle", () => {
+    rememberSeriesTrackFromRow({
+      item: episode,
+      kind: "audio",
+      row: row({ language: "jpn" }),
+      settings: { rememberAudioSelections: false },
+    });
+    expect(getSeriesTrackMemory("s1")).toBeUndefined();
+  });
+
+  test("only remembers for episodes", () => {
+    rememberSeriesTrackFromRow({
+      item: { Id: "m1", Type: "Movie" } as BaseItemDto,
+      kind: "audio",
+      row: row({ language: "eng" }),
+      settings: on,
+    });
+    expect(getSeriesTrackMemory("s1")).toBeUndefined();
+  });
+
+  test("keeps audio and subtitle preferences independent", () => {
+    rememberSeriesTrackFromRow({
+      item: episode,
+      kind: "audio",
+      row: row({ language: "jpn" }),
+      settings: on,
+    });
+    rememberSeriesTrackFromRow({
+      item: episode,
+      kind: "subtitle",
+      row: row({ language: "eng" }),
+      settings: on,
+    });
+    expect(getSeriesTrackMemory("s1")).toMatchObject({
+      audioLang: "jpn",
+      subtitleLang: "eng",
+    });
+  });
+});

--- a/utils/seriesTrackMemory.ts
+++ b/utils/seriesTrackMemory.ts
@@ -1,4 +1,7 @@
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
+import { writeInfoLog } from "@/utils/log";
 import { storage } from "@/utils/mmkv";
+import type { TrackMenuRow } from "@/utils/subtitles/trackMenu";
 
 /**
  * Per-series audio/subtitle preference, written when a track is deliberately
@@ -33,6 +36,72 @@ export function getSeriesTrackMemory(
   seriesId: string,
 ): SeriesTrackMemory | undefined {
   return readAll()[seriesId];
+}
+
+/** The two toggles that gate writing — a subset of Settings, so callers can
+ * pass the settings object straight through. */
+export interface RememberTrackSettings {
+  rememberAudioSelections?: boolean;
+  rememberSubtitleSelections?: boolean;
+}
+
+/**
+ * Persist a deliberate track pick as the series preference.
+ *
+ * Takes the menu row the user actually pressed rather than an index plus a
+ * stream list. That difference matters: the row carries its own language, so
+ * the write cannot consult a list that was refetched since the menu was built —
+ * which is how a just-downloaded subtitle used to store nothing at all. It also
+ * makes the inert rows unrepresentable rather than something each call site has
+ * to remember to skip.
+ *
+ * Shared by every surface that lets the user choose a track. Memory only some
+ * of them write is memory the user can't trust: picking English on the details
+ * page and having the next episode come back Turkish is indistinguishable from
+ * the feature being broken.
+ */
+export function rememberSeriesTrackFromRow(options: {
+  item: BaseItemDto | null | undefined;
+  kind: "audio" | "subtitle";
+  row: Pick<TrackMenuRow, "kind" | "language">;
+  settings: RememberTrackSettings | null | undefined;
+}): void {
+  const { item, kind, row, settings } = options;
+  if (item?.Type !== "Episode" || !item.SeriesId) return;
+
+  const enabled =
+    kind === "audio"
+      ? settings?.rememberAudioSelections
+      : settings?.rememberSubtitleSelections;
+  if (!enabled) return;
+
+  // A sidecar has no server-side identity and a burned-in row is inert — there
+  // is nothing about either that the next episode could act on.
+  if (row.kind === "sidecar" || row.kind === "burnedIn") return;
+
+  if (kind === "subtitle" && row.kind === "off") {
+    rememberSeriesTrack(item.SeriesId, { subtitleLang: "off" });
+    return;
+  }
+  if (row.kind !== "server") return;
+
+  if (!row.language) {
+    // A stream with no Language tag can't be matched in the next episode
+    // (indexes don't carry over), so there is nothing worth storing. Logged
+    // because from the outside this is indistinguishable from "not saved".
+    writeInfoLog("Series track memory: stream has no language, not stored", {
+      seriesId: item.SeriesId,
+      kind,
+    });
+    return;
+  }
+
+  rememberSeriesTrack(
+    item.SeriesId,
+    kind === "audio"
+      ? { audioLang: row.language }
+      : { subtitleLang: row.language },
+  );
 }
 
 export function rememberSeriesTrack(

--- a/utils/subtitles/subtitleIndex.test.ts
+++ b/utils/subtitles/subtitleIndex.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isLocalSubtitleIndex,
+  LOCAL_SUBTITLE_INDEX_BASE,
+  localSubtitleIndex,
+  localSubtitlePosition,
+  SUBTITLES_OFF,
+  toServerSubtitleIndex,
+} from "./subtitleIndex";
+
+describe("isLocalSubtitleIndex", () => {
+  it("rejects the values that share the number space", () => {
+    // Real Jellyfin stream indexes and "off" must never be read as sidecars —
+    // this is the aliasing that made a subtitle pick persist as "off".
+    expect(isLocalSubtitleIndex(0)).toBe(false);
+    expect(isLocalSubtitleIndex(7)).toBe(false);
+    expect(isLocalSubtitleIndex(SUBTITLES_OFF)).toBe(false);
+    expect(isLocalSubtitleIndex(-99)).toBe(false);
+  });
+
+  it("accepts the sidecar block", () => {
+    expect(isLocalSubtitleIndex(LOCAL_SUBTITLE_INDEX_BASE)).toBe(true);
+    expect(isLocalSubtitleIndex(localSubtitleIndex(0))).toBe(true);
+    expect(isLocalSubtitleIndex(localSubtitleIndex(5))).toBe(true);
+  });
+
+  it("still recognises the retired -1000 native sentinel", () => {
+    // A session or route param minted before the two encodings were merged
+    // must not come back as a server stream index.
+    expect(isLocalSubtitleIndex(-1000)).toBe(true);
+  });
+
+  it("treats absent and non-numeric input as not-local", () => {
+    expect(isLocalSubtitleIndex(undefined)).toBe(false);
+    expect(isLocalSubtitleIndex(null)).toBe(false);
+    // A blank route param parses to NaN; it must fall through unchanged rather
+    // than be mistaken for a sidecar.
+    expect(isLocalSubtitleIndex(Number.NaN)).toBe(false);
+  });
+});
+
+describe("localSubtitleIndex / localSubtitlePosition", () => {
+  it("round-trips every position", () => {
+    for (const position of [0, 1, 2, 17]) {
+      expect(localSubtitlePosition(localSubtitleIndex(position))).toBe(
+        position,
+      );
+    }
+  });
+
+  it("gives each sidecar a distinct index", () => {
+    // The block exists precisely so carry-over knows *which* sidecar was
+    // showing; a single shared sentinel could not.
+    const indexes = [0, 1, 2].map(localSubtitleIndex);
+    expect(new Set(indexes).size).toBe(3);
+  });
+});
+
+describe("toServerSubtitleIndex", () => {
+  it("passes server stream indexes through", () => {
+    expect(toServerSubtitleIndex(0)).toBe(0);
+    expect(toServerSubtitleIndex(4)).toBe(4);
+    expect(toServerSubtitleIndex(SUBTITLES_OFF)).toBe(SUBTITLES_OFF);
+  });
+
+  it("maps every sidecar to off", () => {
+    // A sidecar has no server identity; re-negotiating while one shows must ask
+    // for "no subtitles" or the server picks an unrelated stream.
+    expect(toServerSubtitleIndex(localSubtitleIndex(0))).toBe(SUBTITLES_OFF);
+    expect(toServerSubtitleIndex(localSubtitleIndex(3))).toBe(SUBTITLES_OFF);
+    expect(toServerSubtitleIndex(-1000)).toBe(SUBTITLES_OFF);
+  });
+
+  it("maps absent input to off", () => {
+    expect(toServerSubtitleIndex(undefined)).toBe(SUBTITLES_OFF);
+    expect(toServerSubtitleIndex(null)).toBe(SUBTITLES_OFF);
+  });
+});

--- a/utils/subtitles/subtitleIndex.ts
+++ b/utils/subtitles/subtitleIndex.ts
@@ -1,0 +1,57 @@
+/**
+ * The one index space every subtitle surface speaks.
+ *
+ * A subtitle selection is carried as a plain number everywhere — route params,
+ * the JS↔Swift bridge, download records, the native session seed — so the space
+ * has to be total: server streams, "off", and client-side sidecars all live in
+ * it. This module owns the encoding; nothing else may hand-roll it.
+ *
+ * Lives in `utils/` rather than beside the player components because
+ * `utils/nativePlayer` needs it too, and `utils/` must not import from
+ * `components/` — that dependency is why the native config previously carried a
+ * second, incompatible sentinel of its own.
+ */
+
+/** Jellyfin's own "no subtitles" value; also what PlaybackInfo expects. */
+export const SUBTITLES_OFF = -1;
+
+/**
+ * Base of the client-side sidecar block (OpenSubtitles downloads that exist only
+ * on the live player handle, never in the Jellyfin media source).
+ *
+ * A *block* rather than a single sentinel because a session can hold more than
+ * one downloaded sidecar, and the next-episode carry-over has to know which one
+ * was showing. Chosen well below any real `MediaStream.Index` and below -1.
+ */
+export const LOCAL_SUBTITLE_INDEX_BASE = -100;
+
+/** Encode the k-th client-side sidecar of the current item. */
+export const localSubtitleIndex = (position: number): number =>
+  LOCAL_SUBTITLE_INDEX_BASE - position;
+
+/** Inverse of {@link localSubtitleIndex}. Only meaningful for local indexes. */
+export const localSubtitlePosition = (index: number): number =>
+  LOCAL_SUBTITLE_INDEX_BASE - index;
+
+/**
+ * True for a client-side sidecar selection.
+ *
+ * Open-ended (`<=`) so it also recognises the retired -1000 sentinel the native
+ * player used to emit, and so the block can grow without touching callers.
+ */
+export const isLocalSubtitleIndex = (
+  index: number | null | undefined,
+): index is number =>
+  typeof index === "number" && index <= LOCAL_SUBTITLE_INDEX_BASE;
+
+/**
+ * Map a client-side selection to what the Jellyfin stream API understands.
+ *
+ * A sidecar has no server-side identity, so re-negotiating a stream while one is
+ * showing must ask for "no subtitles" — passing the sentinel through would have
+ * the server either error or silently pick a real stream.
+ */
+export const toServerSubtitleIndex = (
+  index: number | null | undefined,
+): number =>
+  index == null || isLocalSubtitleIndex(index) ? SUBTITLES_OFF : index;

--- a/utils/subtitles/subtitleStyle.test.ts
+++ b/utils/subtitles/subtitleStyle.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import type { Settings } from "../atoms/settings";
+import {
+  applySubtitleStyle,
+  buildSubtitleStyle,
+  type SubtitleStyleTarget,
+} from "./subtitleStyle";
+
+describe("buildSubtitleStyle", () => {
+  const baseSettings = {
+    mpvSubtitleScale: 1.2,
+    mpvSubtitleMarginY: 20,
+    mpvSubtitleAlignX: "center",
+    mpvSubtitleAlignY: "bottom",
+  } as Settings;
+
+  it("calculates background alpha hex accurately at default opacity 75", () => {
+    const style = buildSubtitleStyle({
+      ...baseSettings,
+      mpvSubtitleBackgroundEnabled: true,
+      mpvSubtitleBackgroundOpacity: undefined,
+    });
+    expect(style.borderStyle).toBe("background-box");
+    expect(style.backgroundColor).toBe("#000000BF");
+    expect(style.assOverride).toBe("force");
+  });
+
+  it("calculates background alpha hex accurately at 0%, 50%, 100% opacity", () => {
+    const style0 = buildSubtitleStyle({
+      ...baseSettings,
+      mpvSubtitleBackgroundEnabled: true,
+      mpvSubtitleBackgroundOpacity: 0,
+    });
+    expect(style0.backgroundColor).toBe("#00000000");
+
+    const style50 = buildSubtitleStyle({
+      ...baseSettings,
+      mpvSubtitleBackgroundEnabled: true,
+      mpvSubtitleBackgroundOpacity: 50,
+    });
+    expect(style50.backgroundColor).toBe("#00000080");
+
+    const style100 = buildSubtitleStyle({
+      ...baseSettings,
+      mpvSubtitleBackgroundEnabled: true,
+      mpvSubtitleBackgroundOpacity: 100,
+    });
+    expect(style100.backgroundColor).toBe("#000000FF");
+  });
+
+  it("enforces 3-property invariant when background is disabled", () => {
+    const style = buildSubtitleStyle({
+      ...baseSettings,
+      mpvSubtitleBackgroundEnabled: false,
+    });
+    expect(style.borderStyle).toBe("outline-and-shadow");
+    expect(style.backgroundColor).toBe("#00000000");
+    expect(style.assOverride).toBe("no");
+  });
+
+  it("passes positional properties through", () => {
+    const style = buildSubtitleStyle(baseSettings);
+    expect(style.scale).toBe(1.2);
+    expect(style.marginY).toBe(20);
+    expect(style.alignX).toBe("center");
+    expect(style.alignY).toBe("bottom");
+  });
+});
+
+describe("applySubtitleStyle", () => {
+  it("calls player setters in expected order", async () => {
+    const calls: string[] = [];
+    const mockPlayer: SubtitleStyleTarget = {
+      setSubtitleScale: async (val) => {
+        calls.push(`scale:${val}`);
+      },
+      setSubtitleMarginY: async (val) => {
+        calls.push(`marginY:${val}`);
+      },
+      setSubtitleAlignX: async (val) => {
+        calls.push(`alignX:${val}`);
+      },
+      setSubtitleAlignY: async (val) => {
+        calls.push(`alignY:${val}`);
+      },
+      setSubtitleBorderStyle: async (val) => {
+        calls.push(`borderStyle:${val}`);
+      },
+      setSubtitleBackgroundColor: async (val) => {
+        calls.push(`backgroundColor:${val}`);
+      },
+      setSubtitleAssOverride: async (val) => {
+        calls.push(`assOverride:${val}`);
+      },
+    };
+
+    const style = buildSubtitleStyle({
+      mpvSubtitleScale: 1.0,
+      mpvSubtitleMarginY: 10,
+      mpvSubtitleAlignX: "center",
+      mpvSubtitleAlignY: "bottom",
+      mpvSubtitleBackgroundEnabled: true,
+      mpvSubtitleBackgroundOpacity: 100,
+    } as Settings);
+
+    await applySubtitleStyle(mockPlayer, style);
+
+    expect(calls).toEqual([
+      "scale:1",
+      "marginY:10",
+      "alignX:center",
+      "alignY:bottom",
+      "borderStyle:background-box",
+      "backgroundColor:#000000FF",
+      "assOverride:force",
+    ]);
+  });
+
+  it("handles null or undefined player gracefully", async () => {
+    await expect(applySubtitleStyle(null, {})).resolves.toBeUndefined();
+    await expect(applySubtitleStyle(undefined, {})).resolves.toBeUndefined();
+  });
+});

--- a/utils/subtitles/subtitleStyle.ts
+++ b/utils/subtitles/subtitleStyle.ts
@@ -1,0 +1,80 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import type { NativePlayerSubtitleStyle } from "../../modules/mpv-player/src/NativePlayerPresentation.types";
+import type { Settings } from "../atoms/settings";
+
+export interface SubtitleStyleTarget {
+  setSubtitleScale?: (scale: number) => Promise<void>;
+  setSubtitleMarginY?: (margin: number) => Promise<void>;
+  setSubtitleAlignX?: (align: "left" | "center" | "right") => Promise<void>;
+  setSubtitleAlignY?: (align: "top" | "center" | "bottom") => Promise<void>;
+  setSubtitleBorderStyle?: (
+    style: "outline-and-shadow" | "background-box",
+  ) => Promise<void>;
+  setSubtitleBackgroundColor?: (color: string) => Promise<void>;
+  setSubtitleAssOverride?: (mode: "no" | "force") => Promise<void>;
+}
+
+/**
+ * Builds a NativePlayerSubtitleStyle record from current user settings.
+ */
+export const buildSubtitleStyle = (
+  settings: Settings,
+): NativePlayerSubtitleStyle => {
+  const style: NativePlayerSubtitleStyle = {
+    scale: settings.mpvSubtitleScale,
+    marginY: settings.mpvSubtitleMarginY,
+    alignX: settings.mpvSubtitleAlignX,
+    alignY: settings.mpvSubtitleAlignY,
+  };
+  if (settings.mpvSubtitleBackgroundEnabled) {
+    const opacity = settings.mpvSubtitleBackgroundOpacity ?? 75;
+    const alphaHex = Math.round((opacity / 100) * 255)
+      .toString(16)
+      .padStart(2, "0")
+      .toUpperCase();
+    style.borderStyle = "background-box";
+    style.backgroundColor = `#000000${alphaHex}`;
+    style.assOverride = "force";
+  } else {
+    style.borderStyle = "outline-and-shadow";
+    style.backgroundColor = "#00000000";
+    style.assOverride = "no";
+  }
+  return style;
+};
+
+/**
+ * Applies a NativePlayerSubtitleStyle object imperatively to a player instance.
+ */
+export const applySubtitleStyle = async (
+  player: SubtitleStyleTarget | null | undefined,
+  style: NativePlayerSubtitleStyle,
+): Promise<void> => {
+  if (!player) return;
+
+  if (style.scale !== undefined) {
+    await player.setSubtitleScale?.(style.scale);
+  }
+  if (style.marginY !== undefined) {
+    await player.setSubtitleMarginY?.(style.marginY);
+  }
+  if (style.alignX !== undefined) {
+    await player.setSubtitleAlignX?.(style.alignX);
+  }
+  if (style.alignY !== undefined) {
+    await player.setSubtitleAlignY?.(style.alignY);
+  }
+  if (style.borderStyle !== undefined) {
+    await player.setSubtitleBorderStyle?.(style.borderStyle);
+  }
+  if (style.backgroundColor !== undefined) {
+    await player.setSubtitleBackgroundColor?.(style.backgroundColor);
+  }
+  if (style.assOverride !== undefined) {
+    await player.setSubtitleAssOverride?.(style.assOverride);
+  }
+};

--- a/utils/subtitles/trackMenu.test.ts
+++ b/utils/subtitles/trackMenu.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  MediaStream,
+  SubtitleDeliveryMethod,
+} from "@jellyfin/sdk/lib/generated-client";
+import { localSubtitleIndex, SUBTITLES_OFF } from "./subtitleIndex";
+import { buildAudioMenu, buildSubtitleMenu } from "./trackMenu";
+
+const Encode = "Encode" as SubtitleDeliveryMethod;
+
+const sub = (
+  index: number | undefined,
+  extra: Partial<MediaStream> = {},
+): MediaStream => ({
+  Type: "Subtitle",
+  Index: index,
+  IsTextSubtitleStream: true,
+  ...extra,
+});
+
+const audio = (
+  index: number | undefined,
+  extra: Partial<MediaStream> = {},
+): MediaStream => ({ Type: "Audio", Index: index, ...extra });
+
+const base = { offLabel: "Off", isTranscoding: false, selectedIndex: -1 };
+
+describe("buildSubtitleMenu", () => {
+  test("drops streams with no Index instead of aliasing them to off", () => {
+    // `?? -1` used to collapse these onto the "subtitles off" sentinel, which
+    // then persisted "off" as the series preference for a track the user picked.
+    const rows = buildSubtitleMenu(
+      [sub(undefined, { DisplayTitle: "Broken" }), sub(2, { Language: "eng" })],
+      base,
+    );
+    expect(rows.filter((r) => r.index === SUBTITLES_OFF)).toHaveLength(1);
+    expect(rows.map((r) => r.index)).toEqual([SUBTITLES_OFF, 2]);
+  });
+
+  test("always leads with the off row and marks it selected when nothing is chosen", () => {
+    const rows = buildSubtitleMenu([sub(0)], base);
+    expect(rows[0].kind).toBe("off");
+    expect(rows[0].selected).toBe(true);
+  });
+
+  test("carries the stream language onto the row", () => {
+    // The row is what a per-series memory write reads, so the language must
+    // travel with it rather than be re-derived from a possibly-stale list.
+    const rows = buildSubtitleMenu([sub(3, { Language: "swe" })], base);
+    expect(rows[1].language).toBe("swe");
+    expect(rows[1].kind).toBe("server");
+  });
+
+  test("orders like jellyfin-web: in-container first, externals last", () => {
+    const rows = buildSubtitleMenu(
+      [sub(0, { IsExternal: true }), sub(1), sub(2, { IsExternal: true })],
+      base,
+    );
+    expect(rows.map((r) => r.index)).toEqual([SUBTITLES_OFF, 1, 0, 2]);
+  });
+
+  describe("requiresReload", () => {
+    const image = sub(1, { IsTextSubtitleStream: false });
+    const text = sub(2, { Language: "eng" });
+
+    test("is false when not transcoding, whatever the codec", () => {
+      const rows = buildSubtitleMenu([image, text], {
+        ...base,
+        isTranscoding: false,
+      });
+      expect(rows.every((r) => !r.requiresReload)).toBe(true);
+    });
+
+    test("is set when switching TO an image sub under transcoding", () => {
+      const rows = buildSubtitleMenu([image, text], {
+        ...base,
+        isTranscoding: true,
+      });
+      expect(rows.find((r) => r.index === 1)?.requiresReload).toBe(true);
+      expect(rows.find((r) => r.index === 2)?.requiresReload).toBe(false);
+    });
+
+    test("is set when switching AWAY from an active image sub", () => {
+      // The rule is a function of (current, target). Checking only the target
+      // left the "turn this one off" case silently broken.
+      const rows = buildSubtitleMenu([image, text], {
+        ...base,
+        isTranscoding: true,
+        selectedIndex: 1,
+      });
+      expect(rows.find((r) => r.index === 2)?.requiresReload).toBe(true);
+      expect(rows.find((r) => r.index === SUBTITLES_OFF)?.requiresReload).toBe(
+        true,
+      );
+    });
+
+    test("treats an Encode-delivered text sub as needing a re-process", () => {
+      // The menus used to test only IsTextSubtitleStream while the resolver
+      // tested DeliveryMethod, so a text sub the server chose to burn in was
+      // offered as a cheap switch and failed.
+      const encoded = sub(5, {
+        IsTextSubtitleStream: true,
+        DeliveryMethod: Encode,
+      });
+      const rows = buildSubtitleMenu([encoded], {
+        ...base,
+        isTranscoding: true,
+      });
+      expect(rows.find((r) => r.index === 5)?.requiresReload).toBe(true);
+    });
+  });
+
+  describe("client-side sidecars", () => {
+    test("appends them after the server tracks with distinct indexes", () => {
+      const rows = buildSubtitleMenu([sub(0)], {
+        ...base,
+        localSubs: [
+          { name: "Swedish.srt", filePath: "/a.srt" },
+          { name: "English.srt", filePath: "/b.srt" },
+        ],
+      });
+      const sidecars = rows.filter((r) => r.kind === "sidecar");
+      expect(sidecars.map((r) => r.index)).toEqual([
+        localSubtitleIndex(0),
+        localSubtitleIndex(1),
+      ]);
+      expect(sidecars[0].localPath).toBe("/a.srt");
+    });
+
+    test("marks the active sidecar selected and no server row", () => {
+      const rows = buildSubtitleMenu([sub(0)], {
+        ...base,
+        selectedIndex: localSubtitleIndex(1),
+        localSubs: [
+          { name: "a", filePath: "/a.srt" },
+          { name: "b", filePath: "/b.srt" },
+        ],
+      });
+      expect(rows.filter((r) => r.selected)).toHaveLength(1);
+      expect(rows.find((r) => r.selected)?.localPath).toBe("/b.srt");
+    });
+
+    test("never marks a sidecar as needing a re-process", () => {
+      // It exists only on the player handle; the server cannot re-negotiate it.
+      const rows = buildSubtitleMenu([sub(0)], {
+        ...base,
+        isTranscoding: true,
+        localSubs: [{ name: "a", filePath: "/a.srt" }],
+      });
+      expect(rows.find((r) => r.kind === "sidecar")?.requiresReload).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("offline transcoded downloads", () => {
+    test("shows only the burned-in row when an image sub was baked in", () => {
+      const rows = buildSubtitleMenu(
+        [
+          sub(1, { IsTextSubtitleStream: false, DisplayTitle: "Swedish" }),
+          sub(2),
+        ],
+        { ...base, offlineTranscoded: { burnedInIndex: 1 } },
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].kind).toBe("burnedIn");
+      expect(rows[0].label).toBe("Swedish (burned in)");
+      expect(rows[0].selected).toBe(true);
+    });
+
+    test("keeps text subs switchable and drops image subs otherwise", () => {
+      const rows = buildSubtitleMenu(
+        [sub(1, { IsTextSubtitleStream: false }), sub(2, { Language: "eng" })],
+        { ...base, offlineTranscoded: {} },
+      );
+      expect(rows.map((r) => r.index)).toEqual([SUBTITLES_OFF, 2]);
+    });
+  });
+});
+
+describe("buildAudioMenu", () => {
+  test("drops streams with no Index", () => {
+    const rows = buildAudioMenu([audio(undefined), audio(1)], {
+      isTranscoding: false,
+    });
+    expect(rows.map((r) => r.index)).toEqual([1]);
+  });
+
+  test("marks every row as needing a re-process while transcoding", () => {
+    const rows = buildAudioMenu([audio(1), audio(2)], { isTranscoding: true });
+    expect(rows.every((r) => r.requiresReload)).toBe(true);
+  });
+
+  test("offers only the downloaded track for a transcoded download", () => {
+    // The other tracks are not in the file, so listing them would offer audio
+    // that can never play.
+    const rows = buildAudioMenu([audio(1), audio(2)], {
+      isTranscoding: false,
+      offlineTranscoded: true,
+      selectedIndex: 2,
+    });
+    expect(rows.map((r) => r.index)).toEqual([2]);
+    expect(rows[0].selected).toBe(true);
+  });
+
+  test("carries the language for the series memory", () => {
+    const rows = buildAudioMenu([audio(1, { Language: "jpn" })], {
+      isTranscoding: false,
+    });
+    expect(rows[0].language).toBe("jpn");
+  });
+});

--- a/utils/subtitles/trackMenu.ts
+++ b/utils/subtitles/trackMenu.ts
@@ -1,0 +1,212 @@
+/**
+ * One builder for every audio/subtitle menu in the app.
+ *
+ * Five surfaces used to filter, sort and label streams themselves — both item
+ * pages, both JS player menus and the native player's bridge config — and they
+ * disagreed in ways that were individually small and collectively the source of
+ * most of this subsystem's bugs. The rows below are deliberately neutral: no
+ * callbacks, no player handles, no React. Each surface renders them and attaches
+ * its own selection behaviour.
+ */
+import type { MediaStream } from "@jellyfin/sdk/lib/generated-client";
+import {
+  compareTracksForMenu,
+  isBurnedInSubtitle,
+  isImageBasedSubtitle,
+} from "@/utils/jellyfin/subtitleUtils";
+import { localSubtitleIndex, SUBTITLES_OFF } from "./subtitleIndex";
+
+export type TrackRowKind =
+  /** "No subtitles" — Jellyfin index -1. */
+  | "off"
+  /** A stream in the Jellyfin media source. */
+  | "server"
+  /** A client-side downloaded file that exists only on the player handle. */
+  | "sidecar"
+  /** Pixels in the video, not a track. Inert: it can only be shown or hidden by re-processing the stream. */
+  | "burnedIn";
+
+export interface TrackMenuRow {
+  /** Identity in the unified index space (see subtitleIndex.ts). */
+  index: number;
+  label: string;
+  selected: boolean;
+  kind: TrackRowKind;
+  /**
+   * ISO code of the stream this row was built from, carried so a per-series
+   * memory write never has to re-derive it from a stream list that may have
+   * been refetched since the menu was built.
+   */
+  language?: string;
+  /**
+   * Selecting this row needs the server to re-process the stream rather than a
+   * cheap in-player track switch.
+   */
+  requiresReload: boolean;
+  /** `kind: "sidecar"` only — the local file to load into the player. */
+  localPath?: string;
+}
+
+export interface LocalSubtitleFile {
+  name: string;
+  filePath: string;
+}
+
+const defaultLabel = (stream: MediaStream): string =>
+  stream.DisplayTitle || stream.Language || `Track ${stream.Index}`;
+
+/**
+ * Under transcoding these are burned into the video by the server. Both
+ * switching *to* one and switching *away from* an active one need a re-process,
+ * so the rule is a function of (current, target) — not of the target alone.
+ *
+ * Tests both predicates: `isImageBasedSubtitle` (PGS/VOBSUB) and
+ * `isBurnedInSubtitle` (DeliveryMethod Encode, which also catches a *text*
+ * format no profile could deliver). The menus previously checked only the
+ * first while the resolver checked only the second, so a text sub the server
+ * chose to Encode was offered as a cheap switch and silently failed.
+ */
+const needsReprocessing = (stream: MediaStream | undefined): boolean =>
+  !!stream && (isImageBasedSubtitle(stream) || isBurnedInSubtitle(stream));
+
+export interface SubtitleMenuOptions {
+  /** Currently selected index in the unified space. */
+  selectedIndex: number;
+  /** Localized label for the "no subtitles" row. */
+  offLabel: string;
+  isTranscoding: boolean;
+  /** Client-side downloads, listed after the server tracks. */
+  localSubs?: LocalSubtitleFile[];
+  /**
+   * Offline transcoded download: the file carries a subset of streams, and any
+   * image subtitle chosen at download time was burned into the video.
+   */
+  offlineTranscoded?: { burnedInIndex?: number };
+  /** Override the default label format (DisplayTitle → Language → "Track N"). */
+  formatLabel?: (stream: MediaStream) => string;
+  /** Suffix for the inert burned-in row on a transcoded download. */
+  burnedInSuffix?: string;
+}
+
+export const buildSubtitleMenu = (
+  streams: MediaStream[] | null | undefined,
+  options: SubtitleMenuOptions,
+): TrackMenuRow[] => {
+  const {
+    selectedIndex,
+    offLabel,
+    isTranscoding,
+    localSubs,
+    offlineTranscoded,
+    formatLabel = defaultLabel,
+    burnedInSuffix = "(burned in)",
+  } = options;
+
+  // A stream with no Index cannot be selected or remembered. Dropping it is the
+  // point: `?? -1` aliased it onto the "subtitles off" sentinel, which then
+  // persisted "off" as the series preference for a track the user had picked.
+  const subtitleStreams = (streams ?? []).filter(
+    (s): s is MediaStream & { Index: number } =>
+      s.Type === "Subtitle" && typeof s.Index === "number",
+  );
+
+  // An image subtitle burned into a transcoded download is in the pixels: it
+  // cannot be turned off or swapped, so offering "Off" or any alternative would
+  // advertise controls that cannot affect it.
+  if (offlineTranscoded?.burnedInIndex !== undefined) {
+    const burned = subtitleStreams.find(
+      (s) => s.Index === offlineTranscoded.burnedInIndex,
+    );
+    if (burned && isImageBasedSubtitle(burned)) {
+      return [
+        {
+          index: burned.Index,
+          label: `${formatLabel(burned)} ${burnedInSuffix}`.trim(),
+          selected: true,
+          kind: "burnedIn",
+          language: burned.Language ?? undefined,
+          requiresReload: false,
+        },
+      ];
+    }
+  }
+
+  const current = subtitleStreams.find((s) => s.Index === selectedIndex);
+
+  const rows: TrackMenuRow[] = [
+    {
+      index: SUBTITLES_OFF,
+      label: offLabel,
+      selected: selectedIndex === SUBTITLES_OFF,
+      kind: "off",
+      requiresReload: isTranscoding && needsReprocessing(current),
+    },
+  ];
+
+  for (const stream of [...subtitleStreams].sort(compareTracksForMenu)) {
+    // Image subs are not present in a transcoded download — only the one that
+    // was burned in was, and that is handled above.
+    if (offlineTranscoded && isImageBasedSubtitle(stream)) continue;
+
+    rows.push({
+      index: stream.Index,
+      label: formatLabel(stream),
+      selected: stream.Index === selectedIndex,
+      kind: "server",
+      language: stream.Language ?? undefined,
+      requiresReload:
+        isTranscoding &&
+        (needsReprocessing(stream) || needsReprocessing(current)),
+    });
+  }
+
+  localSubs?.forEach((local, position) => {
+    rows.push({
+      index: localSubtitleIndex(position),
+      label: local.name,
+      selected: localSubtitleIndex(position) === selectedIndex,
+      kind: "sidecar",
+      requiresReload: false,
+      localPath: local.filePath,
+    });
+  });
+
+  return rows;
+};
+
+export interface AudioMenuOptions {
+  selectedIndex?: number;
+  isTranscoding: boolean;
+  /** A transcoded download contains only the audio track it was encoded with. */
+  offlineTranscoded?: boolean;
+  formatLabel?: (stream: MediaStream) => string;
+}
+
+export const buildAudioMenu = (
+  streams: MediaStream[] | null | undefined,
+  options: AudioMenuOptions,
+): TrackMenuRow[] => {
+  const {
+    selectedIndex,
+    isTranscoding,
+    offlineTranscoded,
+    formatLabel = defaultLabel,
+  } = options;
+
+  return (streams ?? [])
+    .filter(
+      (s): s is MediaStream & { Index: number } =>
+        s.Type === "Audio" && typeof s.Index === "number",
+    )
+    .filter((s) => !offlineTranscoded || s.Index === selectedIndex)
+    .map((stream) => ({
+      index: stream.Index,
+      label: formatLabel(stream),
+      selected: stream.Index === selectedIndex,
+      kind: "server" as const,
+      language: stream.Language ?? undefined,
+      // A transcoded stream carries only the encoded track; any other choice
+      // has to be re-negotiated with the server.
+      requiresReload: isTranscoding,
+    }));
+};


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

### What was broken?

You'd pick English audio or subtitles for a show — and the app would forget. The next episode came back on the server's default track, especially on Apple TV.

Why? Five different parts of the app (item pages, player menus, native player) each had their **own** code for listing and picking tracks, and they disagreed. Some remembered your choice, some didn't. One bug even made a Swedish preference match *Swahili* tracks.

### What this PR does

- **One shared brain for tracks.** Every menu and player now uses the same code to list tracks and remember your pick.
- **Your language settings always apply** — next episode, TV, item page, remote play. Not just some paths.
- **"Subtitles off" counts as a choice** and is remembered too.
- **Downloads play with the tracks you downloaded**, not what the server thinks you have.
- **New on TV:** audio/subtitle language settings, plus a proper "locked by admin" look for locked settings.
- **138 unit tests** now cover all of this — and they actually run in CI now.

### Safe by default

If you never set a language preference, nothing changes for you. Only people who configured something will notice.

### Built on #1938 (original audio language)

This branch is rebased onto #1938 and integrates it: its `MediaContext` logic moved into the shared `useMediaPreferences` hook (so TV gets the feature too), the duplicated TV audio-language control was collapsed into one, and the "Original language" option keeps working on every playback path.

## 🏷️ Ticket / Issue

N/A — reported directly. Builds on #1938 (which closed #36).

### 🖼️ Screenshots / GIFs (if UI)

To be added. UI changes are the TV settings audio/subtitle language rows and the shared track menus; no new mobile screens.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

Device verification is still outstanding — see below. 138 unit tests across 12 files cover the resolver, the menu builder, the index space, series memory, settings precedence and the user-configuration mapping. `test:unit` is now wired into `bun run test`; those tests existed before this PR but nothing ran them.

## 🔍 Testing Instructions

**1. Per-series track memory (the original bug) — Apple TV and Android especially**
1. Open a series whose episodes default to a language you don't want (server default not English).
2. Play an episode, switch audio and subtitles to English in the player.
3. Let it advance to the next episode, or start the next one from the item page.
4. Verify it starts on English audio and English subtitles.
5. Repeat, but make the selection from the **item page** instead of inside the player — it must be remembered the same way.
6. Repeat on the JS player specifically (Android, or iOS with the native player disabled) — this path did not record selections before.

**2. Subtitles off is remembered as a choice**
1. On a series, turn subtitles off in the player.
2. Next episode must start with subtitles off, not with the server default subtitle.

**3. Language preference on every path**
1. Settings → Audio and Subtitles → set a default audio and subtitle language.
2. Verify it applies when starting from the item page, from the next-episode auto-advance, from the top shelf, and from a WebSocket "Play" command.
3. Previously only some of these applied it.

**4. Original language (needs a Jellyfin 12 server)**
1. Settings → Audio and Subtitles → Audio language → "Original language".
2. Verify a Japanese title plays Japanese, a French title French.
3. Verify the same option appears and works on the TV settings screen.
4. Switch away to a real language, then back to None — verify "Play default audio track" behaves (cleared when Original is picked, restored when the preference is cleared).
5. On a Jellyfin 10.x server, verify the option is **not** offered.

**5. Admin-locked settings (Streamyfin plugin)**
1. Lock `defaultAudioLanguage` (or `playDefaultAudioTrack`) in the plugin.
2. Verify the TV and mobile audio-language controls render as locked and do nothing when pressed.
3. Unlock it and verify the control becomes usable without an app relaunch.

**6. Downloads**
1. Download an episode with a specific audio track, and one transcoded with a burned-in image subtitle.
2. Play offline. Verify it starts on the tracks it was downloaded with, and that the burned-in subtitle shows as a single inert row rather than offering "Off" and alternatives that can't affect pixels.

**7. Transcoding / burn-in switches**
1. While transcoding, switch to and away from an image-based (PGS/VOBSUB) subtitle.
2. Verify the stream re-processes in both directions and the correct subtitle shows.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added culture-based audio and subtitle language preferences, including original-language and subtitles-off options.
  * Media preferences now sync with supported account settings and respect administrator locks.
  * Track selections can be remembered per series, including offline download selections and local subtitles.
  * Improved subtitle styling and playback support across native, TV, Chromecast, and download experiences.
  * Large TV option lists now load more efficiently while preserving focus and navigation.

* **Bug Fixes**
  * Improved language matching and track selection reliability.
  * Corrected subtitle handling for offline playback and media-source changes.
  * Added Swedish translation for the original-language setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

https://claude.ai/code/session_01JHjtnZSAebXvGu8yv4rSfr
