### PR TITLE
fix(chromecast): deliver text subtitles as external VTT tracks instead of burning them in

### DIFF
--- a/components/PlayButton.tsx
+++ b/components/PlayButton.tsx
@@ -199,14 +199,19 @@ export const PlayButton: React.FC<Props> = ({
                           basePath: api.basePath,
                         });
                         if (!url || s.Index == null) return [];
+                        // Only server-relative URLs get the token — an
+                        // IsExternalUrl sub lives on a third-party host that
+                        // must never see the Jellyfin access token.
+                        const needsApiKey =
+                          !s.IsExternalUrl && !/[?&]api_?key=/i.test(url);
                         return [
                           {
                             id: s.Index,
                             type: "text" as const,
                             subtype: "subtitles" as const,
-                            contentId: /api_?key=/i.test(url)
-                              ? url
-                              : `${url}${url.includes("?") ? "&" : "?"}api_key=${api.accessToken}`,
+                            contentId: needsApiKey
+                              ? `${url}${url.includes("?") ? "&" : "?"}api_key=${encodeURIComponent(api.accessToken)}`
+                              : url,
                             contentType: "text/vtt",
                             language: s.Language ?? "und",
                             name: s.DisplayTitle ?? undefined,

--- a/components/PlayButton.tsx
+++ b/components/PlayButton.tsx
@@ -11,6 +11,7 @@ import CastContext, {
   MediaHlsSegmentFormat,
   MediaHlsVideoSegmentFormat,
   MediaStreamType,
+  type MediaTrack,
   PlayServicesState,
   useMediaStatus,
   useRemoteMediaClient,
@@ -38,6 +39,10 @@ import { useSettings } from "@/utils/atoms/settings";
 import { getParentBackdropImageUrl } from "@/utils/jellyfin/image/getParentBackdropImageUrl";
 import { getPrimaryImageUrl } from "@/utils/jellyfin/image/getPrimaryImageUrl";
 import { getStreamUrl } from "@/utils/jellyfin/media/getStreamUrl";
+import {
+  getExternalSubtitleUrl,
+  isExternalSubtitle,
+} from "@/utils/jellyfin/subtitleUtils";
 import type { PlayRequest } from "@/utils/nativePlayer/playRequest";
 import { formatDuration, runtimeTicksToMinutes } from "@/utils/time";
 import { chromecast } from "../utils/profiles/chromecast";
@@ -178,6 +183,37 @@ export const PlayButton: React.FC<Props> = ({
                       return;
                     }
 
+                    // Text subtitles ride along as sidecar VTT tracks the
+                    // receiver renders itself (see the chromecast subtitle
+                    // profile). The receiver fetches them without auth
+                    // headers, so the api key must be in the URL.
+                    const subtitleTracks: MediaTrack[] = (
+                      data.mediaSource?.MediaStreams ?? []
+                    )
+                      .filter(
+                        (s) => s.Type === "Subtitle" && isExternalSubtitle(s),
+                      )
+                      .flatMap((s) => {
+                        const url = getExternalSubtitleUrl(s, {
+                          offline: false,
+                          basePath: api.basePath,
+                        });
+                        if (!url || s.Index == null) return [];
+                        return [
+                          {
+                            id: s.Index,
+                            type: "text" as const,
+                            subtype: "subtitles" as const,
+                            contentId: /api_?key=/i.test(url)
+                              ? url
+                              : `${url}${url.includes("?") ? "&" : "?"}api_key=${api.accessToken}`,
+                            contentType: "text/vtt",
+                            language: s.Language ?? "und",
+                            name: s.DisplayTitle ?? undefined,
+                          },
+                        ];
+                      });
+
                     // Calculate start time in seconds from playback position
                     const startTimeSeconds = positionTicks / 10000000;
 
@@ -209,6 +245,9 @@ export const PlayButton: React.FC<Props> = ({
                             hlsVideoSegmentFormat: isFmp4
                               ? MediaHlsVideoSegmentFormat.FMP4
                               : MediaHlsVideoSegmentFormat.MPEG2_TS,
+                          }),
+                          ...(subtitleTracks.length > 0 && {
+                            mediaTracks: subtitleTracks,
                           }),
                           streamType: MediaStreamType.BUFFERED,
                           streamDuration: streamDurationSeconds,
@@ -266,6 +305,19 @@ export const PlayButton: React.FC<Props> = ({
                         startTime: startTimeSeconds,
                       })
                       .then(() => {
+                        const activeSubtitle = subtitleTracks.find(
+                          (s) => s.id === selectedOptions.subtitleIndex,
+                        );
+                        if (activeSubtitle) {
+                          client
+                            .setActiveTrackIds([activeSubtitle.id])
+                            .catch((e) => {
+                              console.error(
+                                "Chromecast setActiveTrackIds failed:",
+                                e,
+                              );
+                            });
+                        }
                         // state is already set when reopening current media, so skip it here.
                         if (isOpeningCurrentlyPlayingMedia) {
                           return;
@@ -274,9 +326,17 @@ export const PlayButton: React.FC<Props> = ({
                       })
                       .catch((e) => {
                         console.error("Chromecast loadMedia failed:", e);
+                        Alert.alert(
+                          t("player.client_error"),
+                          t("player.chromecast_playback_failed"),
+                        );
                       });
                   } catch (e) {
-                    console.log(e);
+                    console.error("Chromecast stream setup failed:", e);
+                    Alert.alert(
+                      t("player.client_error"),
+                      t("player.could_not_create_stream_for_chromecast"),
+                    );
                   }
                 }
               });

--- a/translations/en.json
+++ b/translations/en.json
@@ -701,6 +701,7 @@
     "an_error_occurred_while_playing_the_video": "An error occurred while playing the video. Check logs in settings.",
     "client_error": "Client error",
     "could_not_create_stream_for_chromecast": "Could not create a stream for Chromecast",
+    "chromecast_playback_failed": "Chromecast could not play this stream",
     "message_from_server": "Message from server: {{message}}",
     "next_episode": "Next episode",
     "continue_watching": "Continue watching",

--- a/utils/profiles/subtitles.test.ts
+++ b/utils/profiles/subtitles.test.ts
@@ -35,9 +35,9 @@ describe("getSubtitleProfiles", () => {
     expect(profiles[0]).toEqual({ Format: "vtt", Method: "Encode" });
   });
 
-  it("returns 1 entry for target chromecast (deduplicated vtt)", () => {
+  it("returns 1 entry for target chromecast (external vtt)", () => {
     const profiles = getSubtitleProfiles({ target: "chromecast" });
-    expect(profiles).toEqual([{ Format: "vtt", Method: "Encode" }]);
+    expect(profiles).toEqual([{ Format: "vtt", Method: "External" }]);
   });
 
   it("returns empty array for target music", () => {

--- a/utils/profiles/subtitles.ts
+++ b/utils/profiles/subtitles.ts
@@ -83,8 +83,12 @@ const EXOPLAYER_SUBTITLE_PROFILES: SubtitleProfile[] = [
   { Format: "pgssub", Method: "Encode" },
 ];
 
+// Text subs are delivered as sidecar VTT files the receiver fetches and
+// renders itself. Burning them in (Encode) forces a full video re-encode,
+// which some receivers refuse to play — image subs (no External profile)
+// still fall back to server-side burn-in.
 const CHROMECAST_SUBTITLE_PROFILES: SubtitleProfile[] = [
-  { Format: "vtt", Method: "Encode" },
+  { Format: "vtt", Method: "External" },
 ];
 
 // Note: Method "Encode" forces Jellyfin to burn subtitles into the downloaded stream.


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Cast text subtitles as side-loaded VTT tracks that the receiver renders itself, instead of burning them in with a full video re-encode. The burn-in transcode would not play on an older Chromecast, while the exact same stream with subtitles off played fine. With External delivery the video is streamed untouched, so subtitle casts now use the same DirectStream pipeline as subtitle-less ones.

All external text tracks are attached to the load request and the selected one is activated automatically, so subs can also be toggled from the cast controls. Image-based subs (PGS, VOBSUB) still burn in since they cannot be side-loaded.

Cast failures now show an alert. Before, a failed loadMedia or stream setup died silently.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Pick a movie with a text subtitle track (SRT), select it in the play options and cast to a Chromecast
2. Subtitles should appear on the TV, rendered by the receiver instead of burned into the video
3. Check the ffmpeg log on the server, the job should be a DirectStream with no subtitles filter in the command
4. Toggle the subtitle track from the expanded cast controls
5. Cast something with PGS subs selected and verify those still burn in and play


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chromecast playback now supports selectable subtitles through authenticated external VTT tracks.
  * Selected subtitle tracks are automatically activated after media loads.
  * Other subtitle formats continue to use fallback support.

* **Bug Fixes**
  * Improved subtitle handling during Chromecast playback.
  * Added localized alerts when Chromecast loading or stream setup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->