### PR TITLE
fix: Enabled playback controls timeout

### DIFF
--- a/components/video-player/controls/Controls.tsx
+++ b/components/video-player/controls/Controls.tsx
@@ -618,7 +618,7 @@ export const Controls: FC<Props> = ({
     episodeView,
     onHideControls: hideControls,
     timeout: CONTROLS_CONSTANTS.TIMEOUT,
-    disabled: true,
+    disabled: false,
   });
 
   const switchOnEpisodeMode = useCallback(() => {


### PR DESCRIPTION

## 📝 Description
Let the controls timeout themselves, so that they don't stay on screen after autoplay, tested on android and iOS simulator.

## 🏷️ Ticket / Issue
Fixes #1922 

## ✅ Checklist
<!--
Review and check off items as you complete them.
-->
- [/ ] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ /] Verified that changes behave as expected for all platforms
- [ /] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [ /] No secrets, hardcoded credentials, or private config files are included
- [ /] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions
1. Start an episode of a show
2. Reach the end and allow the app to autoplay next episode
3. See playback controls show up
4. See playback controls dissapear



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored automatic hiding of video player controls after inactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->