### PR TITLE
fix(i18n): give each locale its own file in the Crowdin export

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,7 +4,7 @@ base_path: .
 preserve_hierarchy: 1
 files:
   - source: translations/en.json
-    translation: translations/%two_letters_code%.json
+    translation: translations/%locale%.json
     skip_untranslated_strings: false
     skip_untranslated_files: false
     export_only_approved: false


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

The Crowdin export pattern was `%two_letters_code%`, which is not unique across our target languages:

- `zh-CN` and `zh-TW` both wrote to `translations/zh.json`
- `pt-PT` and `pt-BR` both wrote to `translations/pt.json`

Only one side of each collision survives the export. Today `zh.json` holds Traditional Chinese behind a code that means Simplified, and `pt.json` holds Brazilian Portuguese. Anything translated on the losing side never reaches the repo, which is why Simplified Chinese and European Portuguese stayed largely English no matter how much was translated upstream.

Switching to `%locale%` gives every target language its own file (`zh-CN.json`, `zh-TW.json`, `pt-PT.json`, `pt-BR.json`, and full codes for the rest).

This PR is the config change only. The next translation sync regenerates `translations/` under the new names, and `i18n.ts` gets pointed at them in that sync PR so the imports and the files land together.

While looking at this I also noticed `i18n.ts` never registers `cs`, `el`, `he`, `ko`, `no`, `pt`, `th` and `zh`, so those catalogues are translated but never loaded at runtime. Korean is at 99% and reaches nobody. That gets fixed in the same follow-up commit.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Merge and let the Translation Sync workflow run, or trigger it manually
2. Check the sync PR: `translations/` should now contain `pt-PT.json` and `pt-BR.json` as separate files, and `zh-CN.json` and `zh-TW.json` as separate files
3. Confirm `pt-PT.json` is European Portuguese and `zh-CN.json` is Simplified Chinese, instead of both being overwritten by their sibling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated translation output paths to use locale identifiers for improved localization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->