### PR TITLE
fix(auth): give each account its own device id so multiple accounts can coexist

### DIFF
--- a/app/(auth)/(tabs)/(home)/settings.tv.tsx
+++ b/app/(auth)/(tabs)/(home)/settings.tv.tsx
@@ -31,6 +31,7 @@ import { clearCache as clearAudioCache } from "@/providers/AudioStorage";
 import {
   apiAtom,
   cacheVersionAtom,
+  SessionExpiredError,
   useJellyfin,
   userAtom,
 } from "@/providers/JellyfinProvider";
@@ -127,6 +128,25 @@ export default function SettingsTV() {
 
   const hasOtherAccounts = otherAccounts.length > 0;
 
+  // The account survives a rejected token, so offer a password sign-in rather
+  // than leaving the user tapping a card that keeps failing.
+  const handleSavedLoginError = (error: unknown) => {
+    if (error instanceof SessionExpiredError) {
+      Alert.alert(t("server.session_expired"), t("server.please_login_again"), [
+        { text: t("common.cancel"), style: "cancel" },
+        {
+          text: t("common.ok"),
+          onPress: () => setPasswordModalVisible(true),
+        },
+      ]);
+      return;
+    }
+    Alert.alert(
+      t("login.connection_failed"),
+      error instanceof Error ? error.message : t("server.session_expired"),
+    );
+  };
+
   // Handle account selection from modal
   const handleAccountSelect = async (account: SavedServerAccount) => {
     if (!currentServer) return;
@@ -136,17 +156,10 @@ export default function SettingsTV() {
       try {
         await loginWithSavedCredential(currentServer.address, account.userId);
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : t("server.session_expired");
-        const isSessionExpired = errorMessage.includes(
-          t("server.session_expired"),
-        );
-        Alert.alert(
-          isSessionExpired
-            ? t("server.session_expired")
-            : t("login.connection_failed"),
-          isSessionExpired ? t("server.please_login_again") : errorMessage,
-        );
+        // Kept set so the password retry knows which account it is for.
+        setSelectedServer(currentServer);
+        setSelectedAccount(account);
+        handleSavedLoginError(error);
       }
     } else if (account.securityType === "pin") {
       // Show PIN modal
@@ -171,17 +184,9 @@ export default function SettingsTV() {
           selectedAccount.userId,
         );
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : t("server.session_expired");
-        const isSessionExpired = errorMessage.includes(
-          t("server.session_expired"),
-        );
-        Alert.alert(
-          isSessionExpired
-            ? t("server.session_expired")
-            : t("login.connection_failed"),
-          isSessionExpired ? t("server.please_login_again") : errorMessage,
-        );
+        // The PIN was right but the token behind it is dead.
+        handleSavedLoginError(error);
+        return;
       }
     }
     setSelectedServer(null);

--- a/app/(auth)/(tabs)/(home)/settings.tv.tsx
+++ b/app/(auth)/(tabs)/(home)/settings.tv.tsx
@@ -31,7 +31,6 @@ import { clearCache as clearAudioCache } from "@/providers/AudioStorage";
 import {
   apiAtom,
   cacheVersionAtom,
-  SessionExpiredError,
   useJellyfin,
   userAtom,
 } from "@/providers/JellyfinProvider";
@@ -55,6 +54,10 @@ import {
   type SavedServer,
   type SavedServerAccount,
 } from "@/utils/secureCredentials";
+import {
+  SessionExpiredError,
+  savedLoginAlertText,
+} from "@/utils/sessionExpired";
 import { clearTopShelfCacheSafely } from "@/utils/topshelf/cache";
 
 const buildLanguageOptions = (
@@ -131,8 +134,9 @@ export default function SettingsTV() {
   // The account survives a rejected token, so offer a password sign-in rather
   // than leaving the user tapping a card that keeps failing.
   const handleSavedLoginError = (error: unknown) => {
+    const { title, message } = savedLoginAlertText(error, t);
     if (error instanceof SessionExpiredError) {
-      Alert.alert(t("server.session_expired"), t("server.please_login_again"), [
+      Alert.alert(title, message, [
         { text: t("common.cancel"), style: "cancel" },
         {
           text: t("common.ok"),
@@ -141,10 +145,7 @@ export default function SettingsTV() {
       ]);
       return;
     }
-    Alert.alert(
-      t("login.connection_failed"),
-      error instanceof Error ? error.message : t("server.session_expired"),
-    );
+    Alert.alert(title, message);
   };
 
   // Handle account selection from modal

--- a/components/PreviousServersList.tsx
+++ b/components/PreviousServersList.tsx
@@ -72,6 +72,11 @@ export const PreviousServersList: React.FC<PreviousServersListProps> = ({
     server: SavedServer,
     account: SavedServerAccount,
   ) => {
+    // A successful login unmounts this screen, so the sheet used to close
+    // itself by accident. Now that a rejected token keeps the account, the
+    // failure path comes back here and an open sheet swallows every tap.
+    setAccountsSheetOpen(false);
+
     switch (account.securityType) {
       case "none":
         // Quick login without protection

--- a/components/PreviousServersList.tsx
+++ b/components/PreviousServersList.tsx
@@ -7,7 +7,6 @@ import { Swipeable } from "react-native-gesture-handler";
 import { useMMKVString } from "react-native-mmkv";
 import { Colors } from "@/constants/Colors";
 import { useGlobalModal } from "@/providers/GlobalModalProvider";
-import { SessionExpiredError } from "@/providers/JellyfinProvider";
 import {
   deleteAccountCredential,
   getPreviousServers,
@@ -17,6 +16,7 @@ import {
   type SavedServerAccount,
   updateServerCustomHeaders,
 } from "@/utils/secureCredentials";
+import { savedLoginAlertText } from "@/utils/sessionExpired";
 import { AccountsSheet } from "./AccountsSheet";
 import { Text } from "./common/Text";
 import { ListGroup } from "./list/ListGroup";
@@ -80,18 +80,10 @@ export const PreviousServersList: React.FC<PreviousServersListProps> = ({
           try {
             await onQuickLogin(server.address, account.userId);
           } catch (error) {
-            const isSessionExpired = error instanceof SessionExpiredError;
-            Alert.alert(
-              isSessionExpired
-                ? t("server.session_expired")
-                : t("login.connection_failed"),
-              isSessionExpired
-                ? t("server.please_login_again")
-                : error instanceof Error
-                  ? error.message
-                  : t("server.session_expired"),
-              [{ text: t("common.ok"), onPress: () => onServerSelect(server) }],
-            );
+            const { title, message } = savedLoginAlertText(error, t);
+            Alert.alert(title, message, [
+              { text: t("common.ok"), onPress: () => onServerSelect(server) },
+            ]);
           } finally {
             setLoadingServer(null);
           }
@@ -136,23 +128,13 @@ export const PreviousServersList: React.FC<PreviousServersListProps> = ({
       try {
         await onQuickLogin(selectedServer.address, selectedAccount.userId);
       } catch (error) {
-        const isSessionExpired = error instanceof SessionExpiredError;
-        Alert.alert(
-          isSessionExpired
-            ? t("server.session_expired")
-            : t("login.connection_failed"),
-          isSessionExpired
-            ? t("server.please_login_again")
-            : error instanceof Error
-              ? error.message
-              : t("server.session_expired"),
-          [
-            {
-              text: t("common.ok"),
-              onPress: () => onServerSelect(selectedServer),
-            },
-          ],
-        );
+        const { title, message } = savedLoginAlertText(error, t);
+        Alert.alert(title, message, [
+          {
+            text: t("common.ok"),
+            onPress: () => onServerSelect(selectedServer),
+          },
+        ]);
       } finally {
         setLoadingServer(null);
         setSelectedAccount(null);

--- a/components/PreviousServersList.tsx
+++ b/components/PreviousServersList.tsx
@@ -7,6 +7,7 @@ import { Swipeable } from "react-native-gesture-handler";
 import { useMMKVString } from "react-native-mmkv";
 import { Colors } from "@/constants/Colors";
 import { useGlobalModal } from "@/providers/GlobalModalProvider";
+import { SessionExpiredError } from "@/providers/JellyfinProvider";
 import {
   deleteAccountCredential,
   getPreviousServers,
@@ -79,18 +80,16 @@ export const PreviousServersList: React.FC<PreviousServersListProps> = ({
           try {
             await onQuickLogin(server.address, account.userId);
           } catch (error) {
-            const errorMessage =
-              error instanceof Error
-                ? error.message
-                : t("server.session_expired");
-            const isSessionExpired = errorMessage.includes(
-              t("server.session_expired"),
-            );
+            const isSessionExpired = error instanceof SessionExpiredError;
             Alert.alert(
               isSessionExpired
                 ? t("server.session_expired")
                 : t("login.connection_failed"),
-              isSessionExpired ? t("server.please_login_again") : errorMessage,
+              isSessionExpired
+                ? t("server.please_login_again")
+                : error instanceof Error
+                  ? error.message
+                  : t("server.session_expired"),
               [{ text: t("common.ok"), onPress: () => onServerSelect(server) }],
             );
           } finally {
@@ -137,16 +136,16 @@ export const PreviousServersList: React.FC<PreviousServersListProps> = ({
       try {
         await onQuickLogin(selectedServer.address, selectedAccount.userId);
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : t("server.session_expired");
-        const isSessionExpired = errorMessage.includes(
-          t("server.session_expired"),
-        );
+        const isSessionExpired = error instanceof SessionExpiredError;
         Alert.alert(
           isSessionExpired
             ? t("server.session_expired")
             : t("login.connection_failed"),
-          isSessionExpired ? t("server.please_login_again") : errorMessage,
+          isSessionExpired
+            ? t("server.please_login_again")
+            : error instanceof Error
+              ? error.message
+              : t("server.session_expired"),
           [
             {
               text: t("common.ok"),

--- a/components/login/TVAddUserForm.tsx
+++ b/components/login/TVAddUserForm.tsx
@@ -17,7 +17,8 @@ interface TVAddUserFormProps {
     password: string,
     saveAccount: boolean,
   ) => Promise<void>;
-  onQuickConnect: () => Promise<void>;
+  /** Takes the save toggle too: it sits above both buttons, so it governs both. */
+  onQuickConnect: (saveAccount: boolean) => Promise<void>;
   onBack: () => void;
   loading?: boolean;
   disabled?: boolean;
@@ -173,7 +174,7 @@ export const TVAddUserForm: React.FC<TVAddUserFormProps> = ({
 
         {/* Quick Connect Button */}
         <Button
-          onPress={onQuickConnect}
+          onPress={() => onQuickConnect(saveAccount)}
           color='black'
           className='bg-neutral-800 border border-neutral-700'
         >

--- a/components/login/TVLogin.tsx
+++ b/components/login/TVLogin.tsx
@@ -6,7 +6,11 @@ import { Alert, View } from "react-native";
 import { useMMKVString } from "react-native-mmkv";
 import { Text } from "@/components/common/Text";
 import { useTVMenuKeyInterception } from "@/hooks/useTVBackPress";
-import { apiAtom, useJellyfin } from "@/providers/JellyfinProvider";
+import {
+  apiAtom,
+  SessionExpiredError,
+  useJellyfin,
+} from "@/providers/JellyfinProvider";
 import { selectedTVServerAtom } from "@/utils/atoms/selectedTVServer";
 import type { CustomHeader } from "@/utils/customHeaders";
 import {
@@ -253,6 +257,55 @@ export const TVLogin: React.FC = () => {
     }
   };
 
+  // The account survives a rejected token, so offer a way back in. Quick
+  // Connect first: typing a password on a remote is miserable.
+  const handleSavedLoginError = (
+    error: unknown,
+    account: SavedServerAccount,
+  ) => {
+    if (!(error instanceof SessionExpiredError)) {
+      Alert.alert(
+        t("login.connection_failed"),
+        error instanceof Error ? error.message : t("server.session_expired"),
+        [
+          {
+            text: t("common.ok"),
+            onPress: () => setCurrentScreen("user-selection"),
+          },
+        ],
+      );
+      return;
+    }
+
+    setSelectedAccount(account);
+    Alert.alert(t("server.session_expired"), t("server.please_login_again"), [
+      {
+        text: t("common.cancel"),
+        style: "cancel",
+        onPress: () => setCurrentScreen("user-selection"),
+      },
+      {
+        text: t("login.quick_connect"),
+        // Quick Connect posts through the api, which the user-selection screen
+        // has not created yet.
+        onPress: async () => {
+          setCurrentScreen("user-selection");
+          if (currentServer) {
+            await setServer({ address: currentServer.address });
+          }
+          await handleQuickConnect();
+        },
+      },
+      {
+        text: t("password.enter_password"),
+        onPress: () => {
+          setCurrentScreen("user-selection");
+          setPasswordModalVisible(true);
+        },
+      },
+    ]);
+  };
+
   // Handle user selection
   const handleUserSelect = async (account: SavedServerAccount) => {
     if (!currentServer) return;
@@ -264,25 +317,7 @@ export const TVLogin: React.FC = () => {
         try {
           await loginWithSavedCredential(currentServer.address, account.userId);
         } catch (error) {
-          const errorMessage =
-            error instanceof Error
-              ? error.message
-              : t("server.session_expired");
-          const isSessionExpired = errorMessage.includes(
-            t("server.session_expired"),
-          );
-          Alert.alert(
-            isSessionExpired
-              ? t("server.session_expired")
-              : t("login.connection_failed"),
-            isSessionExpired ? t("server.please_login_again") : errorMessage,
-            [
-              {
-                text: t("common.ok"),
-                onPress: () => setCurrentScreen("user-selection"),
-              },
-            ],
-          );
+          handleSavedLoginError(error, account);
         } finally {
           setLoading(false);
         }
@@ -312,23 +347,8 @@ export const TVLogin: React.FC = () => {
           selectedAccount.userId,
         );
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : t("server.session_expired");
-        const isSessionExpired = errorMessage.includes(
-          t("server.session_expired"),
-        );
-        Alert.alert(
-          isSessionExpired
-            ? t("server.session_expired")
-            : t("login.connection_failed"),
-          isSessionExpired ? t("server.please_login_again") : errorMessage,
-          [
-            {
-              text: t("common.ok"),
-              onPress: () => setCurrentScreen("user-selection"),
-            },
-          ],
-        );
+        handleSavedLoginError(error, selectedAccount);
+        return;
       } finally {
         setLoading(false);
       }

--- a/components/login/TVLogin.tsx
+++ b/components/login/TVLogin.tsx
@@ -115,6 +115,12 @@ export const TVLogin: React.FC = () => {
   const isAnyModalOpen =
     showSaveModal || pinModalVisible || passwordModalVisible;
 
+  // Server address awaiting a Quick Connect start, set by the re-auth prompt
+  // and consumed once the api points at that server.
+  const [pendingQuickConnect, setPendingQuickConnect] = useState<string | null>(
+    null,
+  );
+
   // Pairing state (companion login via phone)
   const [showPairingQR, setShowPairingQR] = useState(false);
   const [pairingCode, setPairingCode] = useState("");
@@ -284,13 +290,14 @@ export const TVLogin: React.FC = () => {
       {
         text: t("login.quick_connect"),
         // Quick Connect posts through the api, which the user-selection screen
-        // has not created yet.
-        onPress: async () => {
+        // has not created yet. Request it and let the effect below start once
+        // the api actually points at this server — calling it straight after
+        // setServer would use the api captured when this alert was built.
+        onPress: () => {
           setCurrentScreen("user-selection");
-          if (currentServer) {
-            await setServer({ address: currentServer.address });
-          }
-          await handleQuickConnect();
+          if (!currentServer) return;
+          setServer({ address: currentServer.address });
+          setPendingQuickConnect(currentServer.address);
         },
       },
       {
@@ -537,6 +544,15 @@ export const TVLogin: React.FC = () => {
       );
     }
   };
+
+  // Start a requested Quick Connect only once the api actually points at the
+  // server it should post to. setServer resolves before the atom has
+  // propagated here, so the request cannot be fired inline.
+  useEffect(() => {
+    if (!pendingQuickConnect || api?.basePath !== pendingQuickConnect) return;
+    setPendingQuickConnect(null);
+    handleQuickConnect();
+  }, [pendingQuickConnect, api?.basePath]);
 
   // Navigate to QR screen with a fresh code and active listener
   const goToQRScreen = useCallback(() => {

--- a/components/login/TVLogin.tsx
+++ b/components/login/TVLogin.tsx
@@ -9,6 +9,8 @@ import { useTVMenuKeyInterception } from "@/hooks/useTVBackPress";
 import { apiAtom, useJellyfin } from "@/providers/JellyfinProvider";
 import { selectedTVServerAtom } from "@/utils/atoms/selectedTVServer";
 import type { CustomHeader } from "@/utils/customHeaders";
+import { normalizeHttpBaseUrl } from "@/utils/customHeaders/urlMatching";
+import { getOrSetDeviceId } from "@/utils/device";
 import {
   checkJellyfinServer,
   ServerTooOldError,
@@ -479,6 +481,9 @@ export const TVLogin: React.FC = () => {
               securityType,
               pinHash,
               primaryImageTag: user.PrimaryImageTag ?? undefined,
+              // The login above adopted this account's own id; leaving it off
+              // would put the account back on a borrowed one.
+              deviceId: getOrSetDeviceId(),
             });
           }
         } catch (saveError) {
@@ -549,7 +554,15 @@ export const TVLogin: React.FC = () => {
   // server it should post to. setServer resolves before the atom has
   // propagated here, so the request cannot be fired inline.
   useEffect(() => {
-    if (!pendingQuickConnect || api?.basePath !== pendingQuickConnect) return;
+    // A saved address may carry a trailing slash the SDK's basePath drops, and
+    // a mismatch here silently strands the request that offers the way back in.
+    if (
+      !pendingQuickConnect ||
+      !api?.basePath ||
+      normalizeHttpBaseUrl(api.basePath) !==
+        normalizeHttpBaseUrl(pendingQuickConnect)
+    )
+      return;
     setPendingQuickConnect(null);
     handleQuickConnect();
   }, [pendingQuickConnect, api?.basePath]);

--- a/components/login/TVLogin.tsx
+++ b/components/login/TVLogin.tsx
@@ -6,11 +6,7 @@ import { Alert, View } from "react-native";
 import { useMMKVString } from "react-native-mmkv";
 import { Text } from "@/components/common/Text";
 import { useTVMenuKeyInterception } from "@/hooks/useTVBackPress";
-import {
-  apiAtom,
-  SessionExpiredError,
-  useJellyfin,
-} from "@/providers/JellyfinProvider";
+import { apiAtom, useJellyfin } from "@/providers/JellyfinProvider";
 import { selectedTVServerAtom } from "@/utils/atoms/selectedTVServer";
 import type { CustomHeader } from "@/utils/customHeaders";
 import {
@@ -33,6 +29,10 @@ import {
   type SavedServerAccount,
   saveAccountCredential,
 } from "@/utils/secureCredentials";
+import {
+  SessionExpiredError,
+  savedLoginAlertText,
+} from "@/utils/sessionExpired";
 import { TVAddServerForm } from "./TVAddServerForm";
 import { TVAddUserForm } from "./TVAddUserForm";
 import { TVPasswordEntryModal } from "./TVPasswordEntryModal";
@@ -263,22 +263,19 @@ export const TVLogin: React.FC = () => {
     error: unknown,
     account: SavedServerAccount,
   ) => {
+    const { title, message } = savedLoginAlertText(error, t);
     if (!(error instanceof SessionExpiredError)) {
-      Alert.alert(
-        t("login.connection_failed"),
-        error instanceof Error ? error.message : t("server.session_expired"),
-        [
-          {
-            text: t("common.ok"),
-            onPress: () => setCurrentScreen("user-selection"),
-          },
-        ],
-      );
+      Alert.alert(title, message, [
+        {
+          text: t("common.ok"),
+          onPress: () => setCurrentScreen("user-selection"),
+        },
+      ]);
       return;
     }
 
     setSelectedAccount(account);
-    Alert.alert(t("server.session_expired"), t("server.please_login_again"), [
+    Alert.alert(title, message, [
       {
         text: t("common.cancel"),
         style: "cancel",

--- a/components/login/TVLogin.tsx
+++ b/components/login/TVLogin.tsx
@@ -532,9 +532,9 @@ export const TVLogin: React.FC = () => {
   };
 
   // Handle quick connect
-  const handleQuickConnect = async () => {
+  const handleQuickConnect = async (saveAccount = false) => {
     try {
-      const code = await initiateQuickConnect();
+      const code = await initiateQuickConnect({ saveAccount });
       if (code) {
         Alert.alert(
           t("login.quick_connect"),
@@ -564,7 +564,9 @@ export const TVLogin: React.FC = () => {
     )
       return;
     setPendingQuickConnect(null);
-    handleQuickConnect();
+    // Re-authenticating an account that is already saved: its token is
+    // refreshed either way, so there is nothing here to consent to.
+    handleQuickConnect(false);
   }, [pendingQuickConnect, api?.basePath]);
 
   // Navigate to QR screen with a fresh code and active listener

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -887,7 +887,10 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       const accountJellyfin = buildJellyfin(accountDeviceId);
       if (!accountJellyfin) throw new Error("Failed to create SDK instance");
 
-      const apiInstance = createApiWithCustomHeaders(accountJellyfin, serverUrl);
+      const apiInstance = createApiWithCustomHeaders(
+        accountJellyfin,
+        serverUrl,
+      );
       if (!apiInstance) {
         throw new Error("Failed to create API instance");
       }

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -439,15 +439,35 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           storage.set("user", JSON.stringify(User));
 
           // Whoever approved meant to sign in, even if that is not the
-          // account we asked to re-authenticate.
+          // account we asked to re-authenticate. Save them if they are new:
+          // Quick Connect has no "save this account" step, so without this the
+          // sign-in works but the account never appears in the switcher.
           if (User?.Id) {
-            await updateAccountToken(
-              serverUrl,
-              User.Id,
-              AccessToken,
-              User.PrimaryImageTag ?? undefined,
-              quickConnectDeviceId,
-            );
+            const existing = await getAccountCredential(serverUrl, User.Id);
+            if (existing) {
+              await updateAccountToken(
+                serverUrl,
+                User.Id,
+                AccessToken,
+                User.PrimaryImageTag ?? undefined,
+                quickConnectDeviceId,
+              );
+            } else {
+              await saveAccountCredential({
+                serverUrl,
+                // Empty keeps whatever name the server list already holds.
+                serverName: "",
+                token: AccessToken,
+                userId: User.Id,
+                username: User.Name || "",
+                savedAt: Date.now(),
+                // Quick Connect is already an approval on a trusted device;
+                // demanding a second factor to switch back would be odd.
+                securityType: "none",
+                primaryImageTag: User.PrimaryImageTag ?? undefined,
+                deviceId: quickConnectDeviceId,
+              });
+            }
           }
           return true;
         }

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -14,7 +14,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -27,7 +26,11 @@ import { useInterval } from "@/hooks/useInterval";
 import { JellyseerrApi, useJellyseerr } from "@/hooks/useJellyseerr";
 import { settingsAtom, useSettings } from "@/utils/atoms/settings";
 import { getIntegrationHeaders } from "@/utils/customHeaders";
-import { getOrSetDeviceId } from "@/utils/device";
+import {
+  getOrSetDeviceId,
+  mintDeviceId,
+  setActiveDeviceId,
+} from "@/utils/device";
 import { markExpectedError } from "@/utils/errors";
 import { createApiWithCustomHeaders } from "@/utils/jellyfin/createApi";
 import {
@@ -45,7 +48,9 @@ import {
   deleteJellyseerrPassword,
   getAccountCredential,
   hashPIN,
+  migrateCurrentAccountDeviceId,
   migrateToMultiAccount,
+  resolveDeviceIdForLogin,
   saveAccountCredential,
   saveJellyseerrPassword,
   updateAccountToken,
@@ -128,6 +133,15 @@ export const pendingAccountSaveAtom = atom<{ serverName?: string } | null>(
   null,
 );
 
+/** A rejected token on a saved account. The account is kept — callers offer
+ * re-authentication instead. */
+export class SessionExpiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionExpiredError";
+  }
+}
+
 interface LoginOptions {
   saveAccount?: boolean;
   securityType?: AccountSecurityType;
@@ -169,26 +183,31 @@ const JellyfinContext = createContext<JellyfinContextValue | undefined>(
   undefined,
 );
 
+/**
+ * Build an SDK instance bound to `deviceId` (defaults to the active account's).
+ */
+function buildJellyfin(deviceId?: string): Jellyfin | undefined {
+  try {
+    return new Jellyfin({
+      clientInfo: { name: "Streamyfin", version: APP_VERSION },
+      deviceInfo: {
+        name: getDeviceNameSync(),
+        id: deviceId ?? getOrSetDeviceId(),
+      },
+    });
+  } catch (e) {
+    console.error("Failed to initialize Jellyfin:", e);
+    return undefined;
+  }
+}
+
 export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
-  const [jellyfin] = useState<Jellyfin | undefined>(() => {
-    try {
-      const id = getOrSetDeviceId();
-      const deviceName = getDeviceNameSync();
-      return new Jellyfin({
-        clientInfo: { name: "Streamyfin", version: APP_VERSION },
-        deviceInfo: {
-          name: deviceName,
-          id,
-        },
-      });
-    } catch (e) {
-      console.error("Failed to initialize Jellyfin synchronously in state:", e);
-      return undefined;
-    }
-  });
-  const [deviceId] = useState<string | undefined>(() => {
+  const [jellyfin, setJellyfin] = useState<Jellyfin | undefined>(() =>
+    buildJellyfin(),
+  );
+  const [deviceId, setDeviceId] = useState<string | undefined>(() => {
     try {
       return getOrSetDeviceId();
     } catch {
@@ -196,12 +215,27 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
     }
   });
 
+  // The device id is baked into deviceInfo, so a switch needs a new instance.
+  // Returned as well as stored, because setState lands too late for the caller.
+  const adoptDeviceId = useCallback((id: string): Jellyfin | undefined => {
+    const instance = buildJellyfin(id);
+    if (!instance) return undefined;
+    setActiveDeviceId(id);
+    setDeviceId(id);
+    setJellyfin(instance);
+    return instance;
+  }, []);
+
   const { t } = useTranslation();
 
   const [api, setApi] = useAtom(apiAtom);
   const [user, setUser] = useAtom(userAtom);
   const [isPolling, setIsPolling] = useState<boolean>(false);
   const [secret, setSecret] = useState<string | null>(null);
+  // Minted for the in-flight Quick Connect attempt, adopted once approved.
+  const [quickConnectDeviceId, setQuickConnectDeviceId] = useState<
+    string | null
+  >(null);
   const { settings, setPluginSettings, refreshStreamyfinPluginSettings } =
     useSettings();
   const { clearAllJellyseerData, jellyseerrUser, setJellyseerrUser } =
@@ -290,6 +324,15 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
     }
   }, [setUser, setApi, setPluginSettings, clearAllJellyseerData, queryClient]);
 
+  // Drop everything scoped to the outgoing account, or it leaks into the next
+  // user's session. Jellyseerr is cleared rather than re-logged in: a token
+  // switch carries no password.
+  const clearAccountScopedState = useCallback(async () => {
+    queryClient.clear();
+    storage.remove("REACT_QUERY_OFFLINE_CACHE");
+    await clearAllJellyseerData();
+  }, [queryClient, clearAllJellyseerData]);
+
   const handleSessionExpired = useCallback(() => {
     if (sessionExpiredRef.current) return; // run once per session
     sessionExpiredRef.current = true;
@@ -317,23 +360,27 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
     };
   }, [api, handleSessionExpired]);
 
-  const headers = useMemo(() => {
-    if (!deviceId) return {};
-    return {
+  const authHeaders = useCallback(
+    (id: string) => ({
       authorization: `MediaBrowser Client="Streamyfin", Device=${
         Platform.OS === "android" ? "Android" : "iOS"
-      }, DeviceId="${deviceId}", Version="${APP_VERSION}"`,
-    };
-  }, [deviceId]);
+      }, DeviceId="${id}", Version="${APP_VERSION}"`,
+    }),
+    [],
+  );
 
   const initiateQuickConnect = useCallback(async () => {
-    if (!api || !deviceId) return;
+    if (!api) return;
+    // Quick Connect cannot name the account upfront. Adopting this id now
+    // would strand the running session, whose token is bound to the old one.
+    const attemptDeviceId = mintDeviceId();
+    setQuickConnectDeviceId(attemptDeviceId);
     try {
       const response = await api.axiosInstance.post(
         `${api.basePath}/QuickConnect/Initiate`,
         null,
         {
-          headers,
+          headers: authHeaders(attemptDeviceId),
         },
       );
       if (response?.status === 200) {
@@ -346,16 +393,18 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       console.error(error);
       throw error;
     }
-  }, [api, deviceId, headers]);
+  }, [api, authHeaders]);
 
   const stopQuickConnectPolling = useCallback(() => {
     setIsPolling(false);
     setSecret(null);
+    setQuickConnectDeviceId(null);
   }, []);
 
   const pollQuickConnect = useCallback(async () => {
-    if (!api || !secret || !jellyfin) return;
+    if (!api || !secret || !jellyfin || !quickConnectDeviceId) return;
 
+    const serverUrl = api.basePath;
     try {
       const response = await api.axiosInstance.get(
         `${api.basePath}/QuickConnect/Connect?Secret=${secret}`,
@@ -371,17 +420,35 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
               secret,
             },
             {
-              headers,
+              headers: authHeaders(quickConnectDeviceId),
             },
           );
 
           const { AccessToken, User } = authResponse.data;
+          // The token is bound to the id the request went out under.
+          const accountJellyfin = adoptDeviceId(quickConnectDeviceId);
+          if (!accountJellyfin)
+            throw new Error("Failed to create SDK instance");
+          setQuickConnectDeviceId(null);
+
           setUser(User);
           setApi(
-            createApiWithCustomHeaders(jellyfin, api.basePath, AccessToken),
+            createApiWithCustomHeaders(accountJellyfin, serverUrl, AccessToken),
           );
           storage.set("token", AccessToken);
           storage.set("user", JSON.stringify(User));
+
+          // Whoever approved meant to sign in, even if that is not the
+          // account we asked to re-authenticate.
+          if (User?.Id) {
+            await updateAccountToken(
+              serverUrl,
+              User.Id,
+              AccessToken,
+              User.PrimaryImageTag ?? undefined,
+              quickConnectDeviceId,
+            );
+          }
           return true;
         }
       }
@@ -391,6 +458,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         if (error.response?.status === 400 || error.response?.status === 404) {
           setIsPolling(false);
           setSecret(null);
+          setQuickConnectDeviceId(null);
           if (error.response?.status === 400) {
             throw new Error("The code has expired. Please try again.");
           }
@@ -400,7 +468,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       console.error("Error polling Quick Connect:", error);
       throw error;
     }
-  }, [api, secret, headers, jellyfin]);
+  }, [api, secret, authHeaders, jellyfin, quickConnectDeviceId, adoptDeviceId]);
 
   useEffect(() => {
     (async () => {
@@ -492,6 +560,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         securityType,
         pinHash,
         primaryImageTag: user.PrimaryImageTag ?? undefined,
+        deviceId: getOrSetDeviceId(),
       });
     },
     [api?.basePath, user],
@@ -509,26 +578,37 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       serverName?: string;
       options?: LoginOptions;
     }) => {
-      if (!api || !jellyfin) throw new Error("API not initialized");
+      if (!api?.basePath || !jellyfin) throw new Error("API not initialized");
+
+      // Adopted only once the login succeeds, so a failed attempt cannot
+      // leave the app on a device id it never authorized.
+      const serverUrl = api.basePath;
+      const accountDeviceId = resolveDeviceIdForLogin(serverUrl, username);
+      const accountJellyfin = buildJellyfin(accountDeviceId);
+      if (!accountJellyfin) throw new Error("Failed to create SDK instance");
 
       try {
-        writeInfoLog(`Login: authenticating against ${api.basePath}`);
-        const auth = await api.authenticateUserByName(username, password);
+        writeInfoLog(`Login: authenticating against ${serverUrl}`);
+        const auth = await createApiWithCustomHeaders(
+          accountJellyfin,
+          serverUrl,
+        ).authenticateUserByName(username, password);
 
         if (auth.data.AccessToken && auth.data.User) {
+          adoptDeviceId(accountDeviceId);
           setUser(auth.data.User);
           storage.set("user", JSON.stringify(auth.data.User));
           setApi(
             createApiWithCustomHeaders(
-              jellyfin,
-              api.basePath,
-              auth.data?.AccessToken,
+              accountJellyfin,
+              serverUrl,
+              auth.data.AccessToken,
             ),
           );
           storage.set("token", auth.data?.AccessToken);
 
           // Save credentials to secure storage if requested
-          if (api.basePath && options?.saveAccount) {
+          if (options?.saveAccount) {
             const securityType = options.securityType || "none";
             let pinHash: string | undefined;
 
@@ -543,7 +623,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
               toast.error(t("save_account.not_saved"));
             } else {
               await saveAccountCredential({
-                serverUrl: api.basePath,
+                serverUrl,
                 serverName: serverName || "",
                 token: auth.data.AccessToken,
                 userId: auth.data.User.Id || "",
@@ -552,6 +632,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
                 securityType,
                 pinHash,
                 primaryImageTag: auth.data.User.PrimaryImageTag ?? undefined,
+                deviceId: accountDeviceId,
               });
             }
           }
@@ -702,9 +783,14 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         throw new Error("No saved credential found");
       }
 
-      // Create API instance with saved token
+      // Credentials predating device ids fall back to the active id, which
+      // after upgrading is still the one they were issued under.
+      const credentialDeviceId = credential.deviceId ?? getOrSetDeviceId();
+      const credentialJellyfin = buildJellyfin(credentialDeviceId);
+      if (!credentialJellyfin) throw new Error("Failed to create SDK instance");
+
       const apiInstance = createApiWithCustomHeaders(
-        jellyfin,
+        credentialJellyfin,
         serverUrl,
         credential.token,
       );
@@ -716,9 +802,8 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       try {
         const response = await getUserApi(apiInstance).getCurrentUser();
 
-        // Clear React Query cache to prevent data from previous account lingering
-        queryClient.clear();
-        storage.remove("REACT_QUERY_OFFLINE_CACHE");
+        adoptDeviceId(credentialDeviceId);
+        await clearAccountScopedState();
 
         // Token is valid, update state
         setApi(apiInstance);
@@ -727,29 +812,30 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         storage.set("token", credential.token);
         storage.set("user", JSON.stringify(response.data));
 
-        // Update account info (in case user changed their avatar)
-        if (response.data.PrimaryImageTag !== credential.primaryImageTag) {
-          addAccountToServer(serverUrl, credential.serverName, {
-            userId: credential.userId,
-            username: credential.username,
-            securityType: credential.securityType,
-            savedAt: credential.savedAt,
-            primaryImageTag: response.data.PrimaryImageTag ?? undefined,
-          });
-        }
+        // Record the id this token is bound to, or it mints a fresh one next
+        // login and revokes itself. Also refreshes a changed avatar.
+        await updateAccountToken(
+          serverUrl,
+          credential.userId,
+          credential.token,
+          response.data.PrimaryImageTag ?? undefined,
+          credentialDeviceId,
+        );
 
         // Refresh plugin settings
         await refreshStreamyfinPluginSettings();
       } catch (error) {
         // Check for axios error
         if (axios.isAxiosError(error)) {
-          // Token is invalid/expired - remove it
+          // Token is invalid/expired. Keep the account — the caller offers
+          // re-authentication and refreshes the token in place.
           if (
             error.response?.status === 401 ||
             error.response?.status === 403
           ) {
-            await deleteAccountCredential(serverUrl, userId);
-            throw markExpectedError(new Error(t("server.session_expired")));
+            throw markExpectedError(
+              new SessionExpiredError(t("server.session_expired")),
+            );
           }
 
           // Network error - server not reachable (no response means server didn't respond)
@@ -790,8 +876,13 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
     }) => {
       if (!jellyfin) throw new Error("Jellyfin not initialized");
 
-      // Create API instance for the server
-      const apiInstance = createApiWithCustomHeaders(jellyfin, serverUrl);
+      // Reuse this account's own id so the refreshed token replaces its
+      // predecessor instead of revoking another account's.
+      const accountDeviceId = resolveDeviceIdForLogin(serverUrl, username);
+      const accountJellyfin = buildJellyfin(accountDeviceId);
+      if (!accountJellyfin) throw new Error("Failed to create SDK instance");
+
+      const apiInstance = createApiWithCustomHeaders(accountJellyfin, serverUrl);
       if (!apiInstance) {
         throw new Error("Failed to create API instance");
       }
@@ -812,15 +903,14 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         });
 
       if (auth.data.AccessToken && auth.data.User) {
-        // Clear React Query cache to prevent data from previous account lingering
-        queryClient.clear();
-        storage.remove("REACT_QUERY_OFFLINE_CACHE");
+        adoptDeviceId(accountDeviceId);
+        await clearAccountScopedState();
 
         setUser(auth.data.User);
         storage.set("user", JSON.stringify(auth.data.User));
         setApi(
           createApiWithCustomHeaders(
-            jellyfin,
+            accountJellyfin,
             serverUrl,
             auth.data.AccessToken,
           ),
@@ -834,6 +924,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           auth.data.User.Id || "",
           auth.data.AccessToken,
           auth.data.User.PrimaryImageTag ?? undefined,
+          accountDeviceId,
         );
 
         // Refresh plugin settings
@@ -887,9 +978,14 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
     }
   }, [initialLoaded]);
 
+  // `jellyfin` is re-created on every switch, so without this the stored
+  // session would be restored again on each one.
+  const restoredRef = useRef(false);
+
   useEffect(() => {
     const initializeJellyfin = async () => {
-      if (!jellyfin) return;
+      if (!jellyfin || restoredRef.current) return;
+      restoredRef.current = true;
 
       try {
         // Run migration to multi-account format (once)
@@ -898,6 +994,16 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         const token = getTokenFromStorage();
         const serverUrl = getServerUrlFromStorage();
         const storedUser = getUserFromStorage();
+
+        // The signed-in account keeps the shared id its token was issued
+        // under; regenerating would revoke the token being restored.
+        if (serverUrl && storedUser?.Id) {
+          await migrateCurrentAccountDeviceId(
+            serverUrl,
+            storedUser.Id,
+            getOrSetDeviceId(),
+          );
+        }
 
         if (serverUrl && token) {
           const apiInstance = createApiWithCustomHeaders(
@@ -941,6 +1047,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
                     savedAt: Date.now(),
                     securityType: "none",
                     primaryImageTag: response.data.PrimaryImageTag ?? undefined,
+                    deviceId: getOrSetDeviceId(),
                   });
                 } else if (
                   response.data.PrimaryImageTag !==
@@ -953,6 +1060,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
                     securityType: existingCredential.securityType,
                     savedAt: existingCredential.savedAt,
                     primaryImageTag: response.data.PrimaryImageTag ?? undefined,
+                    deviceId: existingCredential.deviceId,
                   });
                 }
               }

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -157,7 +157,9 @@ interface JellyfinContextValue {
     serverName?: string;
   }) => Promise<void>;
   logout: () => Promise<void>;
-  initiateQuickConnect: () => Promise<string | undefined>;
+  initiateQuickConnect: (options?: {
+    saveAccount?: boolean;
+  }) => Promise<string | undefined>;
   stopQuickConnectPolling: () => void;
   loginWithSavedCredential: (
     serverUrl: string,
@@ -229,6 +231,11 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
   const [quickConnectDeviceId, setQuickConnectDeviceId] = useState<
     string | null
   >(null);
+  // Whether the attempt asked for the account to be saved. Quick Connect has no
+  // save step of its own, so the answer has to be carried from the screen that
+  // started it through to the approval.
+  const [quickConnectSaveAccount, setQuickConnectSaveAccount] =
+    useState<boolean>(false);
   const { settings, setPluginSettings, refreshStreamyfinPluginSettings } =
     useSettings();
   const { clearAllJellyseerData, jellyseerrUser, setJellyseerrUser } =
@@ -421,35 +428,40 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
     [],
   );
 
-  const initiateQuickConnect = useCallback(async () => {
-    if (!api) return;
-    // Quick Connect cannot name the account upfront. Adopting this id now
-    // would strand the running session, whose token is bound to the old one.
-    const attemptDeviceId = mintDeviceId();
-    setQuickConnectDeviceId(attemptDeviceId);
-    try {
-      const response = await api.axiosInstance.post(
-        `${api.basePath}/QuickConnect/Initiate`,
-        null,
-        {
-          headers: authHeaders(attemptDeviceId),
-        },
-      );
-      if (response?.status === 200) {
-        setSecret(response?.data?.Secret);
-        setIsPolling(true);
-        return response.data?.Code;
+  const initiateQuickConnect = useCallback(
+    async (options?: { saveAccount?: boolean }) => {
+      if (!api) return;
+      // Quick Connect cannot name the account upfront. Adopting this id now
+      // would strand the running session, whose token is bound to the old one.
+      const attemptDeviceId = mintDeviceId();
+      setQuickConnectDeviceId(attemptDeviceId);
+      setQuickConnectSaveAccount(options?.saveAccount ?? false);
+      try {
+        const response = await api.axiosInstance.post(
+          `${api.basePath}/QuickConnect/Initiate`,
+          null,
+          {
+            headers: authHeaders(attemptDeviceId),
+          },
+        );
+        if (response?.status === 200) {
+          setSecret(response?.data?.Secret);
+          setIsPolling(true);
+          return response.data?.Code;
+        }
+        throw new Error("Failed to initiate quick connect");
+      } catch (error) {
+        console.error(error);
+        throw error;
       }
-      throw new Error("Failed to initiate quick connect");
-    } catch (error) {
-      console.error(error);
-      throw error;
-    }
-  }, [api, authHeaders]);
+    },
+    [api, authHeaders],
+  );
 
   const stopQuickConnectPolling = useCallback(() => {
     setIsPolling(false);
     setSecret(null);
+    setQuickConnectSaveAccount(false);
     setQuickConnectDeviceId(null);
   }, []);
 
@@ -500,10 +512,10 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           });
 
           // Whoever approved meant to sign in, even if that is not the account
-          // we asked to re-authenticate. Saving a new one is TV-only: there the
-          // switcher is the way in and no save prompt exists, whereas on mobile
-          // the user answers the protection picker first (see
-          // PendingAccountSaveModal) and may well decline.
+          // we asked to re-authenticate. A known account is always refreshed;
+          // saving an unknown one needs the consent the screen collected before
+          // starting the attempt. Mobile leaves this false and runs its own
+          // protection picker afterwards (see PendingAccountSaveModal).
           if (User?.Id) {
             await recordAccountSignIn({
               serverUrl,
@@ -511,7 +523,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
               username: User.Name || "",
               token: AccessToken,
               deviceId: quickConnectDeviceId,
-              saveIfNew: Platform.isTV,
+              saveIfNew: quickConnectSaveAccount,
               primaryImageTag: User.PrimaryImageTag ?? undefined,
             });
           }
@@ -525,6 +537,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           setIsPolling(false);
           setSecret(null);
           setQuickConnectDeviceId(null);
+          setQuickConnectSaveAccount(false);
           if (error.response?.status === 400) {
             throw new Error("The code has expired. Please try again.");
           }
@@ -540,6 +553,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
     authHeaders,
     jellyfin,
     quickConnectDeviceId,
+    quickConnectSaveAccount,
     adoptDeviceId,
     activateSession,
     clearAccountScopedState,

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -27,6 +27,7 @@ import { JellyseerrApi, useJellyseerr } from "@/hooks/useJellyseerr";
 import { settingsAtom, useSettings } from "@/utils/atoms/settings";
 import { getIntegrationHeaders } from "@/utils/customHeaders";
 import {
+  getBaseDeviceId,
   getOrSetDeviceId,
   mintDeviceId,
   setActiveDeviceId,
@@ -42,7 +43,6 @@ import {
 import { storage } from "@/utils/mmkv";
 import {
   type AccountSecurityType,
-  addAccountToServer,
   addServerToList,
   deleteAccountCredential,
   deleteJellyseerrPassword,
@@ -335,6 +335,56 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
     }
   }, [queryClient, clearAllJellyseerData]);
 
+  // Publish an authorized session. Four login paths reach this point and each
+  // used to write the same five lines by hand, which is how one of them ends up
+  // forgetting the serverUrl or ordering the writes differently.
+  const activateSession = useCallback(
+    (session: {
+      api: Api;
+      serverUrl: string;
+      token: string;
+      user: UserDto;
+    }) => {
+      setUser(session.user);
+      setApi(session.api);
+      storage.set("serverUrl", session.serverUrl);
+      storage.set("token", session.token);
+      storage.set("user", JSON.stringify(session.user));
+    },
+    [setUser, setApi],
+  );
+
+  // Jellyfin access tokens do not expire, so a session nobody keeps a reference
+  // to stays live on the server for good. Logging out tells the server to drop
+  // it — unless a saved account still holds this exact token, since quick login
+  // replays it and revoking would leave that entry unusable.
+  const revokeUnsavedSessionToken = useCallback(async () => {
+    const token = storage.getString("token");
+    if (!api?.basePath || !token) return;
+
+    try {
+      if (user?.Id) {
+        const saved = await getAccountCredential(api.basePath, user.Id);
+        if (saved?.token === token) return;
+      }
+    } catch (e) {
+      // Leaving a token live is what every previous release did; failing the
+      // logout over it would be worse.
+      writeErrorLog(
+        `Failed to check for a saved token: ${e instanceof Error ? e.message : e}`,
+      );
+      return;
+    }
+
+    // Fire-and-forget, like the push-token cleanup above: the SDK's axios
+    // instance carries no timeout, so awaiting this would stall the logout for
+    // the full TCP timeout whenever the server is unreachable.
+    api
+      .post("/Sessions/Logout", null)
+      .then((_r) => writeInfoLog("Revoked session token"))
+      .catch((_e) => writeErrorLog("Failed to revoke session token"));
+  }, [api, user?.Id]);
+
   const handleSessionExpired = useCallback(() => {
     if (sessionExpiredRef.current) return; // run once per session
     sessionExpiredRef.current = true;
@@ -438,15 +488,22 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
             throw new Error("Failed to create SDK instance");
           setQuickConnectDeviceId(null);
 
-          setUser(User);
-          setApi(
-            createApiWithCustomHeaders(accountJellyfin, serverUrl, AccessToken),
-          );
-          storage.set("token", AccessToken);
-          storage.set("user", JSON.stringify(User));
+          activateSession({
+            api: createApiWithCustomHeaders(
+              accountJellyfin,
+              serverUrl,
+              AccessToken,
+            ),
+            serverUrl,
+            token: AccessToken,
+            user: User,
+          });
 
-          // Whoever approved meant to sign in, even if that is not the
-          // account we asked to re-authenticate.
+          // Whoever approved meant to sign in, even if that is not the account
+          // we asked to re-authenticate. Saving a new one is TV-only: there the
+          // switcher is the way in and no save prompt exists, whereas on mobile
+          // the user answers the protection picker first (see
+          // PendingAccountSaveModal) and may well decline.
           if (User?.Id) {
             await recordAccountSignIn({
               serverUrl,
@@ -454,6 +511,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
               username: User.Name || "",
               token: AccessToken,
               deviceId: quickConnectDeviceId,
+              saveIfNew: Platform.isTV,
               primaryImageTag: User.PrimaryImageTag ?? undefined,
             });
           }
@@ -476,7 +534,16 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       console.error("Error polling Quick Connect:", error);
       throw error;
     }
-  }, [api, secret, authHeaders, jellyfin, quickConnectDeviceId, adoptDeviceId]);
+  }, [
+    api,
+    secret,
+    authHeaders,
+    jellyfin,
+    quickConnectDeviceId,
+    adoptDeviceId,
+    activateSession,
+    clearAccountScopedState,
+  ]);
 
   useEffect(() => {
     (async () => {
@@ -607,16 +674,28 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           // which is only reachable after a logout that already tore the
           // previous account's state down.
           adoptDeviceId(accountDeviceId);
-          setUser(auth.data.User);
-          storage.set("user", JSON.stringify(auth.data.User));
-          setApi(
-            createApiWithCustomHeaders(
+          activateSession({
+            api: createApiWithCustomHeaders(
               accountJellyfin,
               serverUrl,
               auth.data.AccessToken,
             ),
+            serverUrl,
+            token: auth.data.AccessToken,
+            user: auth.data.User,
+          });
+
+          // An account that is already saved gets its stored token refreshed
+          // whether or not this login asked to save it. Skipping that strands a
+          // rejected credential on its dead token, and the switcher entry then
+          // fails forever with no way back.
+          await updateAccountToken(
+            serverUrl,
+            auth.data.User.Id || "",
+            auth.data.AccessToken,
+            auth.data.User.PrimaryImageTag ?? undefined,
+            accountDeviceId,
           );
-          storage.set("token", auth.data?.AccessToken);
 
           // Save credentials to secure storage if requested
           if (options?.saveAccount) {
@@ -772,6 +851,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           writeErrorLog("Failed to delete expo push token for device"),
         );
 
+      await revokeUnsavedSessionToken();
       await clearSessionState();
     },
     onError: (error) => {
@@ -794,13 +874,13 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         throw new Error("No saved credential found");
       }
 
-      // Credentials predating device ids fall back to the active id, which
-      // after upgrading is still the one they were issued under. Borrowed for
-      // the request but never written back: tokens are scoped per server, so
-      // two accounts on different servers can both be live here, and
-      // persisting the borrowed id would leave them sharing one.
+      // Credentials predating device ids fall back to the install-wide id they
+      // were actually issued under, not to whichever id happens to be active —
+      // that one belongs to the account being switched away from. Borrowed for
+      // the request but never written back, so the next password login mints an
+      // id of this account's own instead of settling on a shared one.
       const ownsDeviceId = credential.deviceId !== undefined;
-      const credentialDeviceId = credential.deviceId ?? getOrSetDeviceId();
+      const credentialDeviceId = credential.deviceId ?? getBaseDeviceId();
       const credentialJellyfin = buildJellyfin(credentialDeviceId);
       if (!credentialJellyfin) throw new Error("Failed to create SDK instance");
 
@@ -821,11 +901,12 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         adoptDeviceId(credentialDeviceId);
 
         // Token is valid, update state
-        setApi(apiInstance);
-        setUser(response.data);
-        storage.set("serverUrl", serverUrl);
-        storage.set("token", credential.token);
-        storage.set("user", JSON.stringify(response.data));
+        activateSession({
+          api: apiInstance,
+          serverUrl,
+          token: credential.token,
+          user: response.data,
+        });
 
         // Refresh a changed avatar, and keep the account's own device id. An
         // account that never had one keeps it that way, so its next password
@@ -925,17 +1006,16 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         await clearAccountScopedState();
         adoptDeviceId(accountDeviceId);
 
-        setUser(auth.data.User);
-        storage.set("user", JSON.stringify(auth.data.User));
-        setApi(
-          createApiWithCustomHeaders(
+        activateSession({
+          api: createApiWithCustomHeaders(
             accountJellyfin,
             serverUrl,
             auth.data.AccessToken,
           ),
-        );
-        storage.set("serverUrl", serverUrl);
-        storage.set("token", auth.data.AccessToken);
+          serverUrl,
+          token: auth.data.AccessToken,
+          user: auth.data.User,
+        });
 
         // Update the saved credential with new token and image tag
         await updateAccountToken(
@@ -1015,12 +1095,13 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         const storedUser = getUserFromStorage();
 
         // The signed-in account keeps the shared id its token was issued
-        // under; regenerating would revoke the token being restored.
+        // under; regenerating would revoke the token being restored. The
+        // migration itself refuses an id another account has already claimed.
         if (serverUrl && storedUser?.Id) {
           await migrateCurrentAccountDeviceId(
             serverUrl,
             storedUser.Id,
-            getOrSetDeviceId(),
+            getBaseDeviceId(),
           );
         }
 
@@ -1050,38 +1131,26 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
               if (getTokenFromStorage() !== token) return;
               setUser(response.data);
 
-              // Migrate current session to secure storage if not already saved
+              // Migrate current session to secure storage if not already saved,
+              // and otherwise pick up a changed avatar.
               if (storedUser?.Id && storedUser?.Name) {
-                const existingCredential = await getAccountCredential(
+                const known = await getAccountCredential(
                   serverUrl,
                   storedUser.Id,
                 );
-                if (!existingCredential) {
-                  await saveAccountCredential({
-                    serverUrl,
-                    serverName: "",
-                    token,
-                    userId: storedUser.Id,
-                    username: storedUser.Name,
-                    savedAt: Date.now(),
-                    securityType: "none",
-                    primaryImageTag: response.data.PrimaryImageTag ?? undefined,
-                    deviceId: getOrSetDeviceId(),
-                  });
-                } else if (
-                  response.data.PrimaryImageTag !==
-                  existingCredential.primaryImageTag
-                ) {
-                  // Update image tag if it has changed
-                  addAccountToServer(serverUrl, existingCredential.serverName, {
-                    userId: existingCredential.userId,
-                    username: existingCredential.username,
-                    securityType: existingCredential.securityType,
-                    savedAt: existingCredential.savedAt,
-                    primaryImageTag: response.data.PrimaryImageTag ?? undefined,
-                    deviceId: existingCredential.deviceId,
-                  });
-                }
+                await recordAccountSignIn({
+                  serverUrl,
+                  userId: storedUser.Id,
+                  username: storedUser.Name,
+                  token,
+                  // This session's token was issued under the active id, so a
+                  // first save records that. A credential that already exists
+                  // keeps whatever it has: an account still on the legacy id
+                  // must stay unstamped so its next login mints its own.
+                  deviceId: known ? known.deviceId : getOrSetDeviceId(),
+                  saveIfNew: true,
+                  primaryImageTag: response.data.PrimaryImageTag ?? undefined,
+                });
               }
             })
             .catch((e) => {

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -56,6 +56,7 @@ import {
   saveJellyseerrPassword,
   updateAccountToken,
 } from "@/utils/secureCredentials";
+import { SessionExpiredError } from "@/utils/sessionExpired";
 import { store } from "@/utils/store";
 import { clearTVDiscoverySafely } from "@/utils/tvDiscovery/sync";
 import { APP_VERSION } from "@/utils/version";
@@ -133,15 +134,6 @@ export const cacheVersionAtom = atom<number>(0);
 export const pendingAccountSaveAtom = atom<{ serverName?: string } | null>(
   null,
 );
-
-/** A rejected token on a saved account. The account is kept — callers offer
- * re-authentication instead. */
-export class SessionExpiredError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "SessionExpiredError";
-  }
-}
 
 interface LoginOptions {
   saveAccount?: boolean;
@@ -431,6 +423,9 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           if (!accountJellyfin)
             throw new Error("Failed to create SDK instance");
           setQuickConnectDeviceId(null);
+          // Quick Connect can land on a different account than the one already
+          // signed in, so it needs the same teardown as the other paths.
+          await clearAccountScopedState();
 
           setUser(User);
           setApi(
@@ -597,6 +592,9 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         ).authenticateUserByName(username, password);
 
         if (auth.data.AccessToken && auth.data.User) {
+          // No clearAccountScopedState here: this runs from the login screen,
+          // which is only reachable after a logout that already tore the
+          // previous account's state down.
           adoptDeviceId(accountDeviceId);
           setUser(auth.data.User);
           storage.set("user", JSON.stringify(auth.data.User));
@@ -786,7 +784,11 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       }
 
       // Credentials predating device ids fall back to the active id, which
-      // after upgrading is still the one they were issued under.
+      // after upgrading is still the one they were issued under. Borrowed for
+      // the request but never written back: tokens are scoped per server, so
+      // two accounts on different servers can both be live here, and
+      // persisting the borrowed id would leave them sharing one.
+      const ownsDeviceId = credential.deviceId !== undefined;
       const credentialDeviceId = credential.deviceId ?? getOrSetDeviceId();
       const credentialJellyfin = buildJellyfin(credentialDeviceId);
       if (!credentialJellyfin) throw new Error("Failed to create SDK instance");
@@ -814,14 +816,15 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         storage.set("token", credential.token);
         storage.set("user", JSON.stringify(response.data));
 
-        // Record the id this token is bound to, or it mints a fresh one next
-        // login and revokes itself. Also refreshes a changed avatar.
+        // Refresh a changed avatar, and keep the account's own device id. An
+        // account that never had one keeps it that way, so its next password
+        // login mints an id of its own rather than inheriting this one.
         await updateAccountToken(
           serverUrl,
           credential.userId,
           credential.token,
           response.data.PrimaryImageTag ?? undefined,
-          credentialDeviceId,
+          ownsDeviceId ? credentialDeviceId : undefined,
         );
 
         // Refresh plugin settings

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -988,7 +988,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       if (!jellyfin) throw new Error("Jellyfin not initialized");
 
       // Reuse this account's own id so the refreshed token replaces its
-      // predecessor instead of revoking another account's.
+      // predecessor instead of displacing another account's session.
       const accountDeviceId = resolveDeviceIdForLogin(serverUrl, username);
       const accountJellyfin = buildJellyfin(accountDeviceId);
       if (!accountJellyfin) throw new Error("Failed to create SDK instance");
@@ -1109,8 +1109,9 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         const storedUser = getUserFromStorage();
 
         // The signed-in account keeps the shared id its token was issued
-        // under; regenerating would revoke the token being restored. The
-        // migration itself refuses an id another account has already claimed.
+        // under; regenerating would strand it, and on ≤10.8 servers would
+        // revoke the token being restored. The migration itself refuses an id
+        // another account has already claimed.
         if (serverUrl && storedUser?.Id) {
           await migrateCurrentAccountDeviceId(
             serverUrl,

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -50,6 +50,7 @@ import {
   hashPIN,
   migrateCurrentAccountDeviceId,
   migrateToMultiAccount,
+  recordAccountSignIn,
   resolveDeviceIdForLogin,
   saveAccountCredential,
   saveJellyseerrPassword,
@@ -439,35 +440,16 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           storage.set("user", JSON.stringify(User));
 
           // Whoever approved meant to sign in, even if that is not the
-          // account we asked to re-authenticate. Save them if they are new:
-          // Quick Connect has no "save this account" step, so without this the
-          // sign-in works but the account never appears in the switcher.
+          // account we asked to re-authenticate.
           if (User?.Id) {
-            const existing = await getAccountCredential(serverUrl, User.Id);
-            if (existing) {
-              await updateAccountToken(
-                serverUrl,
-                User.Id,
-                AccessToken,
-                User.PrimaryImageTag ?? undefined,
-                quickConnectDeviceId,
-              );
-            } else {
-              await saveAccountCredential({
-                serverUrl,
-                // Empty keeps whatever name the server list already holds.
-                serverName: "",
-                token: AccessToken,
-                userId: User.Id,
-                username: User.Name || "",
-                savedAt: Date.now(),
-                // Quick Connect is already an approval on a trusted device;
-                // demanding a second factor to switch back would be odd.
-                securityType: "none",
-                primaryImageTag: User.PrimaryImageTag ?? undefined,
-                deviceId: quickConnectDeviceId,
-              });
-            }
+            await recordAccountSignIn({
+              serverUrl,
+              userId: User.Id,
+              username: User.Name || "",
+              token: AccessToken,
+              deviceId: quickConnectDeviceId,
+              primaryImageTag: User.PrimaryImageTag ?? undefined,
+            });
           }
           return true;
         }

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -323,7 +323,16 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
   const clearAccountScopedState = useCallback(async () => {
     queryClient.clear();
     storage.remove("REACT_QUERY_OFFLINE_CACHE");
-    await clearAllJellyseerData();
+    try {
+      // Reaches an external service, so it must not be able to abort an
+      // authentication that already succeeded — same reasoning as the logout
+      // teardown above.
+      await clearAllJellyseerData();
+    } catch (e) {
+      writeErrorLog(
+        `Failed to clear Jellyseerr data: ${e instanceof Error ? e.message : e}`,
+      );
+    }
   }, [queryClient, clearAllJellyseerData]);
 
   const handleSessionExpired = useCallback(() => {
@@ -419,13 +428,15 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
 
           const { AccessToken, User } = authResponse.data;
           // The token is bound to the id the request went out under.
+          // Teardown first: adopting the device id publishes it to MMKV, and
+          // an await between that and setApi would let the socket reconnect
+          // under the new device id while still holding the old token.
+          await clearAccountScopedState();
+
           const accountJellyfin = adoptDeviceId(quickConnectDeviceId);
           if (!accountJellyfin)
             throw new Error("Failed to create SDK instance");
           setQuickConnectDeviceId(null);
-          // Quick Connect can land on a different account than the one already
-          // signed in, so it needs the same teardown as the other paths.
-          await clearAccountScopedState();
 
           setUser(User);
           setApi(
@@ -806,8 +817,8 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       try {
         const response = await getUserApi(apiInstance).getCurrentUser();
 
-        adoptDeviceId(credentialDeviceId);
         await clearAccountScopedState();
+        adoptDeviceId(credentialDeviceId);
 
         // Token is valid, update state
         setApi(apiInstance);
@@ -911,8 +922,8 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         });
 
       if (auth.data.AccessToken && auth.data.User) {
-        adoptDeviceId(accountDeviceId);
         await clearAccountScopedState();
+        adoptDeviceId(accountDeviceId);
 
         setUser(auth.data.User);
         storage.set("user", JSON.stringify(auth.data.User));

--- a/providers/WebSocketProvider.tsx
+++ b/providers/WebSocketProvider.tsx
@@ -7,11 +7,11 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
 import { AppState, type AppStateStatus } from "react-native";
+import { useMMKVString } from "react-native-mmkv";
 import { useNetworkAwareQueryClient } from "@/hooks/useNetworkAwareQueryClient";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { useNetworkStatus } from "@/providers/NetworkStatusProvider";
@@ -106,9 +106,11 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
   const [isConnected, setIsConnected] = useState(false);
   const [lastMessage, setLastMessage] = useState<WebSocketMessage | null>(null);
   const queryClient = useNetworkAwareQueryClient();
-  const deviceId = useMemo(() => {
-    return getOrSetDeviceId();
-  }, []);
+  // Read reactively: on an account switch the socket URL and
+  // postFullCapabilities must follow, or this session is reported against the
+  // previous account's device.
+  const [storedDeviceId] = useMMKVString("deviceId");
+  const deviceId = storedDeviceId ?? getOrSetDeviceId();
   const reconnectAttemptsRef = useRef(0);
   const libraryChangeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,

--- a/utils/customHeaders/secureValues.test.ts
+++ b/utils/customHeaders/secureValues.test.ts
@@ -1,16 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const secureStoreValues = new Map<string, string>();
+import { secureStoreMock, secureStoreValues } from "../testing/secureStoreMock";
 
-mock.module("expo-secure-store", () => ({
-  getItem: (key: string) => secureStoreValues.get(key) ?? null,
-  setItem: (key: string, value: string) => {
-    secureStoreValues.set(key, value);
-  },
-  deleteItemAsync: async (key: string) => {
-    secureStoreValues.delete(key);
-  },
-}));
+mock.module("expo-secure-store", secureStoreMock);
 
 const { resolveCustomHeaderValues, secureCustomHeaderMetadata } = await import(
   "./secureValues"

--- a/utils/device.ts
+++ b/utils/device.ts
@@ -14,7 +14,23 @@ export const getOrSetDeviceId = () => {
   return deviceId;
 };
 
+/**
+ * The install-wide id every account shared before ids became per-account.
+ * Tokens issued back then are only valid under it, and the active id no longer
+ * stays put, so it is pinned on first use and never rewritten.
+ */
+export const getBaseDeviceId = () => {
+  const existing = storage.getString("baseDeviceId");
+  if (existing) return existing;
+
+  const base = getOrSetDeviceId();
+  storage.set("baseDeviceId", base);
+  return base;
+};
+
 export const setActiveDeviceId = (deviceId: string) => {
+  // Pin the legacy id before the active one moves off it.
+  getBaseDeviceId();
   storage.set("deviceId", deviceId);
 };
 

--- a/utils/device.ts
+++ b/utils/device.ts
@@ -1,6 +1,8 @@
 import * as Crypto from "expo-crypto";
 import { storage } from "./mmkv";
 
+// Holds the ACTIVE account's device id, rewritten on every login and account
+// switch, so callers should read it rather than cache it.
 export const getOrSetDeviceId = () => {
   const existing = storage.getString("deviceId");
   if (existing) {
@@ -11,6 +13,12 @@ export const getOrSetDeviceId = () => {
   storage.set("deviceId", deviceId);
   return deviceId;
 };
+
+export const setActiveDeviceId = (deviceId: string) => {
+  storage.set("deviceId", deviceId);
+};
+
+export const mintDeviceId = () => Crypto.randomUUID();
 
 export const getDeviceId = () => {
   const deviceId = storage.getString("deviceId");

--- a/utils/jellyfin/getDefaultPlaySettings.test.ts
+++ b/utils/jellyfin/getDefaultPlaySettings.test.ts
@@ -8,14 +8,9 @@ import type { Settings } from "@/utils/atoms/settings";
 
 // react-native-mmkv needs a native module. Back it with a Map so the per-series
 // memory under test is exercised for real rather than stubbed out.
-const store = new Map<string, string>();
-mock.module("react-native-mmkv", () => ({
-  createMMKV: () => ({
-    getString: (key: string) => store.get(key),
-    set: (key: string, value: string) => void store.set(key, value),
-    delete: (key: string) => void store.delete(key),
-  }),
-}));
+import { mmkvMock, mmkvStore } from "@/utils/testing/mmkvMock";
+
+mock.module("react-native-mmkv", mmkvMock);
 
 // BitrateSelector is a React component module; only the BITRATES table matters.
 mock.module("@/components/BitrateSelector", () => ({
@@ -75,7 +70,7 @@ const settingsWith = (patch: Partial<Settings>): Settings =>
 
 const lang = (code: string) => ({ ThreeLetterISOLanguageName: code }) as never;
 
-beforeEach(() => store.clear());
+beforeEach(() => mmkvStore.clear());
 
 describe("language preferences apply on every path", () => {
   // Regression: this block used to be gated behind an `applyLanguagePreferences`

--- a/utils/nativePlayer/resolveTrackIndexes.test.ts
+++ b/utils/nativePlayer/resolveTrackIndexes.test.ts
@@ -5,14 +5,9 @@ import type {
 } from "@jellyfin/sdk/lib/generated-client";
 import type { Settings } from "@/utils/atoms/settings";
 
-const store = new Map<string, string>();
-mock.module("react-native-mmkv", () => ({
-  createMMKV: () => ({
-    getString: (k: string) => store.get(k),
-    set: (k: string, v: string) => void store.set(k, v),
-    delete: (k: string) => void store.delete(k),
-  }),
-}));
+import { mmkvMock, mmkvStore } from "@/utils/testing/mmkvMock";
+
+mock.module("react-native-mmkv", mmkvMock);
 mock.module("@/components/BitrateSelector", () => ({
   BITRATES: [{ key: "Max", value: undefined }],
 }));
@@ -47,7 +42,7 @@ const simple = item([
   },
 ]);
 
-beforeEach(() => store.clear());
+beforeEach(() => mmkvStore.clear());
 
 describe("offline", () => {
   test("uses the download record rather than the server media source", () => {

--- a/utils/secureCredentials.test.ts
+++ b/utils/secureCredentials.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const store = new Map<string, string>();
+mock.module("react-native-mmkv", () => ({
+  createMMKV: () => ({
+    getString: (k: string) => store.get(k),
+    getBoolean: (k: string) => store.get(k) === "true",
+    set: (k: string, v: string | boolean) => void store.set(k, String(v)),
+    delete: (k: string) => void store.delete(k),
+    remove: (k: string) => void store.delete(k),
+  }),
+}));
+
+const secureStore = new Map<string, string>();
+mock.module("expo-secure-store", () => ({
+  getItemAsync: async (k: string) => secureStore.get(k) ?? null,
+  setItemAsync: async (k: string, v: string) => void secureStore.set(k, v),
+  deleteItemAsync: async (k: string) => void secureStore.delete(k),
+}));
+
+let uuidCounter = 0;
+mock.module("expo-crypto", () => ({
+  randomUUID: () => `uuid-${++uuidCounter}`,
+  digestStringAsync: async (_algo: string, value: string) => `hash(${value})`,
+  CryptoDigestAlgorithm: { SHA256: "SHA-256" },
+}));
+
+const {
+  resolveDeviceIdForLogin,
+  migrateCurrentAccountDeviceId,
+  saveAccountCredential,
+  getAccountCredential,
+  getPreviousServers,
+  updateAccountToken,
+} = await import("./secureCredentials");
+// bun's mock.module registry is shared across test files, so mmkv may be backed
+// by another file's map. Reset through the same storage object the code writes
+// to rather than the map declared above.
+const { storage } = await import("./mmkv");
+
+const SERVER = "https://jf.example.com";
+
+const accountsOf = (serverUrl = SERVER) =>
+  getPreviousServers().find((s) => s.address === serverUrl)?.accounts ?? [];
+
+const seed = async (
+  username: string,
+  userId: string,
+  deviceId?: string,
+  serverUrl = SERVER,
+) => {
+  await saveAccountCredential({
+    serverUrl,
+    serverName: "Test",
+    token: `token-${userId}`,
+    userId,
+    username,
+    savedAt: 1,
+    securityType: "none",
+    deviceId,
+  });
+};
+
+beforeEach(() => {
+  store.clear();
+  storage.delete("previousServers");
+  secureStore.clear();
+  uuidCounter = 0;
+});
+
+describe("resolveDeviceIdForLogin", () => {
+  test("mints a fresh id when the username is unknown", () => {
+    expect(resolveDeviceIdForLogin(SERVER, "alice")).toBe("uuid-1");
+  });
+
+  test("mints a distinct id per unknown user, so tokens never collide", () => {
+    const a = resolveDeviceIdForLogin(SERVER, "alice");
+    const b = resolveDeviceIdForLogin(SERVER, "anna");
+    expect(a).not.toBe(b);
+  });
+
+  test("reuses the stored id when the account is already known", async () => {
+    await seed("alice", "u1", "device-alice");
+    expect(resolveDeviceIdForLogin(SERVER, "alice")).toBe("device-alice");
+  });
+
+  test("matches the username case-insensitively", async () => {
+    // Jellyfin accepts any casing at login; a case-only difference must not
+    // mint a second device id, which would revoke the account's own token.
+    await seed("Alice", "u1", "device-alice");
+    expect(resolveDeviceIdForLogin(SERVER, "alice")).toBe("device-alice");
+  });
+
+  test("mints a fresh id for a known account that predates the migration", async () => {
+    // Pre-upgrade accounts have no deviceId. Only one of them can own the
+    // legacy install-wide id, so the rest re-authenticate onto their own.
+    await seed("alice", "u1", undefined);
+    expect(resolveDeviceIdForLogin(SERVER, "alice")).toBe("uuid-1");
+  });
+
+  test("does not share an id across servers for the same username", async () => {
+    await seed("alice", "u1", "device-alice");
+    expect(resolveDeviceIdForLogin("https://other.example.com", "alice")).toBe(
+      "uuid-1",
+    );
+  });
+});
+
+describe("migrateCurrentAccountDeviceId", () => {
+  test("adopts the legacy install-wide id for the signed-in account", async () => {
+    await seed("alice", "u1", undefined);
+
+    await migrateCurrentAccountDeviceId(SERVER, "u1", "legacy-device");
+
+    const credential = await getAccountCredential(SERVER, "u1");
+    expect(credential?.deviceId).toBe("legacy-device");
+    expect(accountsOf()[0].deviceId).toBe("legacy-device");
+  });
+
+  test("leaves other accounts without an id, so they mint their own", async () => {
+    await seed("alice", "u1", undefined);
+    await seed("anna", "u2", undefined);
+
+    await migrateCurrentAccountDeviceId(SERVER, "u1", "legacy-device");
+
+    const anna = await getAccountCredential(SERVER, "u2");
+    expect(anna?.deviceId).toBeUndefined();
+  });
+
+  test("never overwrites an id that was already assigned", async () => {
+    await seed("alice", "u1", "device-alice");
+
+    await migrateCurrentAccountDeviceId(SERVER, "u1", "legacy-device");
+
+    const credential = await getAccountCredential(SERVER, "u1");
+    expect(credential?.deviceId).toBe("device-alice");
+  });
+
+  test("is a no-op when the account was never saved", async () => {
+    await migrateCurrentAccountDeviceId(SERVER, "unknown", "legacy-device");
+    expect(accountsOf()).toEqual([]);
+  });
+});
+
+describe("updateAccountToken", () => {
+  test("rebinds the account to the id the new token was issued under", async () => {
+    // Quick Connect mints an id before knowing who will approve it, so the
+    // account has to move onto that id or its requests go out on a stale one.
+    await seed("alice", "u1", "device-alice");
+
+    await updateAccountToken(SERVER, "u1", "fresh-token", undefined, "qc-id");
+
+    const credential = await getAccountCredential(SERVER, "u1");
+    expect(credential?.token).toBe("fresh-token");
+    expect(credential?.deviceId).toBe("qc-id");
+    expect(accountsOf()[0].deviceId).toBe("qc-id");
+  });
+
+  test("keeps the existing id when none is supplied", async () => {
+    await seed("alice", "u1", "device-alice");
+
+    await updateAccountToken(SERVER, "u1", "fresh-token");
+
+    expect((await getAccountCredential(SERVER, "u1"))?.deviceId).toBe(
+      "device-alice",
+    );
+  });
+});

--- a/utils/secureCredentials.test.ts
+++ b/utils/secureCredentials.test.ts
@@ -31,6 +31,7 @@ const {
   saveAccountCredential,
   getAccountCredential,
   getPreviousServers,
+  recordAccountSignIn,
   updateAccountToken,
 } = await import("./secureCredentials");
 // bun's mock.module registry is shared across test files, so mmkv may be backed
@@ -161,6 +162,81 @@ describe("updateAccountToken", () => {
 
     await updateAccountToken(SERVER, "u1", "fresh-token");
 
+    expect((await getAccountCredential(SERVER, "u1"))?.deviceId).toBe(
+      "device-alice",
+    );
+  });
+});
+
+describe("recordAccountSignIn", () => {
+  const signIn = (userId: string, username: string, deviceId: string) =>
+    recordAccountSignIn({
+      serverUrl: SERVER,
+      userId,
+      username,
+      token: `token-${userId}`,
+      deviceId,
+      primaryImageTag: "tag",
+    });
+
+  test("saves an account signing in for the first time", async () => {
+    // Quick Connect has no save step, so an unknown approver would otherwise
+    // authenticate and never appear in the switcher.
+    await signIn("u1", "alice", "device-alice");
+
+    const credential = await getAccountCredential(SERVER, "u1");
+    expect(credential?.username).toBe("alice");
+    expect(credential?.deviceId).toBe("device-alice");
+    expect(accountsOf()).toHaveLength(1);
+  });
+
+  test("defaults a newly saved account to no protection", async () => {
+    // Quick Connect is itself an approval from a signed-in device.
+    await signIn("u1", "alice", "device-alice");
+
+    expect((await getAccountCredential(SERVER, "u1"))?.securityType).toBe(
+      "none",
+    );
+  });
+
+  test("refreshes a known account rather than duplicating it", async () => {
+    await seed("alice", "u1", "device-alice");
+
+    await signIn("u1", "alice", "device-alice");
+
+    expect(accountsOf()).toHaveLength(1);
+    expect((await getAccountCredential(SERVER, "u1"))?.token).toBe("token-u1");
+  });
+
+  test("preserves a known account's protection choice", async () => {
+    // Re-authenticating must not silently downgrade a PIN-protected account.
+    await saveAccountCredential({
+      serverUrl: SERVER,
+      serverName: "Test",
+      token: "old",
+      userId: "u1",
+      username: "alice",
+      savedAt: 1,
+      securityType: "pin",
+      pinHash: "hash",
+      deviceId: "device-alice",
+    });
+
+    await signIn("u1", "alice", "device-alice");
+
+    const credential = await getAccountCredential(SERVER, "u1");
+    expect(credential?.securityType).toBe("pin");
+    expect(credential?.pinHash).toBe("hash");
+  });
+
+  test("keeps accounts separate when a second user signs in", async () => {
+    await signIn("u1", "alice", "device-alice");
+    await signIn("u2", "bob", "device-bob");
+
+    expect(accountsOf()).toHaveLength(2);
+    expect((await getAccountCredential(SERVER, "u2"))?.deviceId).toBe(
+      "device-bob",
+    );
     expect((await getAccountCredential(SERVER, "u1"))?.deviceId).toBe(
       "device-alice",
     );

--- a/utils/secureCredentials.test.ts
+++ b/utils/secureCredentials.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { logMock } from "./testing/logMock";
 import { mmkvMock, mmkvStore } from "./testing/mmkvMock";
 
+mock.module("@/utils/log", logMock);
 mock.module("react-native-mmkv", mmkvMock);
 
 import { secureStoreMock, secureStoreValues } from "./testing/secureStoreMock";

--- a/utils/secureCredentials.test.ts
+++ b/utils/secureCredentials.test.ts
@@ -1,15 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const store = new Map<string, string>();
-mock.module("react-native-mmkv", () => ({
-  createMMKV: () => ({
-    getString: (k: string) => store.get(k),
-    getBoolean: (k: string) => store.get(k) === "true",
-    set: (k: string, v: string | boolean) => void store.set(k, String(v)),
-    delete: (k: string) => void store.delete(k),
-    remove: (k: string) => void store.delete(k),
-  }),
-}));
+import { mmkvMock, mmkvStore } from "./testing/mmkvMock";
+
+mock.module("react-native-mmkv", mmkvMock);
 
 import { secureStoreMock, secureStoreValues } from "./testing/secureStoreMock";
 
@@ -60,7 +53,7 @@ const seed = async (
 };
 
 beforeEach(() => {
-  store.clear();
+  mmkvStore.clear();
   storage.delete("previousServers");
   secureStoreValues.clear();
   uuidCounter = 0;

--- a/utils/secureCredentials.test.ts
+++ b/utils/secureCredentials.test.ts
@@ -11,12 +11,9 @@ mock.module("react-native-mmkv", () => ({
   }),
 }));
 
-const secureStore = new Map<string, string>();
-mock.module("expo-secure-store", () => ({
-  getItemAsync: async (k: string) => secureStore.get(k) ?? null,
-  setItemAsync: async (k: string, v: string) => void secureStore.set(k, v),
-  deleteItemAsync: async (k: string) => void secureStore.delete(k),
-}));
+import { secureStoreMock, secureStoreValues } from "./testing/secureStoreMock";
+
+mock.module("expo-secure-store", secureStoreMock);
 
 let uuidCounter = 0;
 mock.module("expo-crypto", () => ({
@@ -65,7 +62,7 @@ const seed = async (
 beforeEach(() => {
   store.clear();
   storage.delete("previousServers");
-  secureStore.clear();
+  secureStoreValues.clear();
   uuidCounter = 0;
 });
 

--- a/utils/secureCredentials.test.ts
+++ b/utils/secureCredentials.test.ts
@@ -88,6 +88,17 @@ describe("resolveDeviceIdForLogin", () => {
     expect(resolveDeviceIdForLogin(SERVER, "alice")).toBe("uuid-1");
   });
 
+  test("matches a saved address that carries a trailing slash", async () => {
+    // previousServers holds whatever the user typed; the login passes the
+    // SDK's basePath, which drops it. An exact match would mint a second id.
+    await seed("alice", "u1", "device-alice", `${SERVER}/`);
+    expect(resolveDeviceIdForLogin(SERVER, "alice")).toBe("device-alice");
+  });
+
+  test("matches when the login url is the one carrying the slash", () => {
+    expect(resolveDeviceIdForLogin(`${SERVER}/`, "alice")).toBe("uuid-1");
+  });
+
   test("does not share an id across servers for the same username", async () => {
     await seed("alice", "u1", "device-alice");
     expect(resolveDeviceIdForLogin("https://other.example.com", "alice")).toBe(
@@ -142,6 +153,21 @@ describe("migrateCurrentAccountDeviceId", () => {
     expect(
       (await getAccountCredential(SERVER, "u2"))?.deviceId,
     ).toBeUndefined();
+  });
+
+  test("still stamps when the mirror already shows this account's own id", async () => {
+    // The claimed scan must skip the account being migrated: if the summary
+    // and the credential ever disagree, it would refuse to stamp its owner.
+    await seed("alice", "u1", undefined);
+    const servers = getPreviousServers();
+    servers[0].accounts[0].deviceId = "legacy-device";
+    storage.set("previousServers", JSON.stringify(servers));
+
+    await migrateCurrentAccountDeviceId(SERVER, "u1", "legacy-device");
+
+    expect((await getAccountCredential(SERVER, "u1"))?.deviceId).toBe(
+      "legacy-device",
+    );
   });
 
   test("declines an id owned on a different server", async () => {

--- a/utils/secureCredentials.test.ts
+++ b/utils/secureCredentials.test.ts
@@ -24,9 +24,6 @@ const {
   recordAccountSignIn,
   updateAccountToken,
 } = await import("./secureCredentials");
-// bun's mock.module registry is shared across test files, so mmkv may be backed
-// by another file's map. Reset through the same storage object the code writes
-// to rather than the map declared above.
 const { storage } = await import("./mmkv");
 
 const SERVER = "https://jf.example.com";
@@ -54,7 +51,7 @@ const seed = async (
 
 beforeEach(() => {
   mmkvStore.clear();
-  storage.delete("previousServers");
+  storage.remove("previousServers");
   secureStoreValues.clear();
   uuidCounter = 0;
 });
@@ -190,7 +187,18 @@ describe("recordAccountSignIn", () => {
   });
 
   test("refreshes a known account rather than duplicating it", async () => {
-    await seed("alice", "u1", "device-alice");
+    // Seeded with a token signIn does not write, so the assertion below fails
+    // if the refresh never happens.
+    await saveAccountCredential({
+      serverUrl: SERVER,
+      serverName: "Test",
+      token: "stale-token",
+      userId: "u1",
+      username: "alice",
+      savedAt: 1,
+      securityType: "none",
+      deviceId: "device-alice",
+    });
 
     await signIn("u1", "alice", "device-alice");
 

--- a/utils/secureCredentials.test.ts
+++ b/utils/secureCredentials.test.ts
@@ -128,6 +128,31 @@ describe("migrateCurrentAccountDeviceId", () => {
     await migrateCurrentAccountDeviceId(SERVER, "unknown", "legacy-device");
     expect(accountsOf()).toEqual([]);
   });
+
+  test("declines an id another account already owns", async () => {
+    // Otherwise the migration hands two accounts the same device, recreating
+    // the collision this mechanism exists to prevent.
+    await seed("alice", "u1", "legacy-device");
+    await seed("bob", "u2", undefined);
+
+    await migrateCurrentAccountDeviceId(SERVER, "u2", "legacy-device");
+
+    expect(
+      (await getAccountCredential(SERVER, "u2"))?.deviceId,
+    ).toBeUndefined();
+  });
+
+  test("declines an id owned on a different server", async () => {
+    // The legacy id is install-wide, so its owner can sit under any server.
+    await seed("alice", "u1", "legacy-device", "https://other.example.com");
+    await seed("bob", "u2", undefined);
+
+    await migrateCurrentAccountDeviceId(SERVER, "u2", "legacy-device");
+
+    expect(
+      (await getAccountCredential(SERVER, "u2"))?.deviceId,
+    ).toBeUndefined();
+  });
 });
 
 describe("updateAccountToken", () => {
@@ -156,13 +181,19 @@ describe("updateAccountToken", () => {
 });
 
 describe("recordAccountSignIn", () => {
-  const signIn = (userId: string, username: string, deviceId: string) =>
+  const signIn = (
+    userId: string,
+    username: string,
+    deviceId: string,
+    saveIfNew = true,
+  ) =>
     recordAccountSignIn({
       serverUrl: SERVER,
       userId,
       username,
       token: `token-${userId}`,
       deviceId,
+      saveIfNew,
       primaryImageTag: "tag",
     });
 
@@ -225,6 +256,36 @@ describe("recordAccountSignIn", () => {
     const credential = await getAccountCredential(SERVER, "u1");
     expect(credential?.securityType).toBe("pin");
     expect(credential?.pinHash).toBe("hash");
+  });
+
+  test("leaves an unknown account unsaved when saving was not asked for", async () => {
+    // Consent lives with the caller: a Quick Connect sign-in on a shared phone
+    // must not persist a token the user declined to save.
+    await signIn("u1", "alice", "device-alice", false);
+
+    expect(await getAccountCredential(SERVER, "u1")).toBeNull();
+    expect(accountsOf()).toEqual([]);
+  });
+
+  test("still refreshes a known account when saving was not asked for", async () => {
+    // The stored token was rejected; without this the account can never be
+    // revived and its switcher entry stays dead.
+    await saveAccountCredential({
+      serverUrl: SERVER,
+      serverName: "Test",
+      token: "stale-token",
+      userId: "u1",
+      username: "alice",
+      savedAt: 1,
+      securityType: "none",
+      deviceId: "device-alice",
+    });
+
+    await signIn("u1", "alice", "fresh-device", false);
+
+    const credential = await getAccountCredential(SERVER, "u1");
+    expect(credential?.token).toBe("token-u1");
+    expect(credential?.deviceId).toBe("fresh-device");
   });
 
   test("keeps accounts separate when a second user signs in", async () => {

--- a/utils/secureCredentials.test.ts
+++ b/utils/secureCredentials.test.ts
@@ -95,8 +95,9 @@ describe("resolveDeviceIdForLogin", () => {
     expect(resolveDeviceIdForLogin(SERVER, "alice")).toBe("device-alice");
   });
 
-  test("matches when the login url is the one carrying the slash", () => {
-    expect(resolveDeviceIdForLogin(`${SERVER}/`, "alice")).toBe("uuid-1");
+  test("matches when the login url is the one carrying the slash", async () => {
+    await seed("alice", "u1", "device-alice");
+    expect(resolveDeviceIdForLogin(`${SERVER}/`, "alice")).toBe("device-alice");
   });
 
   test("does not share an id across servers for the same username", async () => {

--- a/utils/secureCredentials.ts
+++ b/utils/secureCredentials.ts
@@ -211,9 +211,10 @@ export async function saveAccountCredential(
 }
 
 /**
- * Resolve the device id to authenticate a username under. Jellyfin binds one
- * access token per device id, so accounts must not share one: a known account
- * reuses its own id, anyone else gets a fresh one.
+ * Resolve the device id to authenticate a username under. A device id carries
+ * one active session, and on Jellyfin ≤10.8 only one access token, so accounts
+ * sharing one displace each other: a known account reuses its own id, anyone
+ * else gets a fresh one.
  */
 export function resolveDeviceIdForLogin(
   serverUrl: string,
@@ -230,7 +231,8 @@ export function resolveDeviceIdForLogin(
 
 /**
  * Adopt the legacy install-wide device id for the currently signed-in account,
- * whose token was issued under it. Regenerating instead would revoke it.
+ * whose token was issued under it. Regenerating instead would move the account
+ * off that id, and on ≤10.8 servers would revoke the token outright.
  */
 export async function migrateCurrentAccountDeviceId(
   serverUrl: string,

--- a/utils/secureCredentials.ts
+++ b/utils/secureCredentials.ts
@@ -253,6 +253,47 @@ export async function migrateCurrentAccountDeviceId(
 }
 
 /**
+ * Persist a successful sign-in: refresh a known account's token, or save the
+ * account if this is the first time it has signed in on this device.
+ *
+ * Quick Connect has no "save this account" step — whoever approves the code
+ * decides who signs in — so without this an account added that way would
+ * authenticate but never appear in the switcher.
+ */
+export async function recordAccountSignIn(params: {
+  serverUrl: string;
+  userId: string;
+  username: string;
+  token: string;
+  deviceId: string;
+  primaryImageTag?: string;
+}): Promise<void> {
+  const existing = await getAccountCredential(params.serverUrl, params.userId);
+  if (existing) {
+    await updateAccountToken(
+      params.serverUrl,
+      params.userId,
+      params.token,
+      params.primaryImageTag,
+      params.deviceId,
+    );
+    return;
+  }
+  await saveAccountCredential({
+    serverUrl: params.serverUrl,
+    // Empty keeps whatever name the server list already holds.
+    serverName: "",
+    token: params.token,
+    userId: params.userId,
+    username: params.username,
+    savedAt: Date.now(),
+    securityType: "none",
+    primaryImageTag: params.primaryImageTag,
+    deviceId: params.deviceId,
+  });
+}
+
+/**
  * Retrieve credential for a specific account.
  */
 export async function getAccountCredential(

--- a/utils/secureCredentials.ts
+++ b/utils/secureCredentials.ts
@@ -7,6 +7,7 @@ import {
   secureCustomHeaderMetadata,
 } from "./customHeaders/secureValues";
 import type { CustomHeader } from "./customHeaders/types";
+import { normalizeHttpBaseUrl } from "./customHeaders/urlMatching";
 import { mintDeviceId } from "./device";
 import { logAndCaptureError } from "./log";
 import { storage } from "./mmkv";
@@ -220,7 +221,14 @@ export function resolveDeviceIdForLogin(
   serverUrl: string,
   username: string,
 ): string {
-  const server = getPreviousServers().find((s) => s.address === serverUrl);
+  // The saved address is whatever the user typed; the login passes the SDK's
+  // basePath, which may have dropped a trailing slash. An exact match would
+  // miss the account and mint a second id for it — the collision this exists
+  // to prevent.
+  const wanted = normalizeHttpBaseUrl(serverUrl);
+  const server = getPreviousServers().find(
+    (s) => normalizeHttpBaseUrl(s.address) === wanted,
+  );
   // Jellyfin accepts any casing at login, so match case-insensitively — a
   // case-only difference must not mint a second id for the same account.
   const existing = server?.accounts.find(
@@ -245,7 +253,9 @@ export async function migrateCurrentAccountDeviceId(
   // Stamping an id another account already owns would put both back on one
   // device, which is the collision this whole mechanism exists to avoid.
   const claimed = getPreviousServers().some((server) =>
-    server.accounts.some((a) => a.deviceId === legacyDeviceId),
+    server.accounts.some(
+      (a) => a.deviceId === legacyDeviceId && a.userId !== userId,
+    ),
   );
   if (claimed) return;
 

--- a/utils/secureCredentials.ts
+++ b/utils/secureCredentials.ts
@@ -7,6 +7,7 @@ import {
   secureCustomHeaderMetadata,
 } from "./customHeaders/secureValues";
 import type { CustomHeader } from "./customHeaders/types";
+import { mintDeviceId } from "./device";
 import { logAndCaptureError } from "./log";
 import { storage } from "./mmkv";
 
@@ -31,6 +32,9 @@ export interface ServerCredential {
   securityType: AccountSecurityType;
   pinHash?: string;
   primaryImageTag?: string;
+  /** Device id the token was issued under. Undefined on accounts saved before
+   * this was introduced. */
+  deviceId?: string;
 }
 
 /**
@@ -42,6 +46,9 @@ export interface SavedServerAccount {
   securityType: AccountSecurityType;
   savedAt: number;
   primaryImageTag?: string;
+  /** Mirrors ServerCredential.deviceId so a login can resolve it without
+   * touching secure storage. */
+  deviceId?: string;
 }
 
 /**
@@ -173,6 +180,20 @@ export async function verifyAccountPIN(
 }
 
 /**
+ * Project a credential onto its display-side account summary.
+ */
+function toSavedAccount(credential: ServerCredential): SavedServerAccount {
+  return {
+    userId: credential.userId,
+    username: credential.username,
+    securityType: credential.securityType,
+    savedAt: credential.savedAt,
+    primaryImageTag: credential.primaryImageTag,
+    deviceId: credential.deviceId,
+  };
+}
+
+/**
  * Save credential for a specific account.
  */
 export async function saveAccountCredential(
@@ -182,13 +203,53 @@ export async function saveAccountCredential(
   await SecureStore.setItemAsync(key, JSON.stringify(credential));
 
   // Update previousServers to include this account
-  addAccountToServer(credential.serverUrl, credential.serverName, {
-    userId: credential.userId,
-    username: credential.username,
-    securityType: credential.securityType,
-    savedAt: credential.savedAt,
-    primaryImageTag: credential.primaryImageTag,
-  });
+  addAccountToServer(
+    credential.serverUrl,
+    credential.serverName,
+    toSavedAccount(credential),
+  );
+}
+
+/**
+ * Resolve the device id to authenticate a username under. Jellyfin binds one
+ * access token per device id, so accounts must not share one: a known account
+ * reuses its own id, anyone else gets a fresh one.
+ */
+export function resolveDeviceIdForLogin(
+  serverUrl: string,
+  username: string,
+): string {
+  const server = getPreviousServers().find((s) => s.address === serverUrl);
+  // Jellyfin accepts any casing at login, so match case-insensitively — a
+  // case-only difference must not mint a second id for the same account.
+  const existing = server?.accounts.find(
+    (a) => a.username.toLowerCase() === username.toLowerCase(),
+  );
+  return existing?.deviceId || mintDeviceId();
+}
+
+/**
+ * Adopt the legacy install-wide device id for the currently signed-in account,
+ * whose token was issued under it. Regenerating instead would revoke it.
+ */
+export async function migrateCurrentAccountDeviceId(
+  serverUrl: string,
+  userId: string,
+  legacyDeviceId: string,
+): Promise<void> {
+  const credential = await getAccountCredential(serverUrl, userId);
+  if (!credential || credential.deviceId) return;
+
+  credential.deviceId = legacyDeviceId;
+  await SecureStore.setItemAsync(
+    credentialKey(serverUrl, userId),
+    JSON.stringify(credential),
+  );
+  addAccountToServer(
+    serverUrl,
+    credential.serverName,
+    toSavedAccount(credential),
+  );
 }
 
 /**
@@ -578,6 +639,7 @@ export async function updateAccountToken(
   userId: string,
   newToken: string,
   primaryImageTag?: string,
+  deviceId?: string,
 ): Promise<void> {
   const credential = await getAccountCredential(serverUrl, userId);
   if (credential) {
@@ -586,17 +648,20 @@ export async function updateAccountToken(
     if (primaryImageTag !== undefined) {
       credential.primaryImageTag = primaryImageTag;
     }
+    if (deviceId !== undefined) {
+      // The new token is bound to the id it was requested under; recording
+      // anything else would send later requests on the wrong device.
+      credential.deviceId = deviceId;
+    }
     const key = credentialKey(serverUrl, userId);
     await SecureStore.setItemAsync(key, JSON.stringify(credential));
 
     // Also update the account info in the server list
-    addAccountToServer(serverUrl, credential.serverName, {
-      userId: credential.userId,
-      username: credential.username,
-      securityType: credential.securityType,
-      savedAt: credential.savedAt,
-      primaryImageTag: credential.primaryImageTag,
-    });
+    addAccountToServer(
+      serverUrl,
+      credential.serverName,
+      toSavedAccount(credential),
+    );
   }
 }
 

--- a/utils/secureCredentials.ts
+++ b/utils/secureCredentials.ts
@@ -240,6 +240,13 @@ export async function migrateCurrentAccountDeviceId(
   const credential = await getAccountCredential(serverUrl, userId);
   if (!credential || credential.deviceId) return;
 
+  // Stamping an id another account already owns would put both back on one
+  // device, which is the collision this whole mechanism exists to avoid.
+  const claimed = getPreviousServers().some((server) =>
+    server.accounts.some((a) => a.deviceId === legacyDeviceId),
+  );
+  if (claimed) return;
+
   credential.deviceId = legacyDeviceId;
   await SecureStore.setItemAsync(
     credentialKey(serverUrl, userId),
@@ -253,19 +260,23 @@ export async function migrateCurrentAccountDeviceId(
 }
 
 /**
- * Persist a successful sign-in: refresh a known account's token, or save the
- * account if this is the first time it has signed in on this device.
+ * Persist a successful sign-in: refresh a known account's token, or — when
+ * `saveIfNew` — save the account if this is its first sign-in on this device.
  *
- * Quick Connect has no "save this account" step — whoever approves the code
- * decides who signs in — so without this an account added that way would
- * authenticate but never appear in the switcher.
+ * The refresh is unconditional because a saved account whose stored token was
+ * rejected has no other way back: leave it stale and its switcher entry is dead
+ * for good. Saving is opt-in, since it is the caller that knows whether the
+ * user consented to being remembered.
  */
 export async function recordAccountSignIn(params: {
   serverUrl: string;
   userId: string;
   username: string;
   token: string;
-  deviceId: string;
+  /** Id the token was issued under. Omit when it is not known: a credential
+   * predating per-account ids must not be stamped with a borrowed one. */
+  deviceId?: string;
+  saveIfNew: boolean;
   primaryImageTag?: string;
 }): Promise<void> {
   const existing = await getAccountCredential(params.serverUrl, params.userId);
@@ -279,6 +290,7 @@ export async function recordAccountSignIn(params: {
     );
     return;
   }
+  if (!params.saveIfNew) return;
   await saveAccountCredential({
     serverUrl: params.serverUrl,
     // Empty keeps whatever name the server list already holds.

--- a/utils/seriesTrackMemory.test.ts
+++ b/utils/seriesTrackMemory.test.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
 import type { TrackMenuRow } from "@/utils/subtitles/trackMenu";
 
-import { logMock } from "@/utils/testing/logMock";
-import { mmkvMock, mmkvStore } from "@/utils/testing/mmkvMock";
+import { logMock } from "./testing/logMock";
+import { mmkvMock, mmkvStore } from "./testing/mmkvMock";
 
 mock.module("react-native-mmkv", mmkvMock);
 mock.module("@/utils/log", logMock);

--- a/utils/seriesTrackMemory.test.ts
+++ b/utils/seriesTrackMemory.test.ts
@@ -2,20 +2,11 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
 import type { TrackMenuRow } from "@/utils/subtitles/trackMenu";
 
+import { logMock } from "@/utils/testing/logMock";
 import { mmkvMock, mmkvStore } from "@/utils/testing/mmkvMock";
 
 mock.module("react-native-mmkv", mmkvMock);
-// Bun's mock.module retroactively re-links every module already importing the
-// specifier, so a log mock must cover the module's full function surface —
-// a missing name breaks OTHER test files' modules that import it.
-mock.module("@/utils/log", () => ({
-  writeToLog: () => undefined,
-  writeInfoLog: () => undefined,
-  writeErrorLog: () => undefined,
-  writeDebugLog: () => undefined,
-  logAndCaptureError: () => undefined,
-  readFromLog: () => [],
-}));
+mock.module("@/utils/log", logMock);
 
 const { getSeriesTrackMemory, rememberSeriesTrackFromRow } = await import(
   "./seriesTrackMemory"

--- a/utils/seriesTrackMemory.test.ts
+++ b/utils/seriesTrackMemory.test.ts
@@ -2,14 +2,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
 import type { TrackMenuRow } from "@/utils/subtitles/trackMenu";
 
-const store = new Map<string, string>();
-mock.module("react-native-mmkv", () => ({
-  createMMKV: () => ({
-    getString: (key: string) => store.get(key),
-    set: (key: string, value: string) => void store.set(key, value),
-    delete: (key: string) => void store.delete(key),
-  }),
-}));
+import { mmkvMock, mmkvStore } from "@/utils/testing/mmkvMock";
+
+mock.module("react-native-mmkv", mmkvMock);
 // Bun's mock.module retroactively re-links every module already importing the
 // specifier, so a log mock must cover the module's full function surface —
 // a missing name breaks OTHER test files' modules that import it.
@@ -38,7 +33,7 @@ const row = (patch: Partial<TrackMenuRow>): TrackMenuRow => ({
   ...patch,
 });
 
-beforeEach(() => store.clear());
+beforeEach(() => mmkvStore.clear());
 
 describe("rememberSeriesTrackFromRow", () => {
   test("stores the language carried on the row", () => {

--- a/utils/sessionExpired.ts
+++ b/utils/sessionExpired.ts
@@ -26,6 +26,8 @@ export function savedLoginAlertText(
   return {
     title: t("login.connection_failed"),
     message:
-      error instanceof Error ? error.message : t("server.session_expired"),
+      error instanceof Error
+        ? error.message
+        : t("login.an_unexpected_error_occurred"),
   };
 }

--- a/utils/sessionExpired.ts
+++ b/utils/sessionExpired.ts
@@ -1,0 +1,31 @@
+/**
+ * A saved account's token was rejected. The account is kept — callers offer
+ * re-authentication instead.
+ */
+export class SessionExpiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionExpiredError";
+  }
+}
+
+/**
+ * Alert copy for a failed sign-in with a saved credential. The recovery
+ * actions differ per screen, the wording does not.
+ */
+export function savedLoginAlertText(
+  error: unknown,
+  t: (key: string) => string,
+): { title: string; message: string } {
+  if (error instanceof SessionExpiredError) {
+    return {
+      title: t("server.session_expired"),
+      message: t("server.please_login_again"),
+    };
+  }
+  return {
+    title: t("login.connection_failed"),
+    message:
+      error instanceof Error ? error.message : t("server.session_expired"),
+  };
+}

--- a/utils/testing/logMock.ts
+++ b/utils/testing/logMock.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared in-memory stand-in for @/utils/log.
+ *
+ * The real module reaches Sentry, which pulls in react-native, whose Flow-typed
+ * entry point bun cannot parse — so any suite that loads it transitively dies
+ * with "Unexpected typeof" rather than a test failure.
+ *
+ * It covers the module's full export surface on purpose: `mock.module` is
+ * process-wide in bun, so a partial mock registered here removes names that
+ * OTHER suites' modules import, and which of them breaks depends on load order.
+ */
+export const logMock = () => ({
+  writeToLog: () => undefined,
+  writeInfoLog: () => undefined,
+  writeErrorLog: () => undefined,
+  writeDebugLog: () => undefined,
+  logAndCaptureError: () => undefined,
+  readFromLog: () => [],
+});

--- a/utils/testing/mmkvMock.ts
+++ b/utils/testing/mmkvMock.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared in-memory stand-in for react-native-mmkv.
+ *
+ * `mock.module` is process-wide in bun, so a suite that registers its own mock
+ * over a private map silently takes over every other suite too: their writes
+ * land in this map while their `beforeEach` clears the one nothing uses, and
+ * state leaks between their tests. Each file passes alone and the set fails
+ * together, depending on load order.
+ *
+ * Every suite that needs storage goes through this one double, and clears
+ * `mmkvStore` between tests.
+ */
+export const mmkvStore = new Map<string, string>();
+
+export const mmkvMock = () => ({
+  createMMKV: () => ({
+    getString: (key: string) => mmkvStore.get(key),
+    getBoolean: (key: string) => mmkvStore.get(key) === "true",
+    set: (key: string, value: string | boolean) => {
+      mmkvStore.set(key, String(value));
+    },
+    delete: (key: string) => {
+      mmkvStore.delete(key);
+    },
+    remove: (key: string) => {
+      mmkvStore.delete(key);
+    },
+    getAllKeys: () => Array.from(mmkvStore.keys()),
+  }),
+});

--- a/utils/testing/mmkvMock.ts
+++ b/utils/testing/mmkvMock.ts
@@ -8,23 +8,25 @@
  * together, depending on load order.
  *
  * Every suite that needs storage goes through this one double, and clears
- * `mmkvStore` between tests.
+ * `mmkvStore` between tests. It mirrors the methods this codebase calls — no
+ * more, so a call the real v4 API does not have cannot pass here.
  */
 export const mmkvStore = new Map<string, string>();
 
 export const mmkvMock = () => ({
   createMMKV: () => ({
     getString: (key: string) => mmkvStore.get(key),
-    getBoolean: (key: string) => mmkvStore.get(key) === "true",
-    set: (key: string, value: string | boolean) => {
+    getBoolean: (key: string) =>
+      mmkvStore.has(key) ? mmkvStore.get(key) === "true" : undefined,
+    getNumber: (key: string) =>
+      mmkvStore.has(key) ? Number(mmkvStore.get(key)) : undefined,
+    getAllKeys: () => Array.from(mmkvStore.keys()),
+    set: (key: string, value: string | number | boolean) => {
       mmkvStore.set(key, String(value));
     },
-    delete: (key: string) => {
-      mmkvStore.delete(key);
+    setAny: (key: string, value: unknown) => {
+      mmkvStore.set(key, JSON.stringify(value));
     },
-    remove: (key: string) => {
-      mmkvStore.delete(key);
-    },
-    getAllKeys: () => Array.from(mmkvStore.keys()),
+    remove: (key: string) => mmkvStore.delete(key),
   }),
 });

--- a/utils/testing/mmkvMock.ts
+++ b/utils/testing/mmkvMock.ts
@@ -25,6 +25,12 @@ export const mmkvMock = () => ({
       mmkvStore.set(key, String(value));
     },
     setAny: (key: string, value: unknown) => {
+      // Matches the augmentation in augmentations/mmkv.ts, which removes the
+      // key rather than storing a JSON.stringify(undefined).
+      if (value === undefined) {
+        mmkvStore.delete(key);
+        return;
+      }
       mmkvStore.set(key, JSON.stringify(value));
     },
     remove: (key: string) => mmkvStore.delete(key),

--- a/utils/testing/secureStoreMock.ts
+++ b/utils/testing/secureStoreMock.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared in-memory stand-in for expo-secure-store.
+ *
+ * `mock.module` is process-wide in bun, so two test files that each mock
+ * expo-secure-store with their own backing map clobber one another: whichever
+ * registers last wins, and the other file's assertions read a map nothing
+ * writes to. Both suites go through this one double instead.
+ *
+ * Covers the sync and async halves of the API, since callers use both.
+ */
+export const secureStoreValues = new Map<string, string>();
+
+export const secureStoreMock = () => ({
+  getItem: (key: string) => secureStoreValues.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    secureStoreValues.set(key, value);
+  },
+  getItemAsync: async (key: string) => secureStoreValues.get(key) ?? null,
+  setItemAsync: async (key: string, value: string) => {
+    secureStoreValues.set(key, value);
+  },
+  deleteItemAsync: async (key: string) => {
+    secureStoreValues.delete(key);
+  },
+});


### PR DESCRIPTION
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

# 📦 Pull Request

> **AI assistance disclosure.** This PR was written primarily by Claude Code: the
> investigation, the code, this description, and my earlier reply comment on this PR are all
> AI-assisted. The diagnosis was verified empirically against a live Jellyfin server — see the
> review thread for the probes and results. Every change was tested by me personally on Apple
> TV, iOS and Android simulators against a real Jellyfin server — see Testing Instructions for
> exactly what was and was not covered.
> I take full responsibility for the code submitted here.

## 📝 Description

**A Quick Connect sign-in on tvOS is never saved, so the account can't be switched to.** On
`develop`: turn "Save this account" on, sign in with Quick Connect, log out — the user list
is empty.

The toggle sits above both buttons but only reaches the password handler:

```ts
// components/login/TVAddUserForm.tsx
onQuickConnect: () => Promise<void>;                      // no saveAccount parameter
await onLogin(credentials.username, credentials.password, saveAccount);
onPress={onQuickConnect}                                  // toggle never reaches this path
```

`pollQuickConnect` writes no credential either, so the choice is silently discarded. Quick
Connect is the natural way to sign in on a TV remote, which makes multi-user unreachable for
anyone using it.

**Device ids.** Streamyfin mints one per install (`utils/device.ts`) and authenticates every
account under it. Measured against Jellyfin 10.11.11 this doesn't revoke tokens — accounts
survive, and password-based multi-user works on `develop` today. What it costs is session
identity: `/Devices` keeps a row per `(device, user)` pair, but `/Sessions` keeps only the
most recently authenticated user for a given id, so two accounts sharing one overwrite each
other's session. On Jellyfin **≤10.8**, where only one access token per `deviceId` is allowed
([API authorization guide](https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f)),
the shared id breaks multi-user outright. This PR gives each account its own.

**A rejected token was also unrecoverable.** `loginWithSavedCredential` called
`deleteAccountCredential(...)` on a 401, dropping the account; with one account left, the
`accounts.length < 2` guard in `useTVUserSwitchModal` makes "Switch user" inert. The account
is now kept and re-authentication offered.


### What changed

- **Per-account device ids**, resolved by username (case-insensitively, since Jellyfin
  accepts any casing at login) and stored on the credential. A known account reuses its id;
  minting a new one would move the account off the id its existing token was issued under.
- **The SDK instance follows the account.** The device id lives in `deviceInfo`, so each
  login and switch builds an instance bound to the right id, adopted only *after*
  authentication succeeds — a failed attempt cannot leave the app on an id it never
  authorized.
- **Migration keeps existing users signed in.** On first launch after upgrading, the
  signed-in account adopts the existing install-wide id. Regenerating would move the account
  off the id its token was issued under, and would log everyone out on upgrade on ≤10.8
  servers.
- **A rejected token no longer deletes the account.** A typed `SessionExpiredError` is
  thrown, the account stays, and the caller offers re-authentication (Quick Connect or
  password on the login screen, password in settings).
- **Quick Connect saves new accounts**, via `recordAccountSignIn` in the credential store.
  Protection defaults to `none` — Quick Connect is already an approval from a signed-in
  device.
- **Two related fixes.** `WebSocketProvider` read the device id once at mount, so after a
  switch the socket and `postFullCapabilities` reported against the previous account's
  device. And the previous account's Jellyseerr session is now cleared on a switch, since a
  token switch carries no password to re-login with.

## 🏷️ Ticket / Issue

N/A — no existing issue found. Happy to open one if you'd prefer this tracked separately.

### 🖼️ Screenshots / GIFs (if UI)

N/A — no visual changes. The only user-visible additions are the re-authentication alert
prompts that replace the silent account deletion.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](.github/CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
  - **tvOS**: thoroughly — 8 scenarios below, on a tvOS 26.5 simulator against a real server
  - **iOS**: sign-in, second account, switching, sign-out on an iOS 26.5 simulator
  - **Android**: **not tested.** I have no Android device or emulator set up. The change is
    platform-agnostic code in `JellyfinProvider`, so I have no reason to expect a
    difference, but I have not verified it and would rather say so than tick the box.
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`) — plus 155 unit tests
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

## 🔍 Testing Instructions

Requires a Jellyfin server with two users. The ground truth throughout is
**Dashboard → Devices**, which lists one entry per device id with its user: before the fix a
single entry whose owner flips, after it one entry per account.

**Reproduce the bug on `develop` first:**

1. Sign in as A with "save this account" on
2. Log out, add B with "save this account" on
3. Switch back to A → fails, A disappears from the account list
4. Dashboard → Devices shows one Streamyfin entry, now owned by B

**Then on this branch:**

1. **Two accounts coexist** — add A and B (Quick Connect or password), switch back and forth
   several times. No password prompts, neither account disappears, and Dashboard shows
   **two** Streamyfin entries.
2. **Upgrade path** — install `develop`, sign in, then install this branch *without
   uninstalling*. You stay signed in; the device entry is unchanged.
3. **Rejected token** — delete one account's device entry in Dashboard, then switch to it.
   An alert offers re-authentication, the account **stays in the list**, and a password
   sign-in restores it. (On `develop` the account is deleted here.)
4. **Quick Connect re-auth** — with a revoked token, pick that account on the login screen
   and choose Quick Connect. A code appears and the sign-in completes.
5. **Quick Connect adds accounts** — sign in a user that has never been saved via Quick
   Connect; it now appears in the switcher.

### Known gaps

- **The mobile upgrade path is untested.** iOS was verified on a fresh install, so the
  migration never ran there. Same shared provider code that passed on tvOS, but that is an
  argument rather than evidence.
- **No automated test for "session restore runs once".** It is a ref guard in a provider
  effect; covering it needs a React renderer and this project has no test library for one. I
  verified it by hand with a temporary probe. Happy to add
  `@testing-library/react-native` if you want it covered properly — it seemed wrong to
  introduce a dev dependency unasked inside a bug fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved saved-login alerts for expired sessions and connection failures.
  - Expired sessions offer Quick Connect or password re-entry.
  - Quick Connect can preserve account details based on the save preference.
  - Account-specific device identities improve account switching and session restoration.

- **Bug Fixes**
  - Invalid saved credentials no longer remove saved accounts.
  - Authentication and live connections update correctly after account changes.
  - PIN login failures now exit cleanly.

- **Tests**
  - Expanded coverage for credential storage, migrations, and account separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
