### PR TITLE
fix(player): pause playback and show "still watching" prompt only at end of episode

### DIFF
--- a/components/video-player/controls/ContinueWatchingOverlay.tsx
+++ b/components/video-player/controls/ContinueWatchingOverlay.tsx
@@ -1,10 +1,10 @@
+import { deactivateKeepAwake } from "expo-keep-awake";
 import { t } from "i18next";
-import React from "react";
+import React, { useEffect } from "react";
 import { View } from "react-native";
 import { Button } from "@/components/Button";
 import { Text } from "@/components/common/Text";
 import useRouter from "@/hooks/useAppRouter";
-import { useSettings } from "@/utils/atoms/settings";
 
 export interface ContinueWatchingOverlayProps {
   goToNextItem: (options: {
@@ -16,11 +16,17 @@ export interface ContinueWatchingOverlayProps {
 const ContinueWatchingOverlay: React.FC<ContinueWatchingOverlayProps> = ({
   goToNextItem,
 }) => {
-  const { settings } = useSettings();
   const router = useRouter();
 
-  return settings.autoPlayEpisodeCount >=
-    settings.maxAutoPlayEpisodeCount.value ? (
+  // Let the screen sleep while the prompt waits for an answer. The player's
+  // pause handler releases the wake lock too, but mpv can reach EOF without
+  // emitting a pause event — this covers that path. Choosing "Continue
+  // watching" re-acquires it via the next episode's playing event.
+  useEffect(() => {
+    deactivateKeepAwake().catch(() => {});
+  }, []);
+
+  return (
     <View
       className={
         "absolute top-0 bottom-0 left-0 right-0 z-50 flex flex-col px-4 items-center justify-center bg-[#000000B3]"
@@ -43,7 +49,7 @@ const ContinueWatchingOverlay: React.FC<ContinueWatchingOverlayProps> = ({
         {t("player.go_back")}
       </Button>
     </View>
-  ) : null;
+  );
 };
 
 export default ContinueWatchingOverlay;

--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -5,7 +5,14 @@ import type {
 } from "@jellyfin/sdk/lib/generated-client";
 import { useKeyEventListener } from "expo-key-event";
 import { useLocalSearchParams } from "expo-router";
-import { type FC, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Platform, StyleSheet, useWindowDimensions, View } from "react-native";
 import Animated, {
   Easing,
@@ -428,6 +435,57 @@ export const Controls: FC<Props> = ({
     ((showSkipCreditButton && !hasContentAfterCredits) ||
       remainingTime < 10000);
 
+  // Autoplay would run at EOF but the episode cap stops it: ask "Still
+  // watching?" there instead, with playback paused — mirroring the native
+  // player's stillWatchingRequired flow. Gated on reaching the end so the
+  // prompt never covers a video that is still playing.
+  const stillWatchingRequired =
+    !!nextItem &&
+    settings.autoPlayNextEpisode !== false &&
+    settings.maxAutoPlayEpisodeCount.value !== -1 &&
+    settings.autoPlayEpisodeCount >= settings.maxAutoPlayEpisodeCount.value;
+
+  const [stillWatchingVisible, setStillWatchingVisible] = useState(false);
+  // The cap-hitting autoplay updates the episode count synchronously while
+  // currentTime/remainingTime still hold the outgoing episode's near-zero
+  // values (the next item loads async), so "at EOF" alone would fire the
+  // prompt over the incoming episode. Only a progress tick from mid-playback
+  // of the final episode itself arms the trigger.
+  const stillWatchingArmedRef = useRef(false);
+
+  // Reset after an in-place episode switch (setParams keeps Controls mounted).
+  useEffect(() => {
+    stillWatchingArmedRef.current = false;
+    setStillWatchingVisible(false);
+  }, [item.Id]);
+
+  useEffect(() => {
+    if (!stillWatchingRequired || stillWatchingVisible || maxMs <= 0) {
+      return;
+    }
+    if (
+      currentTime > 0 &&
+      remainingTime > CONTROLS_CONSTANTS.STILL_WATCHING_EOF_WINDOW_MS
+    ) {
+      stillWatchingArmedRef.current = true;
+      return;
+    }
+    if (
+      stillWatchingArmedRef.current &&
+      remainingTime <= CONTROLS_CONSTANTS.STILL_WATCHING_EOF_WINDOW_MS
+    ) {
+      setStillWatchingVisible(true);
+      pause();
+    }
+  }, [
+    stillWatchingVisible,
+    stillWatchingRequired,
+    maxMs,
+    currentTime,
+    remainingTime,
+    pause,
+  ]);
+
   const goToItemCommon = useCallback(
     (item: BaseItemDto) => {
       if (!item || !settings) {
@@ -694,7 +752,7 @@ export const Controls: FC<Props> = ({
           />
         </>
       )}
-      {settings.maxAutoPlayEpisodeCount.value !== -1 && (
+      {stillWatchingVisible && (
         <ContinueWatchingOverlay goToNextItem={handleContinueWatching} />
       )}
     </View>

--- a/components/video-player/controls/constants.ts
+++ b/components/video-player/controls/constants.ts
@@ -14,6 +14,9 @@ export const CONTROLS_CONSTANTS = {
   HOLD_SPEED_DIM_DURATION: 300,
   CONTROLS_SCRIM_OPACITY: 0.75,
   SLIDER_DEBOUNCE_MS: 3,
+  // Progress ticks arrive at most once per second, so the last one before EOF
+  // can land anywhere inside the final second — 1.5s guarantees it's caught.
+  STILL_WATCHING_EOF_WINDOW_MS: 1500,
 } as const;
 
 export const ICON_SIZES = {


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Show the "still watching" prompt only when the final auto-played episode actually reaches its end, and pause playback when it appears. Before, the prompt was driven by the autoplay counter alone, so it covered the entire final episode while the video kept playing underneath. The overlay now also releases the keep-awake lock so the screen can sleep while the prompt waits.

This only touches the JS player. The native player already pauses and releases the wake lock at EOF.

## 🏷️ Ticket / Issue

Supersedes #1921, which released the wake lock while the prompt was up but could do that mid-playback because of the timing bug above.

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Set max autoplay episodes to 1 in settings
2. Watch an episode to the end and let it autoplay the next one
3. The prompt should appear only in the last second of that episode, with the video paused
4. Wait, the screen should turn off on its own
5. "Continue watching" should start the next episode and keep the screen awake again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Still watching?” prompt when autoplay reaches the episode limit.
  - Playback now pauses at the end of an episode while the prompt is displayed.
  - The prompt appears consistently and automatically releases the screen wake lock.

- **Bug Fixes**
  - Improved end-of-episode detection to account for delayed playback progress updates.
  - Reset autoplay monitoring correctly when switching content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->