### PR TITLE
fix(navigation): open the Home tab on cold boot instead of Libraries

### DIFF
--- a/app/(auth)/(tabs)/(home)/_layout.tsx
+++ b/app/(auth)/(tabs)/(home)/_layout.tsx
@@ -19,6 +19,30 @@ import { useAtom } from "jotai";
 import { useSessions, type useSessionsProps } from "@/hooks/useSessions";
 import { userAtom } from "@/providers/JellyfinProvider";
 
+// Keeps cold boot on the Home tab.
+//
+// Every tab group holds an `index` route, so all of them match the launch URL
+// `/` equally well — a bare launch has no deep link, so Expo Router resolves
+// `/`. It breaks that tie by first preferring a route that is its own group's
+// anchor (`isInitial` in the getStateFromPath config sorter), and only then by
+// group order, which is alphabetical because Metro sorts the `require.context`
+// keys. When #1928 gave `(libraries)` and `(watchlists)` an `anchor` for their
+// deep-entry back button, it also promoted them above the unanchored `(home)`,
+// and `(libraries)` won that pair alphabetically — so the app booted into the
+// library. Anchoring `(home)` puts it back in the running, ahead of
+// `(libraries)`.
+//
+// So: do NOT add `anchor` to a tab group that sorts before `(home)` —
+// `(custom-links)` or `(favorites)` — or the app boots into that tab instead.
+// An `anchor` on the `(tabs)` layout itself does not help: it only seeds the
+// tab underneath whichever tab the URL resolved to.
+//
+// The anchor is right on its own merits too: a deep link into a home sub-page
+// (`/(auth)/(tabs)/(home)/settings`) now seeds the home list underneath, so
+// the native stack renders a back button — the same reasoning as the comments
+// in the `(libraries)` and `(watchlists)` layouts.
+export const unstable_settings = { anchor: "index" };
+
 export default function IndexLayout() {
   const [user] = useAtom(userAtom);
   const { t } = useTranslation();


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Anchor the `(home)` tab group to its `index` route so a cold boot opens Home instead of Libraries.

A bare launch has no deep link, so Expo Router resolves `/`. Every tab group has an `index` route, so they all match `/` equally well. The tie breaks first on whether a route is its own group's anchor, and only then on group order, which is alphabetical. #1928 gave `(libraries)` and `(watchlists)` an anchor for the See All back button. That lifted them above the unanchored `(home)`. `(libraries)` won that pair alphabetically, so every launch landed on the library.

Anchoring `(home)` puts it back ahead of `(libraries)`. Most of the diff is a comment, since anyone who later adds an anchor to `(custom-links)` or `(favorites)` would hit the same thing.

## 🏷️ Ticket / Issue

Regression from #1928.

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Fully quit the app and relaunch it. Verify it opens on Home, not Libraries.
2. From Home, tap See All on a library row and on a promoted watchlist. Verify the back button still works in both, which is what #1928 fixed.
3. Open Home > Settings and verify the back button is there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation Improvements**
  * Home is now the default destination when the app starts.
  * Deep links into the app can now return to the Home list when navigating back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->