### PR TITLE
fix(settings): redact secret values from the plugin-settings log

### DIFF
--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -451,6 +451,26 @@ export type StreamyfinPluginConfig = {
   settings: PluginLockableSettings;
 };
 
+// Settings whose values are secrets. They must never reach the app log,
+// which users read in-app and paste into bug reports.
+const SENSITIVE_SETTING_KEYS: ReadonlySet<keyof Settings> = new Set([
+  "jellyseerrApiKey",
+  "openSubtitlesApiKey",
+] as const);
+
+export const redactPluginSettings = (
+  settings: PluginLockableSettings | undefined,
+): PluginLockableSettings | undefined =>
+  settings &&
+  (Object.fromEntries(
+    Object.entries(settings).map(([key, lockable]) => [
+      key,
+      SENSITIVE_SETTING_KEYS.has(key as keyof Settings) && lockable?.value
+        ? { ...lockable, value: "[redacted]" }
+        : lockable,
+    ]),
+  ) as PluginLockableSettings);
+
 export const defaultValues: Settings = {
   home: null,
   deviceProfile: "Expo",
@@ -657,7 +677,10 @@ export const useSettings = () => {
     }
     const newPluginSettings = await api.getStreamyfinPluginConfig().then(
       ({ data }) => {
-        writeInfoLog("Got plugin settings", data?.settings);
+        writeInfoLog(
+          "Got plugin settings",
+          redactPluginSettings(data?.settings),
+        );
         return data?.settings;
       },
       (_err) => undefined,


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Redact secret setting values from the "Got plugin settings" log line. The full plugin settings dump landed in the persisted app log on every refresh, which now includes `jellyseerrApiKey` from #1973 (and `openSubtitlesApiKey` before it). Users read that log in-app and paste it into bug reports, so secrets get masked as `[redacted]` before logging. The actual settings object is untouched.

## 🏷️ Ticket / Issue

Follow-up to #1973

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Configure the Seerr plugin with an API key (plugin settings, or paste it in the app).
2. Restart the app so the plugin settings refresh.
3. Open Settings → Logs and find the "Got plugin settings" entry.
4. Verify `jellyseerrApiKey` shows `[redacted]` instead of the key, and that Seerr sign-in still works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sensitive Jellyseerr and OpenSubtitles API keys are now masked in plugin configuration logs.
  * Plugin settings refresh logs no longer expose raw API credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->