### PR TITLE
fix(readme): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ A special mention to the following people and projects for their contributions:
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=streamyfin/streamyfin&type=Date)](https://star-history.com/#streamyfin/streamyfin&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=streamyfin/streamyfin&type=Date)](https://star-history.dera.page/#streamyfin/streamyfin&Date)
 
 ## 📄 License
 


### PR DESCRIPTION
The star history chart on the README is currently broken because the upstream service can no longer reliably fetch stargazer data from the GitHub API. This change points the chart and its link to a working endpoint so the badge renders correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart and links to use the new `star-history.dera.page` destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->