### PR TITLE
fix(mpv): silent audio on tvOS with Atmos Continuous Audio Output

### DIFF
--- a/app.json
+++ b/app.json
@@ -150,7 +150,7 @@
         "./plugins/withGitPod.ts",
         {
           "podName": "MPVKit",
-          "podspecUrl": "https://raw.githubusercontent.com/mpv-ios/MPVKit/0.41.0-av/MPVKit.podspec"
+          "podspecUrl": "https://raw.githubusercontent.com/streamyfin/MPVKit/0.41.0-av2/MPVKit.podspec"
         }
       ]
     ],

--- a/modules/mpv-player/ios/MPVLayerRenderer.swift
+++ b/modules/mpv-player/ios/MPVLayerRenderer.swift
@@ -263,6 +263,15 @@ final class MPVLayerRenderer {
         checkError(mpv_set_option_string(handle, "target-colorspace-hint", "yes"))
         #endif
 
+        // Audio output: with Atmos "Continuous Audio Output" enabled, some HDMI
+        // routes report 32 output channels, which the audiounit AO cannot open -
+        // playback stays silent. Prefer the avfoundation AO
+        // (AVSampleBufferAudioRenderer), which handles these routes, with
+        // audiounit as fallback if it fails to initialize. iOS is unchanged.
+        #if os(tvOS)
+        checkError(mpv_set_option_string(handle, "ao", "avfoundation,audiounit"))
+        #endif
+
         // Subtitle and audio settings
         checkError(mpv_set_option_string(mpv, "sub-scale-with-window", "no"))
         checkError(mpv_set_option_string(mpv, "sub-use-margins", "no"))


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Fix silent playback on tvOS when Atmos "Continuous Audio Output" is enabled. Some HDMI routes then report 32 output channels, which mpv's audiounit output can't open, so there is no sound at all while AVPlayer apps play fine.

Bumps MPVKit to `0.41.0-av2` (streamyfin/MPVKit), which builds mpv's avfoundation audio output (AVSampleBufferAudioRenderer) for iOS/tvOS, ported from mpvkit/MPVKit#73. On tvOS the player now prefers it via `ao=avfoundation,audiounit`, so mpv still falls back to audiounit if it fails to init. iOS audio is unchanged.

The new tag is also the first reproducible build of our MPVKit fork. The vo_avfoundation mpv patch only existed in a local checkout before, it's now committed on [streamyfin/MPVKit@avfoundation-ao-tvos](https://github.com/streamyfin/MPVKit/tree/avfoundation-ao-tvos) together with a CI release workflow.

## 🏷️ Ticket / Issue

Fixes #1673

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Build for tvOS (`bun run prebuild:tv` picks up the new MPVKit pin).
2. Play any video and verify audio works. avfoundation is now the preferred output on tvOS, so normal playback already exercises the new path. Verified on the Apple TV 4K simulator with a direct-played MKV.
3. The actual bug needs a physical Apple TV with "Continuous Audio Output" enabled behind a receiver/soundbar that reports 32 channels. Verify playback is no longer silent there. Not tested on device yet, that's the remaining check before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio output selection on tvOS for better playback compatibility.
  * Preserved existing audio behavior on iOS and other platforms.

* **Chores**
  * Updated the MPVKit configuration to use the latest hosted build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->