### PR TITLE
feat(player): native Android TV player

### DIFF
--- a/app/(auth)/(tabs)/(home)/settings.tv.tsx
+++ b/app/(auth)/(tabs)/(home)/settings.tv.tsx
@@ -779,6 +779,25 @@ export default function SettingsTV() {
             </>
           )}
 
+          {/* Native Android TV player opt-in — Android TV, default off */}
+          {isAndroidTv && (
+            <>
+              <TVSettingsToggle
+                disabledByAdmin={
+                  pluginSettings?.nativeVideoPlayerAndroidTV?.locked
+                }
+                label={t("home.settings.video_player.native_tv")}
+                value={settings.nativeVideoPlayerAndroidTV === true}
+                onToggle={(value) =>
+                  updateSettings({ nativeVideoPlayerAndroidTV: value })
+                }
+              />
+              <Text style={playerNoteStyle}>
+                {t("home.settings.video_player.native_android_tv_note")}
+              </Text>
+            </>
+          )}
+
           <TVSettingsToggle
             disabledByAdmin={pluginSettings?.showResumeDialog?.locked}
             label={t("home.settings.other.resume_dialog")}

--- a/modules/mpv-player/android/build.gradle
+++ b/modules/mpv-player/android/build.gradle
@@ -77,4 +77,6 @@ dependencies {
   implementation 'androidx.activity:activity-ktx:1.9.3'
   implementation 'androidx.savedstate:savedstate-ktx:1.2.1'
   implementation 'androidx.core:core-ktx:1.18.0'
+  // Android TV Compose material
+  implementation 'androidx.tv:tv-material:1.0.0'
 }

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/NativePlayerSession.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/NativePlayerSession.kt
@@ -21,7 +21,10 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.annotation.RequiresApi
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.core.app.OnPictureInPictureModeChangedProvider
 import androidx.core.app.PictureInPictureModeChangedInfo
 import androidx.core.util.Consumer
@@ -35,9 +38,12 @@ import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import expo.modules.kotlin.Promise
+import expo.modules.mpvplayer.DeviceKind
 import expo.modules.mpvplayer.MPVLayerRenderer
 import expo.modules.mpvplayer.nativeplayer.ui.PlayerScreen
 import expo.modules.mpvplayer.nativeplayer.ui.PlayerTheme
