### PR TITLE
fix(jellyseerr): keep the API key field in sync with the stored key

### DIFF
--- a/components/settings/Jellyseerr.tsx
+++ b/components/settings/Jellyseerr.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { useAtom } from "jotai";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 import { toast } from "sonner-native";
@@ -37,6 +37,14 @@ export const JellyseerrSettings = () => {
   const [jellyseerrApiKeyInput, setJellyseerrApiKeyInput] = useState<string>(
     settings?.jellyseerrApiKey ?? "",
   );
+
+  // The stored key can change after mount (plugin settings load async, and a
+  // login rewrites it). Keep the field in sync so what's on screen is always
+  // the key that a password login would clear — otherwise a stored key could
+  // be wiped invisibly behind an empty-looking input.
+  useEffect(() => {
+    setJellyseerrApiKeyInput(settings?.jellyseerrApiKey ?? "");
+  }, [settings?.jellyseerrApiKey]);
 
   const [jellyseerrServerUrl, setjellyseerrServerUrl] = useState<string>(
     settings?.jellyseerrServerUrl ?? "",


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Keep the Seerr API key input in sync with the stored key. The field was seeded from settings once at mount, while a password login always writes `jellyseerrApiKey` from the field's value. A key that arrived after mount (plugin settings load async) could sit behind an empty-looking input and get wiped by a routine password login without the user ever seeing it existed. Now the field re-syncs whenever the stored key changes, so a wipe is always visible and intentional.

Found by code review on #1973.

## 🏷️ Ticket / Issue

Follow-up to #1973

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Sign out of Seerr in the app (reset the Seerr config) with a plugin that distributes an unlocked `jellyseerrApiKey`.
2. Open Settings → Plugins → Seerr and verify the API key field shows the plugin-provided key (not empty).
3. Clear the field, log in with a password, and verify that works as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Jellyseerr API-key settings now stay synchronized after asynchronous updates, including changes made during login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->