+import expo.modules.mpvplayer.nativeplayer.ui.tv.TvPlayerScreen
+import expo.modules.mpvplayer.nativeplayer.ui.tv.TvPlayerTheme
 
 class NativePlayerSession(
     private val emit: (String, Map<String, Any?>) -> Unit,
@@ -83,9 +89,20 @@ class NativePlayerSession(
     }
 
     init {
-        viewModel.emit = emit
+        viewModel.emit = { event, payload -> emit(event, payload) }
         viewModel.onDismissRequested = { reason ->
-            dismiss(reason = reason)
+            dismiss(reason)
+        }
+        viewModel.onRotateRequested = {
+            emit("onOrientationChangeRequested", mapOf("orientation" to "landscape"))
+        }
+        viewModel.onHDRModeDetected = { isHdr, fps ->
+            emit("onHDRModeDetected", mapOf("isHdr" to isHdr, "fps" to fps))
+        }
+        viewModel.onHapticRequested = {
+            hostActivity?.window?.decorView?.performHapticFeedback(
+                android.view.HapticFeedbackConstants.VIRTUAL_KEY
+            )
         }
         viewModel.onHapticRequested = {
             hostActivity?.window?.decorView?.performHapticFeedback(
@@ -101,6 +118,9 @@ class NativePlayerSession(
         }
         hostActivity = activity
 
+        val isTv = DeviceKind.isTelevision(activity)
+        viewModel.isTvChrome = isTv
+
         activity.runOnUiThread {
             try {
                 val newRenderer = MPVLayerRenderer(activity)
@@ -112,19 +132,21 @@ class NativePlayerSession(
                 newRenderer.start(voDriver = "gpu-next", owner = MpvOwnership.Owner.NATIVE_SESSION)
 
                 // Initialize controllers
-                val volumeCtrl = SystemVolumeController(activity)
-                val brightnessCtrl = BrightnessController(activity)
-                viewModel.volumeController = volumeCtrl
-                viewModel.brightnessController = brightnessCtrl
+                if (!isTv) {
+                    val volumeCtrl = SystemVolumeController(activity)
+                    val brightnessCtrl = BrightnessController(activity)
+                    viewModel.volumeController = volumeCtrl
+                    viewModel.brightnessController = brightnessCtrl
 
-                volumeCtrl.onExternalChange = {
-                    viewModel.revealVolumeSliderTransiently()
-                }
-                volumeCtrl.onMuteStateChanged = { muted ->
-                    emit("onMuteStateChanged", mapOf(
-                        "muted" to muted,
-                        "positionSec" to viewModel.displayPosition
-                    ))
+                    volumeCtrl.onExternalChange = {
+                        viewModel.revealVolumeSliderTransiently()
+                    }
+                    volumeCtrl.onMuteStateChanged = { muted ->
+                        emit("onMuteStateChanged", mapOf(
+                            "muted" to muted,
+                            "positionSec" to viewModel.displayPosition
+                        ))
+                    }
                 }
 
                 val mediaCtrl = MediaSessionController(activity, viewModel)
@@ -141,7 +163,7 @@ class NativePlayerSession(
                 viewModel.apply(config)
 
                 // Setup Overlay Views on MainActivity
-                setupOverlay(activity, config)
+                setupOverlay(activity, config, isTv)
 
                 // Kick stream load
                 startStream(config)
@@ -155,20 +177,31 @@ class NativePlayerSession(
         }
     }
 
-    private fun setupOverlay(activity: Activity, config: PlayerPresentConfigRecord) {
-        val container = FrameLayout(activity).apply {
-            layoutParams = FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
-            setBackgroundColor(Color.BLACK)
-            isFocusable = true
-            isFocusableInTouchMode = true
-            setOnKeyListener { _, keyCode, event ->
-                if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
-                    dismiss("closeButton")
-                    true
-                } else false
+    private fun setupOverlay(activity: Activity, config: PlayerPresentConfigRecord, isTv: Boolean) {
+        val container = if (isTv) {
+            val keyHandler = TvRemoteKeyHandler(viewModel, onExitRequested = { dismiss("closeButton") })
+            TvOverlayContainer(activity, keyHandler).apply {
+                layoutParams = FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+                setBackgroundColor(Color.BLACK)
+            }
+        } else {
+            FrameLayout(activity).apply {
+                layoutParams = FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+                setBackgroundColor(Color.BLACK)
+                isFocusable = true
+                isFocusableInTouchMode = true
+                setOnKeyListener { _, keyCode, event ->
+                    if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
+                        dismiss("closeButton")
+                        true
+                    } else false
+                }
             }
         }
         overlayContainer = container
@@ -202,14 +235,39 @@ class NativePlayerSession(
         (activity as? ViewModelStoreOwner)?.let { cView.setViewTreeViewModelStoreOwner(it) }
         (activity as? SavedStateRegistryOwner)?.let { cView.setViewTreeSavedStateRegistryOwner(it) }
 
-        cView.setContent {
-            PlayerTheme {
-                PlayerScreen(
-                    viewModel = viewModel,
-                    onPipClick = if (isPiPSupported()) {
-                        { enterPiP() }
-                    } else null
-                )
+        if (isTv) {
+            val tvContainer = container as? TvOverlayContainer
+            cView.setContent {
+                PlayerTheme {
+                    TvPlayerTheme {
+                        // The ui/tv composables are authored oversized for a
+                        // 10-foot layout; shrink every dp/sp in the chrome
+                        // through one density override.
+                        val base = LocalDensity.current
+                        CompositionLocalProvider(
+                            LocalDensity provides Density(
+                                density = base.density * PlayerConstants.TV_CHROME_SCALE,
+                                fontScale = base.fontScale
+                            )
+                        ) {
+                            TvPlayerScreen(
+                                viewModel = viewModel,
+                                onZoneChanged = { zone: TvFocusZone -> tvContainer?.onZoneChanged(zone) }
+                            )
+                        }
+                    }
+                }
+            }
+        } else {
+            cView.setContent {
+                PlayerTheme {
+                    PlayerScreen(
+                        viewModel = viewModel,
+                        onPipClick = if (isPiPSupported()) {
+                            { enterPiP() }
+                        } else null
+                    )
+                }
             }
         }
         composeView = cView
@@ -241,7 +299,9 @@ class NativePlayerSession(
             )
         )
 
-        setupPiP(activity, config.ui.allowPip)
+        if (!isTv) {
+            setupPiP(activity, config.ui.allowPip)
+        }
     }
 
     private fun setupPiP(activity: Activity, allowPip: Boolean) {

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/PlayerConstants.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/PlayerConstants.kt
@@ -15,4 +15,12 @@ object PlayerConstants {
     const val PINCH_ZOOM_OUT_THRESHOLD = 0.88f
     const val HOLD_SPEED_ENGAGE_DELAY_MS = 500L
     const val ECHO_SUPPRESSION_WINDOW_MS = 500L
+    const val TV_SEEK_FEEDBACK_DURATION_MS = 2500L
+    const val TV_SCRUB_ACCEL_REPEATS_PER_STEP = 4
+    const val TV_SCRUB_ACCEL_MAX_MULTIPLIER = 12.0
+
+    // Uniform scale for the whole TV chrome, applied as a LocalDensity
+    // override at the TvPlayerScreen root — the dp/sp values in the ui/tv
+    // composables were authored too large for a 10-foot layout.
+    const val TV_CHROME_SCALE = 0.7f
 }

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/PlayerViewModel.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/PlayerViewModel.kt
@@ -34,6 +34,7 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
     var onHapticRequested: (() -> Unit)? = null
     var onPlaybackStateSync: (() -> Unit)? = null
     var onMetadataSync: (() -> Unit)? = null
+    var isTvChrome: Boolean = false
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -74,6 +75,9 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
     var showEpisodeList by mutableStateOf(false)
     var doubleTapSeekForward by mutableStateOf<Boolean?>(null)
     var showSubtitleSearch by mutableStateOf(false)
+    var seekFeedbackVisible by mutableStateOf(false)
+    var showExitConfirmation by mutableStateOf(false)
+    var tvMenuRoute by mutableStateOf<List<TvMenuScreen>>(emptyList())
 
     // MARK: - Content State
     var metadata by mutableStateOf<MetadataRecord?>(null)
@@ -124,6 +128,7 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
     private var unlockRevealJob: Job? = null
     private var doubleTapFeedbackJob: Job? = null
     private var sleepTimerJob: Job? = null
+    private var seekFeedbackJob: Job? = null
 
     private var lastTickNanos: Long = 0L
     private val frameCallback = object : Choreographer.FrameCallback {
@@ -203,6 +208,10 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
         showSubtitleSearch = false
         downloadingResultId = null
         errorMessage = null
+        seekFeedbackVisible = false
+        showExitConfirmation = false
+        tvMenuRoute = emptyList()
+        hideSeekFeedback()
     }
 
     private fun nilSpeed(): Double? = null
@@ -290,7 +299,7 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
     }
 
     private fun canAutoHide(): Boolean {
-        return isPlaying && !isScrubbing && !isBuffering && !showEpisodeList && !showTechnicalInfo && !showSubtitleSearch && errorMessage == null
+        return isPlaying && !isScrubbing && !isBuffering && !showEpisodeList && !showTechnicalInfo && !showSubtitleSearch && tvMenuRoute.isEmpty() && !showExitConfirmation && errorMessage == null
     }
 
     private fun revealUnlockButton() {
@@ -350,6 +359,20 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
         seekTo(target)
     }
 
+    fun flashSeekFeedback() {
+        seekFeedbackVisible = true
+        seekFeedbackJob?.cancel()
+        seekFeedbackJob = scope.launch {
+            delay(PlayerConstants.TV_SEEK_FEEDBACK_DURATION_MS)
+            seekFeedbackVisible = false
+        }
+    }
+
+    fun hideSeekFeedback() {
+        seekFeedbackJob?.cancel()
+        seekFeedbackVisible = false
+    }
+
     fun doubleTapSeek(forward: Boolean) {
         if (!uiOptions.doubleTapToSeekEnabled) return
         val delta = if (forward) uiOptions.seekForwardSec else -uiOptions.seekBackwardSec
@@ -387,7 +410,7 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
         renderer?.setSpeed(original)
     }
 
-    // MARK: - Scrubbing
+    // MARK: - Scrubbing (Phone Touch)
     fun startScrubbing() {
         wasPlayingBeforeScrub = isPlaying
         if (isPlaying) renderer?.pause()
@@ -411,6 +434,96 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
             renderer?.play()
         }
         scheduleAutoHide()
+    }
+
+    // MARK: - Scrubbing (TV Remote Armed Scrub)
+    fun beginScrub() {
+        if (isScrubbing) return
+        wasPlayingBeforeScrub = isPlaying
+        if (isPlaying) renderer?.pause()
+        isScrubbing = true
+        scrubPosition = displayPosition
+        autoHideJob?.cancel()
+    }
+
+    fun nudgeScrub(deltaSec: Double) {
+        val maxDuration = if (duration > 0) duration else Double.MAX_VALUE
+        val newPos = (scrubPosition + deltaSec).coerceIn(0.0, maxDuration)
+        scrubPosition = newPos
+    }
+
+    fun commitScrub() {
+        if (!isScrubbing) return
+        val target = scrubPosition
+        isScrubbing = false
+        seekTo(target)
+        if (wasPlayingBeforeScrub) {
+            renderer?.play()
+        }
+        scheduleAutoHide()
+    }
+
+    fun commitScrubAndPlay() {
+        if (!isScrubbing) return
+        val target = scrubPosition
+        isScrubbing = false
+        seekTo(target)
+        renderer?.play()
+        scheduleAutoHide()
+    }
+
+    fun cancelScrub() {
+        if (!isScrubbing) return
+        isScrubbing = false
+        if (wasPlayingBeforeScrub) {
+            renderer?.play()
+        }
+        scheduleAutoHide()
+    }
+
+    // MARK: - Chapters
+    fun currentChapterIndex(): Int {
+        if (chapters.isEmpty()) return -1
+        val pos = if (isScrubbing) scrubPosition else displayPosition
+        for (i in chapters.indices.reversed()) {
+            if (pos >= chapters[i].startSec) {
+                return i
+            }
+        }
+        return -1
+    }
+
+    fun chapterName(at: Double = displayPosition): String? {
+        if (chapters.isEmpty()) return null
+        for (i in chapters.indices.reversed()) {
+            if (at >= chapters[i].startSec) {
+                return chapters[i].name ?: "${i + 1}"
+            }
+        }
+        return null
+    }
+
+    fun goToNextChapter() {
+        val currentIndex = currentChapterIndex()
+        val nextIndex = currentIndex + 1
+        if (nextIndex in chapters.indices) {
+            seekTo(chapters[nextIndex].startSec)
+        }
+    }
+
+    fun goToPreviousChapter() {
+        val currentIndex = currentChapterIndex()
+        if (currentIndex < 0) return
+        val currentChapter = chapters[currentIndex]
+        val timeInChapter = displayPosition - currentChapter.startSec
+        if (timeInChapter > PlayerConstants.CHAPTER_RESTART_THRESHOLD_SEC || currentIndex == 0) {
+            seekTo(currentChapter.startSec)
+        } else {
+            val prevIndex = currentIndex - 1
+            if (prevIndex in chapters.indices) {
+                seekTo(chapters[prevIndex].startSec)
+            }
+        }
     }
 
     // MARK: - Video Zoom & Track Controls
@@ -608,6 +721,12 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
         countdownRemaining = null
     }
 
+    fun playNextEpisode() {
+        haptic()
+        disarmCountdownForEpisodeChange()
+        fireNextEpisode(reason = "userTap")
+    }
+
     fun playNextEpisodeNow() {
         haptic()
         disarmCountdownForEpisodeChange()
@@ -693,6 +812,50 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
         }
     }
 
+    // MARK: - TV Menus
+    fun openTvMenu(screen: TvMenuScreen) {
+        tvMenuRoute = listOf(screen)
+        menuInteractionStarted()
+    }
+
+    fun pushTvMenu(screen: TvMenuScreen) {
+        tvMenuRoute = tvMenuRoute + screen
+        menuInteractionStarted()
+    }
+
+    fun popTvMenu(): Boolean {
+        if (tvMenuRoute.isNotEmpty()) {
+            tvMenuRoute = tvMenuRoute.dropLast(1)
+            if (tvMenuRoute.isNotEmpty()) {
+                menuInteractionStarted()
+            } else {
+                scheduleAutoHide()
+            }
+            return true
+        }
+        return false
+    }
+
+    fun closeTvMenu() {
+        tvMenuRoute = emptyList()
+        scheduleAutoHide()
+    }
+
+    // MARK: - Exit Confirmation
+    fun requestExitConfirmation() {
+        cancelCountdown()
+        showExitConfirmation = true
+    }
+
+    fun dismissExitConfirmation() {
+        showExitConfirmation = false
+    }
+
+    fun confirmExit() {
+        showExitConfirmation = false
+        onDismissRequested?.invoke("closeButton")
+    }
+
     // MARK: - Episode List & Subtitle Search
     fun selectEpisode(itemId: String) {
         haptic()
@@ -708,6 +871,11 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
         showSubtitleSearch = true
         emit?.invoke("onSubtitleSearchRequested", mapOf("language" to subtitleSearchLanguage))
         scheduleAutoHide(PlayerConstants.MENU_AUTO_HIDE_DELAY_MS)
+    }
+
+    fun closeSubtitleSearch() {
+        showSubtitleSearch = false
+        scheduleAutoHide()
     }
 
     fun searchSubtitles(language: String) {
@@ -740,6 +908,7 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
         unlockRevealJob?.cancel()
         doubleTapFeedbackJob?.cancel()
         sleepTimerJob?.cancel()
+        seekFeedbackJob?.cancel()
         scope.cancel()
     }
 

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/PlayerViewModel.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/PlayerViewModel.kt
@@ -282,6 +282,20 @@ class PlayerViewModel : MPVLayerRenderer.Delegate {
         scheduleAutoHide()
     }
 
+    /**
+     * TV: when a focused composable unmounts (skip-segment button, technical
+     * info close), Compose focus dies with it and the remote goes dead —
+     * the ComposeView keeps view-level focus so keys land in a focus-less
+     * tree. Bump this tick to have TvControlsRow re-grab its default focus.
+     */
+    var tvControlsFocusRestoreTick by mutableStateOf(0)
+        private set
+
+    fun restoreTvControlsFocus() {
+        showControls()
+        tvControlsFocusRestoreTick++
+    }
+
     fun scheduleAutoHide(delayMs: Long = PlayerConstants.AUTO_HIDE_DELAY_MS) {
         autoHideJob?.cancel()
         autoHideJob = scope.launch {

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/TvFocusZone.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/TvFocusZone.kt
@@ -1,0 +1,21 @@
+package expo.modules.mpvplayer.nativeplayer
+
+enum class TvFocusZone {
+    NONE,
+    CHROME,
+    MENU,
+    SHELF,
+    SUBTITLE_SEARCH,
+    STILL_WATCHING,
+    EXIT_CONFIRM
+}
+
+fun deriveTvFocusZone(vm: PlayerViewModel): TvFocusZone {
+    if (vm.showExitConfirmation) return TvFocusZone.EXIT_CONFIRM
+    if (vm.showStillWatching) return TvFocusZone.STILL_WATCHING
+    if (vm.showSubtitleSearch) return TvFocusZone.SUBTITLE_SEARCH
+    if (vm.showEpisodeList) return TvFocusZone.SHELF
+    if (vm.tvMenuRoute.isNotEmpty()) return TvFocusZone.MENU
+    if (vm.controlsVisible && !vm.isScrubbing) return TvFocusZone.CHROME
+    return TvFocusZone.NONE
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/TvMenuScreen.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/TvMenuScreen.kt
@@ -1,0 +1,14 @@
+package expo.modules.mpvplayer.nativeplayer
+
+enum class TvMenuScreen {
+    CHAPTERS,
+    QUALITY,
+    AUDIO_ROOT,
+    AUDIO_SYNC,
+    VOLUME_BOOST,
+    SUBTITLES_ROOT,
+    SUBTITLE_SIZE,
+    SUBTITLE_SYNC,
+    SPEED,
+    MORE
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/TvOverlayContainer.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/TvOverlayContainer.kt
@@ -1,0 +1,54 @@
+package expo.modules.mpvplayer.nativeplayer
+
+import android.content.Context
+import android.view.KeyEvent
+import android.view.View
+import android.widget.FrameLayout
+
+class TvOverlayContainer(
+    context: Context,
+    private val keyHandler: TvRemoteKeyHandler
+) : FrameLayout(context) {
+
+    init {
+        isFocusable = true
+        isFocusableInTouchMode = true
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (keyHandler.intercept(event)) {
+            return true
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
+    override fun focusSearch(focused: View?, direction: Int): View? {
+        val next = super.focusSearch(focused, direction)
+        // If focus would escape outside this overlay container into background RN views,
+        // keep focus pinned inside this container.
+        if (next == null || !isDescendantOf(next, this)) {
+            return focused ?: this
+        }
+        return next
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        requestFocus()
+    }
+
+    fun onZoneChanged(zone: TvFocusZone) {
+        if (zone == TvFocusZone.NONE) {
+            requestFocus()
+        }
+    }
+
+    private fun isDescendantOf(child: View, parent: View): Boolean {
+        var p = child.parent
+        while (p != null) {
+            if (p === parent) return true
+            p = p.parent
+        }
+        return false
+    }
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/TvRemoteKeyHandler.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/TvRemoteKeyHandler.kt
@@ -1,0 +1,201 @@
+package expo.modules.mpvplayer.nativeplayer
+
+import android.view.KeyEvent
+import kotlin.math.min
+
+class TvRemoteKeyHandler(
+    private val viewModel: PlayerViewModel,
+    private val onExitRequested: () -> Unit
+) {
+    fun intercept(event: KeyEvent): Boolean {
+        val keyCode = event.keyCode
+        val action = event.action
+        val repeatCount = event.repeatCount
+        val zone = deriveTvFocusZone(viewModel)
+
+        // 1. Back Key: Cascade
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                when {
+                    viewModel.showExitConfirmation -> {
+                        viewModel.dismissExitConfirmation()
+                    }
+                    viewModel.showSubtitleSearch -> {
+                        viewModel.closeSubtitleSearch()
+                        viewModel.showControls()
+                    }
+                    viewModel.tvMenuRoute.isNotEmpty() -> {
+                        viewModel.popTvMenu()
+                    }
+                    viewModel.showEpisodeList -> {
+                        viewModel.showEpisodeList = false
+                    }
+                    viewModel.isScrubbing -> {
+                        viewModel.cancelScrub()
+                    }
+                    viewModel.controlsVisible -> {
+                        viewModel.controlsVisible = false
+                    }
+                    viewModel.countdownRemaining != null -> {
+                        viewModel.cancelNextEpisodeCountdown()
+                    }
+                    viewModel.seekFeedbackVisible -> {
+                        viewModel.hideSeekFeedback()
+                    }
+                    viewModel.errorMessage != null -> {
+                        onExitRequested()
+                    }
+                    else -> {
+                        viewModel.requestExitConfirmation()
+                    }
+                }
+            }
+            return true
+        }
+
+        // 2. Media Transport Keys (Always handled)
+        when (keyCode) {
+            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> {
+                if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                    if (viewModel.isScrubbing) {
+                        viewModel.commitScrubAndPlay()
+                    } else {
+                        viewModel.togglePlayPause()
+                    }
+                }
+                return true
+            }
+            KeyEvent.KEYCODE_MEDIA_PLAY -> {
+                if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                    if (viewModel.isScrubbing) {
+                        viewModel.commitScrubAndPlay()
+                    } else {
+                        viewModel.play()
+                    }
+                }
+                return true
+            }
+            KeyEvent.KEYCODE_MEDIA_PAUSE -> {
+                if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                    viewModel.pause()
+                }
+                return true
+            }
+            KeyEvent.KEYCODE_MEDIA_FAST_FORWARD -> {
+                if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                    viewModel.seekBy(viewModel.uiOptions.seekForwardSec)
+                    if (!viewModel.controlsVisible) viewModel.flashSeekFeedback()
+                }
+                return true
+            }
+            KeyEvent.KEYCODE_MEDIA_REWIND -> {
+                if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                    viewModel.seekBy(-viewModel.uiOptions.seekBackwardSec)
+                    if (!viewModel.controlsVisible) viewModel.flashSeekFeedback()
+                }
+                return true
+            }
+            KeyEvent.KEYCODE_MEDIA_NEXT -> {
+                if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                    viewModel.playNextEpisode()
+                }
+                return true
+            }
+            KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
+                if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                    viewModel.seekTo(0.0)
+                }
+                return true
+            }
+            KeyEvent.KEYCODE_MEDIA_STOP -> {
+                if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                    viewModel.requestExitConfirmation()
+                }
+                return true
+            }
+        }
+
+        // While the controls are up, directional keys fall through to the Compose
+        // focus engine below — re-arm the auto-hide timer here or the controls
+        // vanish mid-navigation once the original delay elapses.
+        if (viewModel.controlsVisible && action == KeyEvent.ACTION_DOWN) {
+            when (keyCode) {
+                KeyEvent.KEYCODE_DPAD_LEFT,
+                KeyEvent.KEYCODE_DPAD_RIGHT,
+                KeyEvent.KEYCODE_DPAD_UP,
+                KeyEvent.KEYCODE_DPAD_DOWN,
+                KeyEvent.KEYCODE_DPAD_CENTER,
+                KeyEvent.KEYCODE_ENTER,
+                KeyEvent.KEYCODE_NUMPAD_ENTER -> viewModel.scheduleAutoHide()
+            }
+        }
+
+        // 3. DPAD / Directional Keys (Handled only when zone == NONE or scrubbing)
+        if (zone == TvFocusZone.NONE || viewModel.isScrubbing) {
+            when (keyCode) {
+                KeyEvent.KEYCODE_DPAD_CENTER,
+                KeyEvent.KEYCODE_ENTER,
+                KeyEvent.KEYCODE_NUMPAD_ENTER -> {
+                    if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                        when {
+                            viewModel.countdownRemaining != null -> {
+                                viewModel.playNextEpisode()
+                            }
+                            viewModel.isScrubbing -> {
+                                viewModel.commitScrub()
+                            }
+                            viewModel.activeSegment != null -> {
+                                viewModel.skipActiveSegment()
+                            }
+                            else -> {
+                                viewModel.showControls()
+                            }
+                        }
+                    }
+                    return true
+                }
+                KeyEvent.KEYCODE_DPAD_LEFT -> {
+                    if (action == KeyEvent.ACTION_DOWN) {
+                        if (viewModel.isScrubbing) {
+                            val mult = min(
+                                1.0 + repeatCount.toDouble() / PlayerConstants.TV_SCRUB_ACCEL_REPEATS_PER_STEP,
+                                PlayerConstants.TV_SCRUB_ACCEL_MAX_MULTIPLIER
+                            )
+                            viewModel.nudgeScrub(-viewModel.uiOptions.seekBackwardSec * mult)
+                        } else {
+                            viewModel.seekBy(-viewModel.uiOptions.seekBackwardSec)
+                            viewModel.flashSeekFeedback()
+                        }
+                    }
+                    return true
+                }
+                KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                    if (action == KeyEvent.ACTION_DOWN) {
+                        if (viewModel.isScrubbing) {
+                            val mult = min(
+                                1.0 + repeatCount.toDouble() / PlayerConstants.TV_SCRUB_ACCEL_REPEATS_PER_STEP,
+                                PlayerConstants.TV_SCRUB_ACCEL_MAX_MULTIPLIER
+                            )
+                            viewModel.nudgeScrub(viewModel.uiOptions.seekForwardSec * mult)
+                        } else {
+                            viewModel.seekBy(viewModel.uiOptions.seekForwardSec)
+                            viewModel.flashSeekFeedback()
+                        }
+                    }
+                    return true
+                }
+                KeyEvent.KEYCODE_DPAD_UP,
+                KeyEvent.KEYCODE_DPAD_DOWN -> {
+                    if (action == KeyEvent.ACTION_UP && repeatCount == 0) {
+                        if (viewModel.errorMessage == null && !viewModel.isScrubbing) {
+                            viewModel.showControls()
+                        }
+                    }
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvControlsRow.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvControlsRow.kt
@@ -1,0 +1,341 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.ClosedCaption
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.Forward10
+import androidx.compose.material.icons.filled.Forward30
+import androidx.compose.material.icons.filled.MoreHoriz
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material.icons.filled.Replay10
+import androidx.compose.material.icons.filled.Replay30
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.filled.VideoLibrary
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.IconButton
+import androidx.tv.material3.IconButtonDefaults
+import androidx.tv.material3.Text
+import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
+import expo.modules.mpvplayer.nativeplayer.TvMenuScreen
+import kotlinx.coroutines.delay
+
+enum class TvControl {
+    PREV_EPISODE,
+    SKIP_BACK,
+    PREV_CHAPTER,
+    PLAY_PAUSE,
+    NEXT_CHAPTER,
+    SKIP_FORWARD,
+    NEXT_EPISODE,
+    SKIP_SEGMENT,
+    EPISODES,
+    CHAPTERS,
+    QUALITY,
+    AUDIO,
+    SUBTITLES,
+    SPEED,
+    MORE
+}
+
+@Composable
+fun TvControlsRow(
+    viewModel: PlayerViewModel,
+    lastFocused: TvControl?,
+    onControlFocused: (TvControl) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val isEpisode = viewModel.metadata?.isEpisode == true
+    val hasChapters = viewModel.chapters.isNotEmpty()
+    val hasEpisodes = viewModel.episodeList.isNotEmpty()
+    val hasQuality = viewModel.qualityMenu.isNotEmpty()
+    val hasAudio = viewModel.audioMenu.isNotEmpty()
+    val hasSubtitles = viewModel.subtitleMenu.isNotEmpty() || viewModel.uiOptions.subtitleSearchEnabled
+    val activeSegment = viewModel.activeSegment
+
+    fun isAvailable(control: TvControl): Boolean = when (control) {
+        TvControl.PREV_EPISODE, TvControl.NEXT_EPISODE -> isEpisode
+        TvControl.PREV_CHAPTER, TvControl.NEXT_CHAPTER, TvControl.CHAPTERS -> hasChapters
+        TvControl.EPISODES -> hasEpisodes
+        TvControl.QUALITY -> hasQuality
+        TvControl.AUDIO -> hasAudio
+        TvControl.SUBTITLES -> hasSubtitles
+        TvControl.SKIP_SEGMENT -> activeSegment != null
+        TvControl.SKIP_BACK, TvControl.SKIP_FORWARD, TvControl.PLAY_PAUSE, TvControl.SPEED, TvControl.MORE -> true
+    }
+
+    val defaultFocusTarget = if (lastFocused != null && isAvailable(lastFocused)) {
+        lastFocused
+    } else {
+        TvControl.PLAY_PAUSE
+    }
+
+    val focusRequesters = remember {
+        TvControl.entries.associateWith { FocusRequester() }
+    }
+
+    LaunchedEffect(Unit) {
+        delay(40L)
+        runCatching {
+            focusRequesters[defaultFocusTarget]?.requestFocus()
+        }
+    }
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // --- Left Transport Cluster ---
+        if (isEpisode) {
+            TvIconButton(
+                control = TvControl.PREV_EPISODE,
+                icon = Icons.Filled.SkipPrevious,
+                contentDescription = "Previous Episode",
+                focusRequester = focusRequesters.getValue(TvControl.PREV_EPISODE),
+                onFocused = onControlFocused,
+                onClick = { viewModel.playPreviousEpisode() }
+            )
+        }
+
+        val skipBackIcon = when (viewModel.uiOptions.seekBackwardSec.toInt()) {
+            10 -> Icons.Filled.Replay10
+            30 -> Icons.Filled.Replay30
+            else -> Icons.Filled.Replay
+        }
+        TvIconButton(
+            control = TvControl.SKIP_BACK,
+            icon = skipBackIcon,
+            contentDescription = "Skip Back",
+            focusRequester = focusRequesters.getValue(TvControl.SKIP_BACK),
+            onFocused = onControlFocused,
+            onClick = { viewModel.seekBy(-viewModel.uiOptions.seekBackwardSec) }
+        )
+
+        if (hasChapters) {
+            TvIconButton(
+                control = TvControl.PREV_CHAPTER,
+                icon = Icons.Filled.FastRewind,
+                contentDescription = "Previous Chapter",
+                focusRequester = focusRequesters.getValue(TvControl.PREV_CHAPTER),
+                onFocused = onControlFocused,
+                onClick = { viewModel.goToPreviousChapter() }
+            )
+        }
+
+        TvIconButton(
+            control = TvControl.PLAY_PAUSE,
+            icon = if (viewModel.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+            contentDescription = if (viewModel.isPlaying) "Pause" else "Play",
+            focusRequester = focusRequesters.getValue(TvControl.PLAY_PAUSE),
+            onFocused = onControlFocused,
+            onClick = { viewModel.togglePlayPause() }
+        )
+
+        if (hasChapters) {
+            TvIconButton(
+                control = TvControl.NEXT_CHAPTER,
+                icon = Icons.Filled.FastForward,
+                contentDescription = "Next Chapter",
+                focusRequester = focusRequesters.getValue(TvControl.NEXT_CHAPTER),
+                onFocused = onControlFocused,
+                onClick = { viewModel.goToNextChapter() }
+            )
+        }
+
+        val skipForwardIcon = when (viewModel.uiOptions.seekForwardSec.toInt()) {
+            10 -> Icons.Filled.Forward10
+            30 -> Icons.Filled.Forward30
+            else -> Icons.Filled.FastForward
+        }
+        TvIconButton(
+            control = TvControl.SKIP_FORWARD,
+            icon = skipForwardIcon,
+            contentDescription = "Skip Forward",
+            focusRequester = focusRequesters.getValue(TvControl.SKIP_FORWARD),
+            onFocused = onControlFocused,
+            onClick = { viewModel.seekBy(viewModel.uiOptions.seekForwardSec) }
+        )
+
+        if (isEpisode) {
+            TvIconButton(
+                control = TvControl.NEXT_EPISODE,
+                icon = Icons.Filled.SkipNext,
+                contentDescription = "Next Episode",
+                focusRequester = focusRequesters.getValue(TvControl.NEXT_EPISODE),
+                onFocused = onControlFocused,
+                onClick = { viewModel.playNextEpisode() }
+            )
+        }
+
+        if (activeSegment != null) {
+            val segmentLabel = if (activeSegment.type == "Intro") {
+                viewModel.str("skipIntro", "Skip Intro")
+            } else {
+                viewModel.str("skipCredits", "Skip Credits")
+            }
+            Button(
+                onClick = { viewModel.skipActiveSegment() },
+                modifier = Modifier
+                    .focusRequester(focusRequesters.getValue(TvControl.SKIP_SEGMENT))
+                    .onFocusChanged {
+                        if (it.isFocused) {
+                            onControlFocused(TvControl.SKIP_SEGMENT)
+                            viewModel.scheduleAutoHide()
+                        }
+                    },
+                colors = ButtonDefaults.colors(
+                    containerColor = Color(0xFF2E2E2E),
+                    focusedContainerColor = Color.White,
+                    contentColor = Color.White,
+                    focusedContentColor = Color.Black
+                )
+            ) {
+                Text(
+                    text = segmentLabel,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        // --- Right Options Cluster ---
+        if (hasEpisodes) {
+            TvIconButton(
+                control = TvControl.EPISODES,
+                icon = Icons.Filled.VideoLibrary,
+                contentDescription = "Episodes",
+                focusRequester = focusRequesters.getValue(TvControl.EPISODES),
+                onFocused = onControlFocused,
+                onClick = { viewModel.showEpisodeList = true }
+            )
+        }
+
+        if (hasChapters) {
+            TvIconButton(
+                control = TvControl.CHAPTERS,
+                icon = Icons.Filled.Bookmark,
+                contentDescription = "Chapters",
+                focusRequester = focusRequesters.getValue(TvControl.CHAPTERS),
+                onFocused = onControlFocused,
+                onClick = { viewModel.openTvMenu(TvMenuScreen.CHAPTERS) }
+            )
+        }
+
+        if (hasQuality) {
+            TvIconButton(
+                control = TvControl.QUALITY,
+                icon = Icons.Filled.Speed,
+                contentDescription = "Quality",
+                focusRequester = focusRequesters.getValue(TvControl.QUALITY),
+                onFocused = onControlFocused,
+                onClick = { viewModel.openTvMenu(TvMenuScreen.QUALITY) }
+            )
+        }
+
+        if (hasAudio) {
+            TvIconButton(
+                control = TvControl.AUDIO,
+                icon = Icons.Filled.VolumeUp,
+                contentDescription = "Audio",
+                focusRequester = focusRequesters.getValue(TvControl.AUDIO),
+                onFocused = onControlFocused,
+                onClick = { viewModel.openTvMenu(TvMenuScreen.AUDIO_ROOT) }
+            )
+        }
+
+        if (hasSubtitles) {
+            TvIconButton(
+                control = TvControl.SUBTITLES,
+                icon = Icons.Filled.ClosedCaption,
+                contentDescription = "Subtitles",
+                focusRequester = focusRequesters.getValue(TvControl.SUBTITLES),
+                onFocused = onControlFocused,
+                onClick = { viewModel.openTvMenu(TvMenuScreen.SUBTITLES_ROOT) }
+            )
+        }
+
+        TvIconButton(
+            control = TvControl.SPEED,
+            icon = Icons.Filled.Timer,
+            contentDescription = "Speed",
+            focusRequester = focusRequesters.getValue(TvControl.SPEED),
+            onFocused = onControlFocused,
+            onClick = { viewModel.openTvMenu(TvMenuScreen.SPEED) }
+        )
+
+        TvIconButton(
+            control = TvControl.MORE,
+            icon = Icons.Filled.MoreHoriz,
+            contentDescription = "More",
+            focusRequester = focusRequesters.getValue(TvControl.MORE),
+            onFocused = onControlFocused,
+            onClick = { viewModel.openTvMenu(TvMenuScreen.MORE) }
+        )
+    }
+}
+
+@Composable
+private fun TvIconButton(
+    control: TvControl,
+    icon: ImageVector,
+    contentDescription: String,
+    focusRequester: FocusRequester,
+    onFocused: (TvControl) -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .focusRequester(focusRequester)
+            .onFocusChanged {
+                if (it.isFocused) {
+                    onFocused(control)
+                }
+            },
+        colors = IconButtonDefaults.colors(
+            containerColor = Color(0xFF2E2E2E),
+            focusedContainerColor = Color.White,
+            contentColor = Color.White,
+            focusedContentColor = Color.Black
+        )
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(24.dp)
+        )
+    }
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvControlsRow.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvControlsRow.kt
@@ -26,7 +26,10 @@ import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.VideoLibrary
 import androidx.compose.material.icons.filled.VolumeUp
-import androidx.compose.material3.Icon
+// tv-material3's Icon, not compose.material3's: the TV IconButton feeds its
+// content color through the TV library's LocalContentColor, which the mobile
+// Icon never reads (it defaults to black).
+import androidx.tv.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -103,10 +106,21 @@ fun TvControlsRow(
         TvControl.entries.associateWith { FocusRequester() }
     }
 
-    LaunchedEffect(Unit) {
+    // Fires on mount (tick 0) and again whenever the view model asks for a
+    // focus restore — e.g. after a focused overlay/button unmounted and left
+    // the Compose tree without any focused node.
+    LaunchedEffect(viewModel.tvControlsFocusRestoreTick) {
         delay(40L)
         runCatching {
             focusRequesters[defaultFocusTarget]?.requestFocus()
+        }
+    }
+
+    // The skip button can vanish while focused (clicked, or the segment
+    // expired under the user) — put focus back on a control that exists.
+    LaunchedEffect(activeSegment) {
+        if (activeSegment == null && lastFocused == TvControl.SKIP_SEGMENT) {
+            viewModel.restoreTvControlsFocus()
         }
     }
 

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvControlsRow.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvControlsRow.kt
@@ -1,5 +1,6 @@
 package expo.modules.mpvplayer.nativeplayer.ui.tv
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -32,7 +33,10 @@ import androidx.compose.material.icons.filled.VolumeUp
 import androidx.tv.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -43,6 +47,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.BorderStroke
+import androidx.tv.material3.Border
 import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.IconButton
@@ -228,10 +234,15 @@ fun TvControlsRow(
                         }
                     },
                 colors = ButtonDefaults.colors(
-                    containerColor = Color(0xFF2E2E2E),
-                    focusedContainerColor = Color.White,
-                    contentColor = Color.White,
-                    focusedContentColor = Color.Black
+                    containerColor = TvPalette.SurfaceGlass,
+                    focusedContainerColor = TvPalette.FocusFill,
+                    contentColor = TvPalette.OnSurface,
+                    focusedContentColor = TvPalette.OnFocus
+                ),
+                border = ButtonDefaults.border(
+                    border = Border(
+                        border = BorderStroke(1.dp, TvPalette.Hairline)
+                    )
                 )
             ) {
                 Text(
@@ -330,26 +341,34 @@ private fun TvIconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    var isFocused by remember { mutableStateOf(false) }
     IconButton(
         onClick = onClick,
         modifier = modifier
+            .size(TvMetrics.CONTROL_SIZE)
             .focusRequester(focusRequester)
             .onFocusChanged {
+                isFocused = it.isFocused
                 if (it.isFocused) {
                     onFocused(control)
                 }
-            },
+            }
+            // Hairline only while unfocused; the focused fill is solid white.
+            .then(
+                if (isFocused) Modifier
+                else Modifier.border(1.dp, TvPalette.Hairline, CircleShape)
+            ),
         colors = IconButtonDefaults.colors(
-            containerColor = Color(0xFF2E2E2E),
-            focusedContainerColor = Color.White,
-            contentColor = Color.White,
-            focusedContentColor = Color.Black
+            containerColor = TvPalette.SurfaceGlass,
+            focusedContainerColor = TvPalette.FocusFill,
+            contentColor = TvPalette.OnSurface,
+            focusedContentColor = TvPalette.OnFocus
         )
     ) {
         Icon(
             imageVector = icon,
             contentDescription = contentDescription,
-            modifier = Modifier.size(24.dp)
+            modifier = Modifier.size(TvMetrics.ICON_SIZE)
         )
     }
 }

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvEpisodeShelf.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvEpisodeShelf.kt
@@ -1,0 +1,221 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Border
+import androidx.tv.material3.Card
+import androidx.tv.material3.CardDefaults
+import androidx.tv.material3.Surface
+import androidx.tv.material3.Text
+import expo.modules.mpvplayer.nativeplayer.EpisodeListItemRecord
+import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
+import expo.modules.mpvplayer.nativeplayer.ui.RemoteImage
+import kotlinx.coroutines.delay
+
+@Composable
+fun TvEpisodeShelf(
+    viewModel: PlayerViewModel,
+    modifier: Modifier = Modifier
+) {
+    val episodes = viewModel.episodeList
+    val nowPlayingIndex = remember(episodes) {
+        val idx = episodes.indexOfFirst { it.isCurrent }
+        if (idx >= 0) idx else 0
+    }
+
+    val listState = rememberLazyListState()
+    val nowPlayingFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(nowPlayingIndex) {
+        if (episodes.isNotEmpty()) {
+            listState.scrollToItem(nowPlayingIndex)
+            // One frame retry for Compose focus
+            delay(50L)
+            runCatching {
+                nowPlayingFocusRequester.requestFocus()
+            }
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(
+                        Color.Black.copy(alpha = 0f),
+                        Color.Black.copy(alpha = 0.75f),
+                        Color.Black.copy(alpha = 0.95f)
+                    )
+                )
+            )
+            .padding(vertical = 28.dp),
+        contentAlignment = Alignment.BottomStart
+    ) {
+        Column {
+            Text(
+                text = viewModel.str("episodes", "Episodes"),
+                color = Color.White,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = TvMetrics.INSET_H)
+            )
+
+            Spacer(modifier = Modifier.height(18.dp))
+
+            LazyRow(
+                state = listState,
+                horizontalArrangement = Arrangement.spacedBy(24.dp),
+                contentPadding = PaddingValues(horizontal = TvMetrics.INSET_H)
+            ) {
+                itemsIndexed(episodes, key = { _, item -> item.itemId }) { index, episode ->
+                    val isNowPlaying = index == nowPlayingIndex
+                    TvEpisodeCard(
+                        episode = episode,
+                        nowPlayingText = viewModel.str("nowPlaying", "Now Playing"),
+                        onClick = { viewModel.selectEpisode(episode.itemId) },
+                        modifier = if (isNowPlaying) Modifier.focusRequester(nowPlayingFocusRequester) else Modifier
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvEpisodeCard(
+    episode: EpisodeListItemRecord,
+    nowPlayingText: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.size(TvMetrics.POSTER_WIDTH, TvMetrics.POSTER_HEIGHT),
+        shape = CardDefaults.shape(shape = RoundedCornerShape(TvMetrics.POSTER_CORNER)),
+        border = CardDefaults.border(
+            focusedBorder = Border(
+                border = androidx.compose.foundation.BorderStroke(3.dp, Color.White),
+                shape = RoundedCornerShape(TvMetrics.POSTER_CORNER)
+            )
+        )
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.BottomStart
+        ) {
+            RemoteImage(
+                url = episode.imageUrl,
+                modifier = Modifier.fillMaxSize()
+            )
+
+            TvPosterScrim(modifier = Modifier.align(Alignment.BottomCenter))
+
+            // Now Playing Badge (top-left)
+            if (episode.isCurrent) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(10.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color.White)
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.PlayArrow,
+                            contentDescription = null,
+                            tint = Color.Black,
+                            modifier = Modifier.size(12.dp)
+                        )
+                        Text(
+                            text = nowPlayingText,
+                            color = Color.Black,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+
+            // Episode Title and Watch Progress (bottom)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = TvMetrics.TEXT_INSET_H,
+                        vertical = TvMetrics.TEXT_INSET_V
+                    )
+            ) {
+                val titleText = if (episode.indexNumber != null) {
+                    "${episode.indexNumber}. ${episode.title}"
+                } else {
+                    episode.title
+                }
+
+                Text(
+                    text = titleText,
+                    color = Color.White,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                if (episode.progressPercent > 0) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(4.dp)
+                            .clip(CircleShape)
+                            .background(Color.White.copy(alpha = 0.3f))
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth((episode.progressPercent / 100.0).toFloat().coerceIn(0f, 1f))
+                                .height(4.dp)
+                                .clip(CircleShape)
+                                .background(Color.White)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvErrorOverlay.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvErrorOverlay.kt
@@ -1,0 +1,77 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Text
+import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
+
+@Composable
+fun TvErrorOverlay(
+    viewModel: PlayerViewModel,
+    modifier: Modifier = Modifier
+) {
+    val message = viewModel.errorMessage ?: return
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.8f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .widthIn(max = 680.dp)
+                .clip(RoundedCornerShape(24.dp))
+                .background(Color(0xFF1E1E1E))
+                .padding(40.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Warning,
+                contentDescription = null,
+                tint = Color(0xFFFFCC00),
+                modifier = Modifier.size(56.dp)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = viewModel.str("playbackError", "Playback error"),
+                color = Color.White,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = message,
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 17.sp,
+                textAlign = TextAlign.Center,
+                lineHeight = 24.sp
+            )
+        }
+    }
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvExitConfirmation.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvExitConfirmation.kt
@@ -1,0 +1,115 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.Text
+import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
+
+@Composable
+fun TvExitConfirmation(
+    viewModel: PlayerViewModel,
+    modifier: Modifier = Modifier
+) {
+    val cancelFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        cancelFocusRequester.requestFocus()
+    }
+
+    val title = viewModel.str("stopPlayback", "Stop playback")
+    val message = if (!viewModel.metadata?.title.isNullOrEmpty()) {
+        viewModel.strings.formatStopPlayingTitle(viewModel.metadata?.title ?: "")
+    } else {
+        viewModel.str("stopPlayingConfirm", "Are you sure you want to stop playback?")
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.7f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .widthIn(max = 580.dp)
+                .clip(RoundedCornerShape(24.dp))
+                .background(Color(0xFF1E1E1E))
+                .padding(36.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = title,
+                color = Color.White,
+                fontSize = 26.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = message,
+                color = Color.White.copy(alpha = 0.8f),
+                fontSize = 18.sp,
+                textAlign = TextAlign.Center,
+                lineHeight = 24.sp
+            )
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Button(
+                    onClick = { viewModel.dismissExitConfirmation() },
+                    modifier = Modifier.focusRequester(cancelFocusRequester)
+                ) {
+                    Text(
+                        text = viewModel.str("cancel", "Cancel"),
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+
+                Button(
+                    onClick = { viewModel.confirmExit() },
+                    colors = ButtonDefaults.colors(
+                        containerColor = Color(0xFFE50914).copy(alpha = 0.8f),
+                        focusedContainerColor = Color(0xFFE50914)
+                    )
+                ) {
+                    Text(
+                        text = viewModel.str("stop", "Stop"),
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+        }
+    }
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvMenus.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvMenus.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.BorderStroke
+import androidx.tv.material3.Border
 import androidx.tv.material3.ListItem
 import androidx.tv.material3.ListItemDefaults
 import androidx.tv.material3.MaterialTheme
@@ -82,7 +84,10 @@ fun TvMenuPanel(
                 .fillMaxHeight()
                 .width(460.dp),
             colors = SurfaceDefaults.colors(
-                containerColor = Color(0xFF181818).copy(alpha = 0.96f)
+                containerColor = TvPalette.SurfaceGlassStrong
+            ),
+            border = Border(
+                border = BorderStroke(1.dp, TvPalette.Hairline)
             ),
             shape = RoundedCornerShape(topStart = 24.dp, bottomStart = 24.dp)
         ) {
@@ -355,15 +360,15 @@ private fun SubtitlesRootMenu(viewModel: PlayerViewModel) {
                         Icon(
                             imageVector = Icons.Filled.Search,
                             contentDescription = null,
-                            tint = Color.White.copy(alpha = 0.7f),
+                            tint = TvPalette.OnSurfaceDim,
                             modifier = Modifier.size(20.dp)
                         )
                     },
                     colors = ListItemDefaults.colors(
-                        containerColor = Color(0xFF222222),
-                        focusedContainerColor = Color.White,
-                        contentColor = Color.White,
-                        focusedContentColor = Color.Black
+                        containerColor = TvPalette.RowFill,
+                        focusedContainerColor = TvPalette.FocusFill,
+                        contentColor = TvPalette.OnSurface,
+                        focusedContentColor = TvPalette.OnFocus
                     )
                 )
             }
@@ -512,10 +517,10 @@ private fun TvMenuRow(
             }
         } else null,
         colors = ListItemDefaults.colors(
-            containerColor = Color(0xFF222222),
-            focusedContainerColor = Color.White,
-            contentColor = Color.White,
-            focusedContentColor = Color.Black
+            containerColor = TvPalette.RowFill,
+            focusedContainerColor = TvPalette.FocusFill,
+            contentColor = TvPalette.OnSurface,
+            focusedContentColor = TvPalette.OnFocus
         ),
         modifier = modifier
     )
@@ -541,15 +546,15 @@ private fun TvSubmenuRow(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowForwardIos,
                 contentDescription = null,
-                tint = Color.White.copy(alpha = 0.5f),
+                tint = TvPalette.OnSurfaceFaint,
                 modifier = Modifier.size(16.dp)
             )
         },
         colors = ListItemDefaults.colors(
-            containerColor = Color(0xFF222222),
-            focusedContainerColor = Color.White,
-            contentColor = Color.White,
-            focusedContentColor = Color.Black
+            containerColor = TvPalette.RowFill,
+            focusedContainerColor = TvPalette.FocusFill,
+            contentColor = TvPalette.OnSurface,
+            focusedContentColor = TvPalette.OnFocus
         ),
         modifier = modifier
     )

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvMenus.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvMenus.kt
@@ -1,0 +1,556 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.ListItem
+import androidx.tv.material3.ListItemDefaults
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Surface
+import androidx.tv.material3.SurfaceDefaults
+import androidx.tv.material3.Text
+import androidx.tv.material3.darkColorScheme
+import expo.modules.mpvplayer.nativeplayer.PlayerConstants
+import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
+import expo.modules.mpvplayer.nativeplayer.TrackMenuItemRecord
+import expo.modules.mpvplayer.nativeplayer.TvMenuScreen
+import expo.modules.mpvplayer.nativeplayer.ui.formatTimeSec
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+@Composable
+fun TvPlayerTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = darkColorScheme(
+            primary = Color.White,
+            onPrimary = Color.Black,
+            surface = Color(0xFF1E1E1E),
+            onSurface = Color.White,
+            background = Color.Black,
+            onBackground = Color.White
+        ),
+        content = content
+    )
+}
+
+@Composable
+fun TvMenuPanel(
+    viewModel: PlayerViewModel,
+    modifier: Modifier = Modifier
+) {
+    val currentScreen = viewModel.tvMenuRoute.lastOrNull() ?: return
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.5f))
+    ) {
+        Surface(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .fillMaxHeight()
+                .width(460.dp),
+            colors = SurfaceDefaults.colors(
+                containerColor = Color(0xFF181818).copy(alpha = 0.96f)
+            ),
+            shape = RoundedCornerShape(topStart = 24.dp, bottomStart = 24.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 24.dp, vertical = 28.dp)
+            ) {
+                val headerTitle = when (currentScreen) {
+                    TvMenuScreen.CHAPTERS -> viewModel.str("chapters", "Chapters")
+                    TvMenuScreen.QUALITY -> viewModel.str("quality", "Quality")
+                    TvMenuScreen.AUDIO_ROOT -> viewModel.str("audio", "Audio")
+                    TvMenuScreen.AUDIO_SYNC -> viewModel.str("audioSync", "Audio sync")
+                    TvMenuScreen.VOLUME_BOOST -> viewModel.str("volumeBoost", "Volume boost")
+                    TvMenuScreen.SUBTITLES_ROOT -> viewModel.str("subtitles", "Subtitles")
+                    TvMenuScreen.SUBTITLE_SIZE -> viewModel.str("subtitleSize", "Subtitle size")
+                    TvMenuScreen.SUBTITLE_SYNC -> viewModel.str("subtitleSync", "Subtitle sync")
+                    TvMenuScreen.SPEED -> viewModel.str("speed", "Speed")
+                    TvMenuScreen.MORE -> viewModel.str("playback_options", "More")
+                }
+
+                Text(
+                    text = headerTitle,
+                    color = Color.White,
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                when (currentScreen) {
+                    TvMenuScreen.CHAPTERS -> ChaptersMenu(viewModel)
+                    TvMenuScreen.QUALITY -> QualityMenu(viewModel)
+                    TvMenuScreen.AUDIO_ROOT -> AudioRootMenu(viewModel)
+                    TvMenuScreen.AUDIO_SYNC -> AudioSyncMenu(viewModel)
+                    TvMenuScreen.VOLUME_BOOST -> VolumeBoostMenu(viewModel)
+                    TvMenuScreen.SUBTITLES_ROOT -> SubtitlesRootMenu(viewModel)
+                    TvMenuScreen.SUBTITLE_SIZE -> SubtitleSizeMenu(viewModel)
+                    TvMenuScreen.SUBTITLE_SYNC -> SubtitleSyncMenu(viewModel)
+                    TvMenuScreen.SPEED -> SpeedMenu(viewModel)
+                    TvMenuScreen.MORE -> MoreMenu(viewModel)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChaptersMenu(viewModel: PlayerViewModel) {
+    val chapters = viewModel.chapters
+    val currentIdx = viewModel.currentChapterIndex()
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        try { firstFocus.requestFocus() } catch (_: Exception) {}
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        itemsIndexed(chapters) { index, chapter ->
+            val isSelected = index == currentIdx
+            val label = "${chapter.name ?: "${index + 1}"} — ${formatTimeSec(chapter.startSec)}"
+            TvMenuRow(
+                label = label,
+                selected = isSelected,
+                onClick = {
+                    viewModel.seekTo(chapter.startSec)
+                    viewModel.closeTvMenu()
+                },
+                modifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun QualityMenu(viewModel: PlayerViewModel) {
+    val items = viewModel.qualityMenu
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        try { firstFocus.requestFocus() } catch (_: Exception) {}
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        itemsIndexed(items) { index, item ->
+            TvMenuRow(
+                label = item.label,
+                selected = item.selected,
+                onClick = {
+                    viewModel.selectQuality(item)
+                    viewModel.closeTvMenu()
+                },
+                modifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun AudioRootMenu(viewModel: PlayerViewModel) {
+    val items = viewModel.audioMenu
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        try { firstFocus.requestFocus() } catch (_: Exception) {}
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        itemsIndexed(items) { index, item ->
+            TvMenuRow(
+                label = item.label,
+                selected = item.selected,
+                onClick = { viewModel.selectAudio(item) },
+                modifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier
+            )
+        }
+
+        item {
+            TvSubmenuRow(
+                label = viewModel.str("audioSync", "Audio sync"),
+                onClick = { viewModel.pushTvMenu(TvMenuScreen.AUDIO_SYNC) }
+            )
+        }
+
+        item {
+            TvSubmenuRow(
+                label = viewModel.str("volumeBoost", "Volume boost"),
+                onClick = { viewModel.pushTvMenu(TvMenuScreen.VOLUME_BOOST) }
+            )
+        }
+
+        item {
+            TvMenuRow(
+                label = viewModel.str("dialogueBoost", "Dialogue boost"),
+                selected = viewModel.dialogueBoostEnabled,
+                onClick = { viewModel.toggleDialogueBoost() }
+            )
+        }
+
+        item {
+            TvMenuRow(
+                label = viewModel.str("monoAudio", "Mono audio"),
+                selected = viewModel.monoAudioEnabled,
+                onClick = { viewModel.toggleMonoAudio() }
+            )
+        }
+    }
+}
+
+@Composable
+private fun AudioSyncMenu(viewModel: PlayerViewModel) {
+    val presets = PlayerConstants.SYNC_OFFSET_PRESETS
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        try { firstFocus.requestFocus() } catch (_: Exception) {}
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        itemsIndexed(presets) { index, offset ->
+            val isSelected = abs(viewModel.audioDelay - offset) < 0.001
+            val label = if (offset == 0.0) "0 s" else String.format("%+g s", offset)
+            TvMenuRow(
+                label = label,
+                selected = isSelected,
+                onClick = { viewModel.setAudioDelay(offset) },
+                modifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun VolumeBoostMenu(viewModel: PlayerViewModel) {
+    val presets = PlayerConstants.VOLUME_BOOST_PRESETS
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        try { firstFocus.requestFocus() } catch (_: Exception) {}
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        itemsIndexed(presets) { index, percent ->
+            val isSelected = viewModel.volumeBoostPercent == percent
+            TvMenuRow(
+                label = "$percent%",
+                selected = isSelected,
+                onClick = { viewModel.setVolumeBoost(percent) },
+                modifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun SubtitlesRootMenu(viewModel: PlayerViewModel) {
+    val items = viewModel.subtitleMenu
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        try { firstFocus.requestFocus() } catch (_: Exception) {}
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        itemsIndexed(items) { index, item ->
+            TvMenuRow(
+                label = item.label,
+                selected = item.selected,
+                onClick = { viewModel.selectSubtitle(item) },
+                modifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier
+            )
+        }
+
+        item {
+            TvSubmenuRow(
+                label = viewModel.str("subtitleSize", "Subtitle size"),
+                onClick = { viewModel.pushTvMenu(TvMenuScreen.SUBTITLE_SIZE) }
+            )
+        }
+
+        item {
+            TvSubmenuRow(
+                label = viewModel.str("subtitleSync", "Subtitle sync"),
+                onClick = { viewModel.pushTvMenu(TvMenuScreen.SUBTITLE_SYNC) }
+            )
+        }
+
+        if (viewModel.uiOptions.subtitleSearchEnabled) {
+            item {
+                ListItem(
+                    selected = false,
+                    onClick = {
+                        viewModel.closeTvMenu()
+                        viewModel.controlsVisible = false
+                        viewModel.openSubtitleSearch()
+                    },
+                    headlineContent = {
+                        Text(
+                            text = viewModel.str("searchSubtitles", "Search subtitles"),
+                            fontSize = 17.sp,
+                            fontWeight = FontWeight.Medium
+                        )
+                    },
+                    trailingContent = {
+                        Icon(
+                            imageVector = Icons.Filled.Search,
+                            contentDescription = null,
+                            tint = Color.White.copy(alpha = 0.7f),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    },
+                    colors = ListItemDefaults.colors(
+                        containerColor = Color(0xFF222222),
+                        focusedContainerColor = Color.White,
+                        contentColor = Color.White,
+                        focusedContentColor = Color.Black
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SubtitleSizeMenu(viewModel: PlayerViewModel) {
+    val presets = PlayerConstants.SUBTITLE_SCALE_PRESETS
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        try { firstFocus.requestFocus() } catch (_: Exception) {}
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        itemsIndexed(presets) { index, preset ->
+            val isSelected = abs(viewModel.subtitleScale - preset) < 0.001
+            val label = "${(preset * 100).roundToInt()}%"
+            TvMenuRow(
+                label = label,
+                selected = isSelected,
+                onClick = { viewModel.setSubtitleScale(preset) },
+                modifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun SubtitleSyncMenu(viewModel: PlayerViewModel) {
+    val presets = PlayerConstants.SYNC_OFFSET_PRESETS
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        try { firstFocus.requestFocus() } catch (_: Exception) {}
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        itemsIndexed(presets) { index, offset ->
+            val isSelected = abs(viewModel.subtitleDelay - offset) < 0.001
+            val label = if (offset == 0.0) "0 s" else String.format("%+g s", offset)
+            TvMenuRow(
+                label = label,
+                selected = isSelected,
+                onClick = { viewModel.setSubtitleDelay(offset) },
+                modifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpeedMenu(viewModel: PlayerViewModel) {
+    val presets = PlayerConstants.SPEED_PRESETS
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        try { firstFocus.requestFocus() } catch (_: Exception) {}
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        itemsIndexed(presets) { index, option ->
+            val isSelected = abs(viewModel.speed - option) < 0.001
+            val label = if (option == 1.0) "1×" else String.format("%g×", option)
+            TvMenuRow(
+                label = label,
+                selected = isSelected,
+                onClick = { viewModel.setSpeed(option) },
+                modifier = if (index == 0) Modifier.focusRequester(firstFocus) else Modifier
+            )
+        }
+    }
+}
+
+@Composable
+private fun MoreMenu(viewModel: PlayerViewModel) {
+    val firstFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        try { firstFocus.requestFocus() } catch (_: Exception) {}
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        item {
+            TvMenuRow(
+                label = viewModel.str("zoomToFill", "Zoom to fill"),
+                selected = viewModel.isZoomedToFill,
+                onClick = { viewModel.toggleZoomToFill() },
+                modifier = Modifier.focusRequester(firstFocus)
+            )
+        }
+
+        item {
+            TvMenuRow(
+                label = viewModel.str("technicalInfo", "Technical info"),
+                selected = viewModel.showTechnicalInfo,
+                onClick = { viewModel.showTechnicalInfo = !viewModel.showTechnicalInfo }
+            )
+        }
+    }
+}
+
+@Composable
+private fun TvMenuRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ListItem(
+        selected = selected,
+        onClick = onClick,
+        headlineContent = {
+            Text(
+                text = label,
+                fontSize = 17.sp,
+                fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium
+            )
+        },
+        trailingContent = if (selected) {
+            {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        } else null,
+        colors = ListItemDefaults.colors(
+            containerColor = Color(0xFF222222),
+            focusedContainerColor = Color.White,
+            contentColor = Color.White,
+            focusedContentColor = Color.Black
+        ),
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun TvSubmenuRow(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ListItem(
+        selected = false,
+        onClick = onClick,
+        headlineContent = {
+            Text(
+                text = label,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Medium
+            )
+        },
+        trailingContent = {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForwardIos,
+                contentDescription = null,
+                tint = Color.White.copy(alpha = 0.5f),
+                modifier = Modifier.size(16.dp)
+            )
+        },
+        colors = ListItemDefaults.colors(
+            containerColor = Color(0xFF222222),
+            focusedContainerColor = Color.White,
+            contentColor = Color.White,
+            focusedContentColor = Color.Black
+        ),
+        modifier = modifier
+    )
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvMetrics.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvMetrics.kt
@@ -1,15 +1,75 @@
 package expo.modules.mpvplayer.nativeplayer.ui.tv
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
+
+/**
+ * The chrome's shared palette. Every floating surface uses the same glass
+ * recipe (translucent fill + hairline + sheen, see Modifier.tvGlass) and
+ * every piece of content the same white ramp — per-component grays are what
+ * made the chrome read as flat, mismatched stickers.
+ */
+object TvPalette {
+    /** Fill for surfaces over video — translucent so the film bleeds through. */
+    val SurfaceGlass = Color.Black.copy(alpha = 0.52f)
+
+    /** Fill for surfaces that need text legibility (menus, cards, pills). */
+    val SurfaceGlassStrong = Color.Black.copy(alpha = 0.72f)
+
+    /** 1dp edge catch-light on every glass surface. */
+    val Hairline = Color.White.copy(alpha = 0.14f)
+
+    /** Top of the faux top-light gradient on larger surfaces. */
+    val SheenTop = Color.White.copy(alpha = 0.09f)
+
+    val OnSurface = Color.White
+    val OnSurfaceDim = Color.White.copy(alpha = 0.65f)
+    val OnSurfaceFaint = Color.White.copy(alpha = 0.40f)
+
+    /** Focus is always white fill with black content. */
+    val FocusFill = Color.White
+    val OnFocus = Color.Black
+
+    /** Unfocused row/chip fill when already sitting on a glass panel. */
+    val RowFill = Color.White.copy(alpha = 0.07f)
+}
+
+/**
+ * The one surface treatment for everything floating over video: translucent
+ * fill, faint top sheen, hairline edge. Apply through this modifier only, so
+ * the look cannot drift per component.
+ */
+fun Modifier.tvGlass(
+    shape: Shape,
+    strong: Boolean = false,
+    sheen: Boolean = true
+): Modifier {
+    val base = this
+        .clip(shape)
+        .background(if (strong) TvPalette.SurfaceGlassStrong else TvPalette.SurfaceGlass)
+    val lit = if (sheen) {
+        base.background(
+            Brush.verticalGradient(
+                0f to TvPalette.SheenTop,
+                0.45f to Color.Transparent
+            )
+        )
+    } else {
+        base
+    }
+    return lit.border(1.dp, TvPalette.Hairline, shape)
+}
 
 object TvMetrics {
     val INSET_H = 48.dp
@@ -19,6 +79,11 @@ object TvMetrics {
     val POSTER_WIDTH = 300.dp
     val POSTER_HEIGHT = 168.dp
     val POSTER_CORNER = 12.dp
+
+    /** One diameter for every round control, one glyph size inside it. */
+    val CONTROL_SIZE = 48.dp
+    val ICON_SIZE = 22.dp
+    val RADIUS_PANEL = 18.dp
 
     val SCRIM_HEIGHT = 110.dp
     val TEXT_INSET_H = 14.dp

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvMetrics.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvMetrics.kt
@@ -1,0 +1,44 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+object TvMetrics {
+    val INSET_H = 48.dp
+    val INSET_V = 27.dp
+    val FLOATING_BOTTOM_INSET = 47.dp
+
+    val POSTER_WIDTH = 300.dp
+    val POSTER_HEIGHT = 168.dp
+    val POSTER_CORNER = 12.dp
+
+    val SCRIM_HEIGHT = 110.dp
+    val TEXT_INSET_H = 14.dp
+    val TEXT_INSET_V = 12.dp
+}
+
+@Composable
+fun TvPosterScrim(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(TvMetrics.SCRIM_HEIGHT)
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(
+                        Color.Black.copy(alpha = 0f),
+                        Color.Black.copy(alpha = 0.55f),
+                        Color.Black.copy(alpha = 0.85f)
+                    )
+                )
+            )
+    )
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvPlayerScreen.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvPlayerScreen.kt
@@ -1,0 +1,199 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Text
+import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
+import expo.modules.mpvplayer.nativeplayer.TvFocusZone
+import expo.modules.mpvplayer.nativeplayer.deriveTvFocusZone
+
+@Composable
+fun TvPlayerScreen(
+    viewModel: PlayerViewModel,
+    onZoneChanged: (TvFocusZone) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val currentZone by remember(viewModel) {
+        derivedStateOf { deriveTvFocusZone(viewModel) }
+    }
+
+    LaunchedEffect(currentZone) {
+        onZoneChanged(currentZone)
+    }
+
+    var lastFocusedControl by remember { mutableStateOf<TvControl?>(TvControl.PLAY_PAUSE) }
+
+    val showChrome = viewModel.controlsVisible || viewModel.isScrubbing || viewModel.seekFeedbackVisible
+    val isModalOpen = viewModel.tvMenuRoute.isNotEmpty() ||
+            viewModel.showEpisodeList ||
+            viewModel.showSubtitleSearch ||
+            viewModel.showStillWatching ||
+            viewModel.showExitConfirmation
+
+    Box(modifier = modifier.fillMaxSize()) {
+        // --- 1. Scrims & Chrome Layer ---
+        AnimatedVisibility(
+            visible = showChrome && !isModalOpen,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                // Top & Bottom gradient scrims
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(240.dp)
+                            .background(
+                                Brush.verticalGradient(
+                                    colors = listOf(
+                                        Color.Black.copy(alpha = 0.55f),
+                                        Color.Black.copy(alpha = 0f)
+                                    )
+                                )
+                            )
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(280.dp)
+                            .background(
+                                Brush.verticalGradient(
+                                    colors = listOf(
+                                        Color.Black.copy(alpha = 0f),
+                                        Color.Black.copy(alpha = 0.55f)
+                                    )
+                                )
+                            )
+                    )
+                }
+
+                // Chrome content
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(
+                            horizontal = TvMetrics.INSET_H,
+                            vertical = TvMetrics.INSET_V
+                        ),
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    // Top: Metadata Header
+                    TvMetadataHeader(viewModel = viewModel)
+
+                    // Bottom: Controls Row + Transport Bar
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        if (viewModel.controlsVisible && !viewModel.isScrubbing) {
+                            TvControlsRow(
+                                viewModel = viewModel,
+                                lastFocused = lastFocusedControl,
+                                onControlFocused = { lastFocusedControl = it }
+                            )
+                        }
+
+                        TvTransportBar(viewModel = viewModel)
+                    }
+                }
+            }
+        }
+
+        // --- 2. Status Overlays Layer ---
+        TvStatusOverlays(viewModel = viewModel)
+
+        // --- 3. Menu Panel Drawer Layer ---
+        if (viewModel.tvMenuRoute.isNotEmpty()) {
+            TvMenuPanel(viewModel = viewModel)
+        }
+
+        // --- 4. Episode Shelf Layer ---
+        if (viewModel.showEpisodeList) {
+            TvEpisodeShelf(
+                viewModel = viewModel,
+                modifier = Modifier.align(Alignment.BottomCenter)
+            )
+        }
+
+        // --- 5. Subtitle Search Panel Layer ---
+        if (viewModel.showSubtitleSearch) {
+            TvSubtitleSearchPanel(viewModel = viewModel)
+        }
+
+        // --- 6. Still Watching Overlay Layer ---
+        if (viewModel.showStillWatching) {
+            TvStillWatchingOverlay(viewModel = viewModel)
+        }
+
+        // --- 7. Exit Confirmation Overlay Layer ---
+        if (viewModel.showExitConfirmation) {
+            TvExitConfirmation(viewModel = viewModel)
+        }
+
+        // --- 8. Error Overlay Layer ---
+        if (viewModel.errorMessage != null) {
+            TvErrorOverlay(viewModel = viewModel)
+        }
+    }
+}
+
+@Composable
+private fun TvMetadataHeader(
+    viewModel: PlayerViewModel,
+    modifier: Modifier = Modifier
+) {
+    val meta = viewModel.metadata ?: return
+
+    Column(
+        modifier = modifier.fillMaxWidth(0.7f),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        if (!meta.title.isNullOrBlank()) {
+            Text(
+                text = meta.title ?: "",
+                color = Color.White,
+                fontSize = 26.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        if (!meta.subtitle.isNullOrBlank()) {
+            Text(
+                text = meta.subtitle ?: "",
+                color = Color.White.copy(alpha = 0.7f),
+                fontSize = 18.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvStatusOverlays.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvStatusOverlays.kt
@@ -66,7 +66,12 @@ fun TvStatusOverlays(
             ) {
                 TechnicalInfoOverlay(
                     viewModel = viewModel,
-                    onDismiss = { viewModel.showTechnicalInfo = false }
+                    onDismiss = {
+                        viewModel.showTechnicalInfo = false
+                        // The close button had focus; restore it to the
+                        // controls row or the remote goes dead.
+                        viewModel.restoreTvControlsFocus()
+                    }
                 )
             }
         }

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvStatusOverlays.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvStatusOverlays.kt
@@ -1,0 +1,190 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Text
+import expo.modules.mpvplayer.nativeplayer.MediaSegmentRecord
+import expo.modules.mpvplayer.nativeplayer.NextEpisodeRecord
+import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
+import expo.modules.mpvplayer.nativeplayer.ui.RemoteImage
+import expo.modules.mpvplayer.nativeplayer.ui.TechnicalInfoOverlay
+
+@Composable
+fun TvStatusOverlays(
+    viewModel: PlayerViewModel,
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        // 1. Buffering Spinner
+        if (viewModel.isBuffering && viewModel.errorMessage == null) {
+            CircularProgressIndicator(
+                color = Color.White,
+                strokeWidth = 4.dp,
+                modifier = Modifier
+                    .size(56.dp)
+                    .align(Alignment.Center)
+            )
+        }
+
+        // 2. Technical Info Overlay (top-left, scaled 1.5x)
+        if (viewModel.showTechnicalInfo) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(start = TvMetrics.INSET_H, top = TvMetrics.INSET_V)
+                    .graphicsLayer(
+                        scaleX = 1.5f,
+                        scaleY = 1.5f,
+                        transformOrigin = TransformOrigin(0f, 0f)
+                    )
+            ) {
+                TechnicalInfoOverlay(
+                    viewModel = viewModel,
+                    onDismiss = { viewModel.showTechnicalInfo = false }
+                )
+            }
+        }
+
+        // 3. Skip Pill / Next Episode Countdown (bottom-right when chrome hidden)
+        val showFloatingPrompt = !viewModel.controlsVisible &&
+                !viewModel.showEpisodeList &&
+                !viewModel.showSubtitleSearch &&
+                viewModel.tvMenuRoute.isEmpty() &&
+                !viewModel.showStillWatching &&
+                !viewModel.showExitConfirmation
+
+        AnimatedVisibility(
+            visible = showFloatingPrompt,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = TvMetrics.INSET_H, bottom = TvMetrics.FLOATING_BOTTOM_INSET)
+        ) {
+            val countdown = viewModel.countdownRemaining
+            val next = viewModel.nextEpisode
+            val segment = viewModel.activeSegment
+
+            if (countdown != null && next != null) {
+                TvCountdownCard(
+                    viewModel = viewModel,
+                    next = next,
+                    remaining = countdown
+                )
+            } else if (segment != null && !viewModel.isScrubbing) {
+                TvSkipPill(
+                    viewModel = viewModel,
+                    segment = segment
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun TvSkipPill(
+    viewModel: PlayerViewModel,
+    segment: MediaSegmentRecord,
+    modifier: Modifier = Modifier
+) {
+    val text = if (segment.type == "Intro") {
+        viewModel.str("skipIntro", "Skip Intro")
+    } else {
+        viewModel.str("skipCredits", "Skip Credits")
+    }
+
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(Color(0xFF242424).copy(alpha = 0.92f))
+            .padding(horizontal = 26.dp, vertical = 12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            color = Color.White,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+@Composable
+fun TvCountdownCard(
+    viewModel: PlayerViewModel,
+    next: NextEpisodeRecord,
+    remaining: Double,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .widthIn(max = 580.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(Color(0xFF1E1E1E).copy(alpha = 0.94f))
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (!next.imageUrl.isNullOrBlank()) {
+            RemoteImage(
+                url = next.imageUrl,
+                modifier = Modifier
+                    .size(width = 168.dp, height = 94.dp)
+                    .clip(RoundedCornerShape(10.dp))
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+        }
+
+        Column(modifier = Modifier.weight(1f, fill = false)) {
+            Text(
+                text = "${viewModel.str("nextEpisode", "Next episode")} · ${remaining.toInt()}s",
+                color = Color.White.copy(alpha = 0.7f),
+                fontSize = 14.sp
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = next.title,
+                color = Color.White,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (!next.subtitle.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = next.subtitle ?: "",
+                    color = Color.White.copy(alpha = 0.7f),
+                    fontSize = 14.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvStatusOverlays.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvStatusOverlays.kt
@@ -44,7 +44,7 @@ fun TvStatusOverlays(
         // 1. Buffering Spinner
         if (viewModel.isBuffering && viewModel.errorMessage == null) {
             CircularProgressIndicator(
-                color = Color.White,
+                color = TvPalette.OnSurface,
                 strokeWidth = 4.dp,
                 modifier = Modifier
                     .size(56.dp)
@@ -126,14 +126,13 @@ fun TvSkipPill(
 
     Box(
         modifier = modifier
-            .clip(CircleShape)
-            .background(Color(0xFF242424).copy(alpha = 0.92f))
+            .tvGlass(CircleShape, strong = true)
             .padding(horizontal = 26.dp, vertical = 12.dp),
         contentAlignment = Alignment.Center
     ) {
         Text(
             text = text,
-            color = Color.White,
+            color = TvPalette.OnSurface,
             fontSize = 18.sp,
             fontWeight = FontWeight.SemiBold
         )
@@ -150,8 +149,7 @@ fun TvCountdownCard(
     Row(
         modifier = modifier
             .widthIn(max = 580.dp)
-            .clip(RoundedCornerShape(18.dp))
-            .background(Color(0xFF1E1E1E).copy(alpha = 0.94f))
+            .tvGlass(RoundedCornerShape(TvMetrics.RADIUS_PANEL), strong = true)
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -168,13 +166,13 @@ fun TvCountdownCard(
         Column(modifier = Modifier.weight(1f, fill = false)) {
             Text(
                 text = "${viewModel.str("nextEpisode", "Next episode")} · ${remaining.toInt()}s",
-                color = Color.White.copy(alpha = 0.7f),
+                color = TvPalette.OnSurfaceDim,
                 fontSize = 14.sp
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = next.title,
-                color = Color.White,
+                color = TvPalette.OnSurface,
                 fontSize = 18.sp,
                 fontWeight = FontWeight.SemiBold,
                 maxLines = 1,
@@ -184,7 +182,7 @@ fun TvCountdownCard(
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = next.subtitle ?: "",
-                    color = Color.White.copy(alpha = 0.7f),
+                    color = TvPalette.OnSurfaceDim,
                     fontSize = 14.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvStillWatchingOverlay.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvStillWatchingOverlay.kt
@@ -1,0 +1,96 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Button
+import androidx.tv.material3.Text
+import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
+
+@Composable
+fun TvStillWatchingOverlay(
+    viewModel: PlayerViewModel,
+    modifier: Modifier = Modifier
+) {
+    val continueFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        continueFocusRequester.requestFocus()
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.75f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .widthIn(max = 560.dp)
+                .clip(RoundedCornerShape(24.dp))
+                .background(Color(0xFF1E1E1E))
+                .padding(36.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = viewModel.str("stillWatching", "Are you still watching?"),
+                color = Color.White,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Button(
+                    onClick = { viewModel.continueWatchingFromStillWatching() },
+                    modifier = Modifier.focusRequester(continueFocusRequester)
+                ) {
+                    Text(
+                        text = viewModel.str("continueWatching", "Continue watching"),
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+
+                Button(
+                    onClick = {
+                        viewModel.showStillWatching = false
+                        viewModel.close()
+                    }
+                ) {
+                    Text(
+                        text = viewModel.str("goBack", "Go back"),
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+        }
+    }
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvSubtitleSearchPanel.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvSubtitleSearchPanel.kt
@@ -46,6 +46,7 @@ import androidx.tv.material3.Button
 import androidx.tv.material3.ButtonDefaults
 import androidx.tv.material3.ListItem
 import androidx.tv.material3.ListItemDefaults
+import androidx.tv.material3.LocalContentColor
 import androidx.tv.material3.Text
 import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
 import expo.modules.mpvplayer.nativeplayer.SubtitleSearchResultRecord
@@ -162,18 +163,20 @@ fun TvSubtitleSearchPanel(
                             },
                             trailingContent = if (isSelected) {
                                 {
+                                    // Follows the row's focus state: white on
+                                    // the dark row, black on the focused one.
                                     Icon(
                                         imageVector = Icons.Filled.Check,
                                         contentDescription = null,
-                                        tint = Color.White
+                                        tint = LocalContentColor.current
                                     )
                                 }
                             } else null,
                             colors = ListItemDefaults.colors(
-                                containerColor = Color(0xFF262626),
-                                focusedContainerColor = Color.White,
-                                contentColor = Color.White,
-                                focusedContentColor = Color.Black
+                                containerColor = TvPalette.RowFill,
+                                focusedContainerColor = TvPalette.FocusFill,
+                                contentColor = TvPalette.OnSurface,
+                                focusedContentColor = TvPalette.OnFocus
                             ),
                             modifier = if (index == 0) Modifier.focusRequester(itemFocusRequester) else Modifier
                         )
@@ -278,6 +281,10 @@ private fun TvSubtitleResultRow(
             )
         },
         supportingContent = {
+            // Everything here derives from LocalContentColor — the ListItem
+            // swaps it white↔black with focus, and hardcoded whites vanish
+            // against the focused row's white fill.
+            val content = LocalContentColor.current
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -287,14 +294,14 @@ private fun TvSubtitleResultRow(
                 Box(
                     modifier = Modifier
                         .clip(RoundedCornerShape(4.dp))
-                        .background(Color.White.copy(alpha = 0.15f))
+                        .background(content.copy(alpha = 0.15f))
                         .padding(horizontal = 6.dp, vertical = 2.dp)
                 ) {
                     Text(
                         text = result.providerName,
                         fontSize = 12.sp,
                         fontWeight = FontWeight.Bold,
-                        color = Color.White
+                        color = content
                     )
                 }
 
@@ -302,7 +309,7 @@ private fun TvSubtitleResultRow(
                     Text(
                         text = (result.format ?: "").uppercase(),
                         fontSize = 13.sp,
-                        color = Color.White.copy(alpha = 0.7f)
+                        color = content.copy(alpha = 0.7f)
                     )
                 }
 
@@ -319,7 +326,7 @@ private fun TvSubtitleResultRow(
                         Text(
                             text = String.format("%.1f", rating),
                             fontSize = 13.sp,
-                            color = Color.White.copy(alpha = 0.7f)
+                            color = content.copy(alpha = 0.7f)
                         )
                     }
                 }
@@ -328,7 +335,7 @@ private fun TvSubtitleResultRow(
                     Icon(
                         imageVector = Icons.Filled.Hearing,
                         contentDescription = "SDH",
-                        tint = Color.White.copy(alpha = 0.7f),
+                        tint = content.copy(alpha = 0.7f),
                         modifier = Modifier.size(14.dp)
                     )
                 }
@@ -338,7 +345,7 @@ private fun TvSubtitleResultRow(
                         text = "AI",
                         fontSize = 12.sp,
                         fontWeight = FontWeight.Bold,
-                        color = Color.White.copy(alpha = 0.7f)
+                        color = content.copy(alpha = 0.7f)
                     )
                 }
             }
@@ -346,7 +353,7 @@ private fun TvSubtitleResultRow(
         trailingContent = {
             if (isDownloading) {
                 CircularProgressIndicator(
-                    color = Color.White,
+                    color = LocalContentColor.current,
                     strokeWidth = 2.dp,
                     modifier = Modifier.size(22.dp)
                 )
@@ -360,10 +367,10 @@ private fun TvSubtitleResultRow(
             }
         },
         colors = ListItemDefaults.colors(
-            containerColor = Color(0xFF242424),
-            focusedContainerColor = Color.White,
-            contentColor = Color.White,
-            focusedContentColor = Color.Black
+            containerColor = TvPalette.RowFill,
+            focusedContainerColor = TvPalette.FocusFill,
+            contentColor = TvPalette.OnSurface,
+            focusedContentColor = TvPalette.OnFocus
         ),
         modifier = modifier
     )

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvSubtitleSearchPanel.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvSubtitleSearchPanel.kt
@@ -1,0 +1,370 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Hearing
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
+import androidx.tv.material3.ListItem
+import androidx.tv.material3.ListItemDefaults
+import androidx.tv.material3.Text
+import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
+import expo.modules.mpvplayer.nativeplayer.SubtitleSearchResultRecord
+
+@Composable
+fun TvSubtitleSearchPanel(
+    viewModel: PlayerViewModel,
+    modifier: Modifier = Modifier
+) {
+    val langFocusRequester = remember { FocusRequester() }
+    val firstResultFocusRequester = remember { FocusRequester() }
+    var showLanguagePicker by remember { mutableStateOf(false) }
+
+    val results = viewModel.subtitleSearchResults
+    val status = viewModel.subtitleSearchStatus
+
+    LaunchedEffect(results.size) {
+        if (results.isNotEmpty()) {
+            try {
+                firstResultFocusRequester.requestFocus()
+            } catch (_: Exception) {}
+        } else if (!showLanguagePicker) {
+            try {
+                langFocusRequester.requestFocus()
+            } catch (_: Exception) {}
+        }
+    }
+
+    val currentLangName = remember(viewModel.subtitleSearchLanguage, viewModel.uiOptions.subtitleSearchLanguages) {
+        viewModel.uiOptions.subtitleSearchLanguages.firstOrNull { it.code == viewModel.subtitleSearchLanguage }?.name
+            ?: viewModel.subtitleSearchLanguage.uppercase()
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.7f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .size(width = 960.dp, height = 640.dp)
+                .clip(RoundedCornerShape(24.dp))
+                .background(Color(0xFF1A1A1A))
+                .padding(32.dp)
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = viewModel.str("searchSubtitles", "Search Subtitles"),
+                    color = Color.White,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Button(
+                    onClick = { showLanguagePicker = !showLanguagePicker },
+                    modifier = Modifier.focusRequester(langFocusRequester)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Language,
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Text(
+                            text = currentLangName,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // Body
+            if (showLanguagePicker) {
+                // Language selection list
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(vertical = 8.dp)
+                ) {
+                    itemsIndexed(viewModel.uiOptions.subtitleSearchLanguages) { index, lang ->
+                        val isSelected = lang.code == viewModel.subtitleSearchLanguage
+                        val itemFocusRequester = remember { FocusRequester() }
+                        if (index == 0) {
+                            LaunchedEffect(Unit) {
+                                try { itemFocusRequester.requestFocus() } catch (_: Exception) {}
+                            }
+                        }
+
+                        ListItem(
+                            selected = isSelected,
+                            onClick = {
+                                showLanguagePicker = false
+                                viewModel.searchSubtitles(lang.code)
+                            },
+                            headlineContent = {
+                                Text(
+                                    text = lang.name,
+                                    fontSize = 18.sp,
+                                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
+                                )
+                            },
+                            trailingContent = if (isSelected) {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Filled.Check,
+                                        contentDescription = null,
+                                        tint = Color.White
+                                    )
+                                }
+                            } else null,
+                            colors = ListItemDefaults.colors(
+                                containerColor = Color(0xFF262626),
+                                focusedContainerColor = Color.White,
+                                contentColor = Color.White,
+                                focusedContentColor = Color.Black
+                            ),
+                            modifier = if (index == 0) Modifier.focusRequester(itemFocusRequester) else Modifier
+                        )
+                    }
+                }
+            } else {
+                when (status) {
+                    "searching" -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(color = Color.White)
+                        }
+                    }
+                    "error" -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Icon(
+                                    imageVector = Icons.Filled.Warning,
+                                    contentDescription = null,
+                                    tint = Color(0xFFFFCC00),
+                                    modifier = Modifier.size(48.dp)
+                                )
+                                Spacer(modifier = Modifier.height(12.dp))
+                                Text(
+                                    text = viewModel.str("searchFailed", "Search failed"),
+                                    color = Color.White,
+                                    fontSize = 20.sp,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                                if (!viewModel.subtitleSearchError.isNullOrBlank()) {
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    Text(
+                                        text = viewModel.subtitleSearchError ?: "",
+                                        color = Color.White.copy(alpha = 0.7f),
+                                        fontSize = 15.sp,
+                                        textAlign = TextAlign.Center
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    else -> {
+                        if (results.isEmpty()) {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = viewModel.str("noSubtitlesFound", "No subtitles found"),
+                                    color = Color.White.copy(alpha = 0.7f),
+                                    fontSize = 18.sp
+                                )
+                            }
+                        } else {
+                            LazyColumn(
+                                modifier = Modifier.fillMaxSize(),
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                                contentPadding = PaddingValues(vertical = 8.dp)
+                            ) {
+                                itemsIndexed(results, key = { _, item -> item.id }) { index, result ->
+                                    TvSubtitleResultRow(
+                                        result = result,
+                                        isDownloading = viewModel.downloadingResultId == result.id,
+                                        downloadDisabled = viewModel.downloadingResultId != null,
+                                        onClick = { viewModel.downloadSubtitle(result.id) },
+                                        modifier = if (index == 0) Modifier.focusRequester(firstResultFocusRequester) else Modifier
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TvSubtitleResultRow(
+    result: SubtitleSearchResultRecord,
+    isDownloading: Boolean,
+    downloadDisabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ListItem(
+        selected = false,
+        onClick = onClick,
+        enabled = !downloadDisabled,
+        headlineContent = {
+            Text(
+                text = result.name,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        supportingContent = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                modifier = Modifier.padding(top = 4.dp)
+            ) {
+                // Provider Badge
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(Color.White.copy(alpha = 0.15f))
+                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                ) {
+                    Text(
+                        text = result.providerName,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                }
+
+                if (!result.format.isNullOrBlank()) {
+                    Text(
+                        text = (result.format ?: "").uppercase(),
+                        fontSize = 13.sp,
+                        color = Color.White.copy(alpha = 0.7f)
+                    )
+                }
+
+                val rating = result.communityRating
+                if (rating != null && rating > 0) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = Color(0xFFFFCC00),
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(2.dp))
+                        Text(
+                            text = String.format("%.1f", rating),
+                            fontSize = 13.sp,
+                            color = Color.White.copy(alpha = 0.7f)
+                        )
+                    }
+                }
+
+                if (result.hearingImpaired) {
+                    Icon(
+                        imageVector = Icons.Filled.Hearing,
+                        contentDescription = "SDH",
+                        tint = Color.White.copy(alpha = 0.7f),
+                        modifier = Modifier.size(14.dp)
+                    )
+                }
+
+                if (result.aiTranslated) {
+                    Text(
+                        text = "AI",
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White.copy(alpha = 0.7f)
+                    )
+                }
+            }
+        },
+        trailingContent = {
+            if (isDownloading) {
+                CircularProgressIndicator(
+                    color = Color.White,
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(22.dp)
+                )
+            } else if (result.isHashMatch) {
+                Icon(
+                    imageVector = Icons.Filled.CheckCircle,
+                    contentDescription = "Match",
+                    tint = Color(0xFF4CAF50),
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+        },
+        colors = ListItemDefaults.colors(
+            containerColor = Color(0xFF242424),
+            focusedContainerColor = Color.White,
+            contentColor = Color.White,
+            focusedContentColor = Color.Black
+        ),
+        modifier = modifier
+    )
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvTransportBar.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvTransportBar.kt
@@ -1,0 +1,325 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import android.view.KeyEvent
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Border
+import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.tv.material3.Surface
+import androidx.tv.material3.SurfaceDefaults
+import androidx.tv.material3.Text
+import expo.modules.mpvplayer.nativeplayer.PlayerViewModel
+import expo.modules.mpvplayer.nativeplayer.ui.formatTimeSec
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+@Composable
+fun TvTransportBar(
+    viewModel: PlayerViewModel,
+    modifier: Modifier = Modifier
+) {
+    val isScrubbing = viewModel.isScrubbing
+    val position = if (isScrubbing) viewModel.scrubPosition else viewModel.displayPosition
+    val duration = viewModel.duration
+    val remaining = max(0.0, duration - position)
+    var isBarFocused by remember { mutableStateOf(false) }
+
+    val trackHeight by animateDpAsState(
+        targetValue = if (isScrubbing || isBarFocused) 14.dp else 10.dp,
+        label = "trackHeight"
+    )
+
+    val isFocusable = viewModel.controlsVisible &&
+            !isScrubbing &&
+            !viewModel.showEpisodeList &&
+            !viewModel.showStillWatching &&
+            !viewModel.showExitConfirmation &&
+            viewModel.tvMenuRoute.isEmpty()
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        // 1. Focusable Progress Bar Row. The tv-material3 Surface clips its
+        // children to the focus shape (graphicsLayer clip + Offscreen
+        // compositing), so the floating trickplay card renders as a sibling
+        // of the Surface in this wrapper instead of inside it.
+        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+            val barWidthPx = constraints.maxWidth.toFloat()
+
+            Surface(
+                onClick = {
+                    if (viewModel.controlsVisible && !isScrubbing) {
+                        viewModel.togglePlayPause()
+                    }
+                },
+                enabled = isFocusable,
+                shape = ClickableSurfaceDefaults.shape(shape = RoundedCornerShape(8.dp)),
+                colors = ClickableSurfaceDefaults.colors(
+                    containerColor = Color.Transparent,
+                    focusedContainerColor = Color.Transparent
+                ),
+                border = ClickableSurfaceDefaults.border(
+                    focusedBorder = Border(
+                        border = androidx.compose.foundation.BorderStroke(2.dp, Color.White.copy(alpha = 0.4f)),
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onFocusChanged {
+                        isBarFocused = it.isFocused
+                        if (it.isFocused) {
+                            viewModel.scheduleAutoHide()
+                        }
+                    }
+                    .onPreviewKeyEvent { keyEvent ->
+                        if (keyEvent.nativeKeyEvent.action == KeyEvent.ACTION_DOWN) {
+                            when (keyEvent.nativeKeyEvent.keyCode) {
+                                KeyEvent.KEYCODE_DPAD_LEFT -> {
+                                    if (viewModel.controlsVisible && !isScrubbing) {
+                                        if (viewModel.isReadyToSeek && duration > 0 && viewModel.errorMessage == null) {
+                                            viewModel.beginScrub()
+                                            viewModel.nudgeScrub(-viewModel.uiOptions.seekBackwardSec)
+                                            return@onPreviewKeyEvent true
+                                        }
+                                    }
+                                }
+                                KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                                    if (viewModel.controlsVisible && !isScrubbing) {
+                                        if (viewModel.isReadyToSeek && duration > 0 && viewModel.errorMessage == null) {
+                                            viewModel.beginScrub()
+                                            viewModel.nudgeScrub(viewModel.uiOptions.seekForwardSec)
+                                            return@onPreviewKeyEvent true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        false
+                    }
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 6.dp, horizontal = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    // Play/Pause/Scrub Glyph
+                    val glyph = when {
+                        isScrubbing -> Icons.Filled.FastRewind
+                        viewModel.isPlaying -> Icons.Filled.PlayArrow
+                        else -> Icons.Filled.Pause
+                    }
+                    Icon(
+                        imageVector = glyph,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(24.dp)
+                    )
+
+                    // Track and Chapter Ticks
+                    BoxWithConstraints(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(trackHeight)
+                    ) {
+                        val trackWidthPx = constraints.maxWidth.toFloat()
+                        val playedFraction = if (duration > 0) (position / duration).coerceIn(0.0, 1.0).toFloat() else 0f
+                        val bufferedFraction = if (duration > 0) {
+                            ((viewModel.displayPosition + viewModel.cacheSeconds) / duration).coerceIn(0.0, 1.0).toFloat()
+                        } else 0f
+
+                        // Background track
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(trackHeight)
+                                .clip(CircleShape)
+                                .background(Color.White.copy(alpha = 0.25f))
+                        ) {
+                            // Buffered track
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth(bufferedFraction)
+                                    .height(trackHeight)
+                                    .clip(CircleShape)
+                                    .background(Color.White.copy(alpha = 0.45f))
+                            )
+
+                            // Played track
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth(playedFraction)
+                                    .height(trackHeight)
+                                    .clip(CircleShape)
+                                    .background(Color.White)
+                            )
+
+                            // Chapter tick marks
+                            if (duration > 0) {
+                                viewModel.chapters.forEach { chapter ->
+                                    if (chapter.startSec > 0) {
+                                        val tickFraction = (chapter.startSec / duration).coerceIn(0.0, 1.0).toFloat()
+                                        val tickOffsetPx = (trackWidthPx * tickFraction) - 1.5f
+                                        Box(
+                                            modifier = Modifier
+                                                .offset { IntOffset(tickOffsetPx.roundToInt(), 0) }
+                                                .width(3.dp)
+                                                .height(trackHeight)
+                                                .background(Color.Black.copy(alpha = 0.6f))
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
+                    }
+                }
+            }
+
+            // Floating trickplay card above the scrub position. Also shown
+            // during the seek-feedback flash (hidden-chrome left/right skips),
+            // where `position` is the freshly sought displayPosition.
+            if (
+                (isScrubbing || viewModel.seekFeedbackVisible) &&
+                viewModel.trickplay?.isAvailable == true
+            ) {
+                val density = LocalDensity.current
+                // Track geometry inside the Surface row: 4.dp row padding +
+                // 24.dp glyph + 16.dp spacing to the left of the track, 4.dp
+                // to its right (the time-labels row hardcodes the same 44.dp).
+                val trackStartPx = with(density) { 44.dp.toPx() }
+                val trackEndPx = barWidthPx - with(density) { 4.dp.toPx() }
+                val trackSpanPx = max(0f, trackEndPx - trackStartPx)
+                val cardWidthPx = with(density) { TvMetrics.POSTER_WIDTH.toPx() }
+                val playedFraction =
+                    if (duration > 0) (position / duration).coerceIn(0.0, 1.0).toFloat() else 0f
+                val thumbCenterPx = trackStartPx + trackSpanPx * playedFraction
+                val cardLeftPx = (thumbCenterPx - cardWidthPx / 2f)
+                    .coerceIn(trackStartPx, max(trackStartPx, trackEndPx - cardWidthPx))
+
+                // Measure the card unconstrained but report zero size — the
+                // floating card must never inflate the bar's own layout box,
+                // or the whole bar jumps up by the poster height on scrub.
+                Box(
+                    modifier = Modifier.layout { measurable, _ ->
+                        val placeable = measurable.measure(Constraints())
+                        val cardTopPx = -(TvMetrics.POSTER_HEIGHT + 32.dp).roundToPx()
+                        layout(0, 0) {
+                            placeable.place(cardLeftPx.roundToInt(), cardTopPx)
+                        }
+                    }
+                ) {
+                    TvTrickplayCard(
+                        provider = viewModel.trickplay!!,
+                        positionSec = position
+                    )
+                }
+            }
+        }
+
+        // 2. Time Labels Row (Elapsed + Chapter name left, Remaining + Ends at right)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 44.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top
+        ) {
+            // Left: Elapsed time + chapter name
+            Column(horizontalAlignment = Alignment.Start) {
+                Text(
+                    text = formatTimeSec(position),
+                    color = Color.White.copy(alpha = 0.9f),
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Medium,
+                    fontFamily = FontFamily.Monospace
+                )
+
+                val chName = viewModel.chapterName(position)
+                if (!chName.isNullOrBlank()) {
+                    Text(
+                        text = chName,
+                        color = Color.White.copy(alpha = 0.55f),
+                        fontSize = 16.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            // Right: -Remaining time + Ends at HH:mm
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = "-${formatTimeSec(remaining)}",
+                    color = Color.White.copy(alpha = 0.9f),
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Medium,
+                    fontFamily = FontFamily.Monospace
+                )
+
+                if (duration > 0) {
+                    val endsAtText = endsAtLabel(viewModel, remaining)
+                    Text(
+                        text = endsAtText,
+                        color = Color.White.copy(alpha = 0.55f),
+                        fontSize = 16.sp,
+                        fontFamily = FontFamily.Monospace
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun endsAtLabel(viewModel: PlayerViewModel, remainingSec: Double): String {
+    val endsAtMillis = System.currentTimeMillis() + (remainingSec * 1000).toLong()
+    val sdf = SimpleDateFormat("HH:mm", Locale.getDefault())
+    val timeFormatted = sdf.format(Date(endsAtMillis))
+    return viewModel.strings.formatEndsAt(timeFormatted)
+}

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvTransportBar.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvTransportBar.kt
@@ -98,6 +98,15 @@ fun TvTransportBar(
                 },
                 enabled = isFocusable,
                 shape = ClickableSurfaceDefaults.shape(shape = RoundedCornerShape(8.dp)),
+                // No focus zoom: the default focusedScale of 1.1 makes the
+                // whole bar rescale when scrubbing starts (focus is evicted
+                // as the Surface disables). Focus is shown by border + track
+                // thickness instead.
+                scale = ClickableSurfaceDefaults.scale(
+                    scale = 1f,
+                    focusedScale = 1f,
+                    pressedScale = 1f
+                ),
                 colors = ClickableSurfaceDefaults.colors(
                     containerColor = Color.Transparent,
                     focusedContainerColor = Color.Transparent

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvTrickplayCard.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvTrickplayCard.kt
@@ -3,6 +3,7 @@ package expo.modules.mpvplayer.nativeplayer.ui.tv
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -44,11 +45,12 @@ fun TvTrickplayCard(
         }
     }
 
+    val shape = RoundedCornerShape(TvMetrics.RADIUS_PANEL)
     Box(
         modifier = modifier
             .size(TvMetrics.POSTER_WIDTH, TvMetrics.POSTER_HEIGHT)
-            .clip(RoundedCornerShape(18.dp))
-            .background(Color.Black.copy(alpha = 0.6f)),
+            .clip(shape)
+            .background(TvPalette.SurfaceGlassStrong),
         contentAlignment = Alignment.BottomStart
     ) {
         val bmp = imageBitmap
@@ -62,6 +64,13 @@ fun TvTrickplayCard(
         }
 
         TvPosterScrim(modifier = Modifier.align(Alignment.BottomCenter))
+
+        // Hairline drawn over the thumbnail so the edge catch-light survives.
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .border(1.dp, TvPalette.Hairline, shape)
+        )
 
         Text(
             text = formatTimeSec(positionSec),

--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvTrickplayCard.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/nativeplayer/ui/tv/TvTrickplayCard.kt
@@ -1,0 +1,78 @@
+package expo.modules.mpvplayer.nativeplayer.ui.tv
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.tv.material3.Text
+import expo.modules.mpvplayer.nativeplayer.TrickplayProvider
+import expo.modules.mpvplayer.nativeplayer.ui.formatTimeSec
+
+@Composable
+fun TvTrickplayCard(
+    provider: TrickplayProvider,
+    positionSec: Double,
+    modifier: Modifier = Modifier
+) {
+    var imageBitmap by remember { mutableStateOf<Bitmap?>(null) }
+    val tileIndex = remember(positionSec) { provider.tileIndex(positionSec) }
+
+    LaunchedEffect(tileIndex) {
+        val next = provider.thumbnail(positionSec)
+        if (next != null) {
+            imageBitmap = next
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .size(TvMetrics.POSTER_WIDTH, TvMetrics.POSTER_HEIGHT)
+            .clip(RoundedCornerShape(18.dp))
+            .background(Color.Black.copy(alpha = 0.6f)),
+        contentAlignment = Alignment.BottomStart
+    ) {
+        val bmp = imageBitmap
+        if (bmp != null) {
+            Image(
+                bitmap = bmp.asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        }
+
+        TvPosterScrim(modifier = Modifier.align(Alignment.BottomCenter))
+
+        Text(
+            text = formatTimeSec(positionSec),
+            color = Color.White,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Medium,
+            fontFamily = FontFamily.Monospace,
+            modifier = Modifier.padding(
+                horizontal = TvMetrics.TEXT_INSET_H,
+                vertical = TvMetrics.TEXT_INSET_V
+            )
+        )
+    }
+}

--- a/providers/NativePlayerProvider.tsx
+++ b/providers/NativePlayerProvider.tsx
@@ -71,6 +71,7 @@ import { useWebSocketContext } from "@/providers/WebSocketProvider";
 import {
   getActiveVideoPlayer,
   isNativePlayerSupported,
+  isNativePlayerSupportedAndroidTV,
   isNativePlayerSupportedTV,
   useSettings,
   VideoPlayer,
@@ -238,7 +239,9 @@ export const NativePlayerProvider: React.FC<{
   // native is decided per-request by getActiveVideoPlayer (the TV opt-in
   // toggle); the inner WS "Play" handler already respects it.
   const enabled =
-    (isNativePlayerSupported || isNativePlayerSupportedTV) &&
+    (isNativePlayerSupported ||
+      isNativePlayerSupportedTV ||
+      isNativePlayerSupportedAndroidTV) &&
     isNativePlayerModuleAvailable();
 
   if (!enabled) {

--- a/translations/en.json
+++ b/translations/en.json
@@ -233,7 +233,8 @@
         "exoplayer_note": "ExoPlayer does not support advanced ASS/SSA subtitle styling or horizontal subtitle alignment. Switch to MPV if you need those.",
         "mpv_note": "MPV on TV does not currently pass HDR metadata to the display, so HDR10/HDR10+ content is tone-mapped to SDR. Switch to ExoPlayer for HDR output.",
         "native_tv": "Native player (experimental)",
-        "native_tv_note": "Use the new fully-native Apple TV player. Turn it off to fall back to the previous player if you run into playback issues."
+        "native_tv_note": "Use the new fully-native Apple TV player. Turn it off to fall back to the previous player if you run into playback issues.",
+        "native_android_tv_note": "Use the new fully-native Android TV player. Turn it off to fall back to the previous player if you run into playback issues."
       },
       "buffer": {
         "title": "Buffer settings",

--- a/translations/sv-SE.json
+++ b/translations/sv-SE.json
@@ -232,7 +232,8 @@
         "exoplayer_note": "ExoPlayer stöder inte avancerad ASS/SSA-undertextstil eller horisontell undertextjustering. Byt till MPV om du behöver det.",
         "mpv_note": "MPV på TV skickar för närvarande inte HDR-metadata till skärmen, så HDR10-/HDR10+-innehåll konverteras till SDR. Byt till ExoPlayer för HDR-utdata.",
         "native_tv": "Inbyggd spelare (experimentell)",
-        "native_tv_note": "Använd den nya helt inbyggda Apple TV-spelaren. Stäng av för att använda den tidigare spelaren om du får uppspelningsproblem."
+        "native_tv_note": "Använd den nya helt inbyggda Apple TV-spelaren. Stäng av för att använda den tidigare spelaren om du får uppspelningsproblem.",
+        "native_android_tv_note": "Använd den nya helt inbyggda Android TV-spelaren. Stäng av för att använda den tidigare spelaren om du får uppspelningsproblem."
       },
       "buffer": {
         "title": "Bufferinställningar",
@@ -741,6 +742,7 @@
     "stopPlayback": "Stoppa uppspelning",
     "stopPlayingTitle": "Sluta spela \"{{title}}\"?",
     "stopPlayingConfirm": "Är du säker på att du vill stoppa uppspelningen?",
+    "now_playing": "Spelas nu",
     "downloaded": "Nedladdad",
     "missing_parameters": "Uppspelningsparametrar saknas"
   },

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -216,9 +216,18 @@ export const isNativePlayerSupportedTV =
   Number.parseInt(String(Platform.Version), 10) >= 26;
 
 /**
+ * Whether the fully-native player can run on the current platform as the
+ * Android TV variant. It is opt-in via `nativeVideoPlayerAndroidTV` (default false),
+ * and requires Android TV.
+ */
+export const isNativePlayerSupportedAndroidTV =
+  Platform.OS === "android" && Boolean(Platform.isTV);
+
+/**
  * Resolve the actually-active video player for the current settings.
  * MPV is the default on Android; users can opt into ExoPlayer on
  * Android TV or the Native player on Android mobile via settings.videoPlayer.
+ * On Android TV, users can opt into the native player via `nativeVideoPlayerAndroidTV`.
  * On iPhone/iPad the fully-native player is the default: an unset `videoPlayer`
  * (user never chose) or an explicit `Native` selection resolves to Native,
  * while an explicit MPV choice is the opt-out and wins. On Apple TV (tvOS 26+)
@@ -231,7 +240,12 @@ export const isNativePlayerSupportedTV =
  */
 export const getActiveVideoPlayer = (
   settings:
-    | Partial<Pick<Settings, "videoPlayer" | "nativeVideoPlayerTV">>
+    | Partial<
+        Pick<
+          Settings,
+          "videoPlayer" | "nativeVideoPlayerTV" | "nativeVideoPlayerAndroidTV"
+        >
+      >
     | null
     | undefined,
 ): VideoPlayer => {
@@ -239,6 +253,12 @@ export const getActiveVideoPlayer = (
     return VideoPlayer.ExoPlayer;
   }
   if (isNativePlayerSupportedTV && settings?.nativeVideoPlayerTV !== false) {
+    return VideoPlayer.Native;
+  }
+  if (
+    isNativePlayerSupportedAndroidTV &&
+    settings?.nativeVideoPlayerAndroidTV === true
+  ) {
     return VideoPlayer.Native;
   }
   if (
@@ -257,7 +277,12 @@ export const getActiveVideoPlayer = (
  */
 export const getActivePlayerType = (
   settings:
-    | Partial<Pick<Settings, "videoPlayer" | "nativeVideoPlayerTV">>
+    | Partial<
+        Pick<
+          Settings,
+          "videoPlayer" | "nativeVideoPlayerTV" | "nativeVideoPlayerAndroidTV"
+        >
+      >
     | null
     | undefined,
 ): "mpv" | "exoplayer" => {
@@ -384,6 +409,8 @@ export type Settings = {
   // TV-specific settings
   /** Apple TV only: use the fully-native tvOS player (default on; needs tvOS 26+). */
   nativeVideoPlayerTV: boolean;
+  /** Android TV only: use the fully-native Android TV player (opt-in; default off). */
+  nativeVideoPlayerAndroidTV?: boolean;
   showHomeBackdrop: boolean;
   showTVHeroCarousel: boolean;
   tvTypographyScale: TVTypographyScale;
@@ -507,6 +534,7 @@ export const defaultValues: Settings = {
   useEpisodeImagesForNextUp: false,
   // TV-specific settings
   nativeVideoPlayerTV: true,
+  nativeVideoPlayerAndroidTV: false,
   showHomeBackdrop: true,
   showTVHeroCarousel: true,
   tvTypographyScale: TVTypographyScale.Default,


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Adds Android TV support to the native player from #1958. Stacked on that PR, only the three TV commits are new here.

The chrome is Jetpack Compose (tv-material3): transport bar with armed scrubbing and trickplay previews, controls row, track/quality/speed menus, episode shelf, next episode countdown, subtitle search, and remote key handling with a focus zone model. All surfaces share one set of glass design tokens so the look stays consistent. Opt-in via a new toggle in the TV settings, default off, so the JS player stays the default.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Build for TV: `bun run prebuild:tv`, then `bun run android:tv` (or a release APK for smooth playback).
2. Settings → Video player → enable "Native player (experimental)".
3. Play something and check the chrome: show controls, navigate the buttons, open the audio/subtitle/speed menus.
4. Focus the seek bar and press left/right to scrub, trickplay thumbnails should follow the position. Also seek with left/right while the controls are hidden.
5. Skip an intro and close the technical info panel, focus should return to the controls both times.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in native video player for Android TV, with administrator controls and explanatory settings text.
  * Introduced a TV-optimized playback experience with remote navigation, focused controls, scrubbing, chapter and episode browsing, subtitle search, playback menus, trickplay previews, and exit confirmation.
  * Added TV-specific overlays for buffering, errors, skip prompts, countdowns, and “Are you still watching?” reminders.
  * Added English and Swedish translations for the new TV player settings and playback labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->