### PR TITLE
feat(sentry): anonymous crash and error reporting with opt-out

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -64,6 +64,18 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     ]);
   }
 
+  // Sentry source-map/dSYM upload needs SENTRY_AUTH_TOKEN; without it the
+  // injected build phases fail Release builds outright. Disable upload unless
+  // the token is present (EAS secret / CI env), so it self-enables with it.
+  for (const plugin of config.plugins ?? []) {
+    if (Array.isArray(plugin) && plugin[0] === "@sentry/react-native/expo") {
+      plugin[1] = {
+        ...plugin[1],
+        disableAutoUpload: !process.env.SENTRY_AUTH_TOKEN,
+      };
+    }
+  }
+
   // Only override googleServicesFile if env var is set
   const androidConfig: { googleServicesFile?: string } = {};
   if (process.env.GOOGLE_SERVICES_JSON) {

--- a/app.json
+++ b/app.json
@@ -73,6 +73,14 @@
       ],
       "expo-router",
       "expo-font",
+      [
+        "@sentry/react-native/expo",
+        {
+          "organization": "streamyfin",
+          "project": "react-native",
+          "url": "https://sentry.io/"
+        }
+      ],
       "./plugins/withExcludeMedia3Dash.ts",
       "./plugins/withTVUserManagement.ts",
       [

--- a/app/(auth)/(tabs)/(home)/settings.tv.tsx
+++ b/app/(auth)/(tabs)/(home)/settings.tv.tsx
@@ -1201,6 +1201,11 @@ export default function SettingsTV() {
               updateSettings({ openSubtitlesEnabled: value })
             }
           />
+          <TVSettingsToggle
+            label={t("home.settings.plugins.crash_reports")}
+            value={settings.sentryEnabled}
+            onToggle={(value) => updateSettings({ sentryEnabled: value })}
+          />
 
           {/* Custom proxy auth headers for Jellyfin and each integration */}
           <TVCustomHeadersSection serverUrl={storage.getString("serverUrl")} />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -69,7 +69,11 @@ if (Platform.isTV) {
 import * as Sentry from "@sentry/react-native";
 import useRouter from "@/hooks/useAppRouter";
 import { userAtom } from "@/providers/JellyfinProvider";
-import { initializeSentryIfConsented } from "@/utils/sentry";
+import { effectiveSettingsAtom, settingsAtom } from "@/utils/atoms/settings";
+import {
+  applySentryConsent,
+  initializeSentryIfConsented,
+} from "@/utils/sentry";
 import { store as jotaiStore, store } from "@/utils/store";
 import "react-native-reanimated";
 import {
@@ -84,8 +88,19 @@ configureReanimatedLogger({
   strict: false,
 });
 
-// Crash reporting is on by default; this is a no-op if the user opted out.
+// Crash reporting is on by default; this is a no-op if the user opted out
+// (or a server admin locked it off). After startup, consent tracks the
+// effective settings, so the switch, plugin-pushed defaults, and admin locks
+// all take effect immediately.
 initializeSentryIfConsented();
+jotaiStore.sub(effectiveSettingsAtom, () => {
+  // Ignore changes until the persisted settings hydrate; before that the
+  // effective value is just defaults and would override a stored opt-out.
+  if (jotaiStore.get(settingsAtom) === null) return;
+  applySentryConsent(
+    jotaiStore.get(effectiveSettingsAtom).sentryEnabled !== false,
+  );
+});
 
 if (!Platform.isTV) {
   Notifications.setNotificationHandler({

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -66,8 +66,10 @@ if (Platform.isTV) {
   LogBox.ignoreLogs(["HoverGestureHandler is not supported on tvOS"]);
 }
 
+import * as Sentry from "@sentry/react-native";
 import useRouter from "@/hooks/useAppRouter";
 import { userAtom } from "@/providers/JellyfinProvider";
+import { initializeSentryIfConsented } from "@/utils/sentry";
 import { store as jotaiStore, store } from "@/utils/store";
 import "react-native-reanimated";
 import {
@@ -81,6 +83,9 @@ configureReanimatedLogger({
   level: ReanimatedLogLevel.warn,
   strict: false,
 });
+
+// Crash reporting is on by default; this is a no-op if the user opted out.
+initializeSentryIfConsented();
 
 if (!Platform.isTV) {
   Notifications.setNotificationHandler({
@@ -209,7 +214,7 @@ const checkAndRequestPermissions = async () => {
   }
 };
 
-export default function RootLayout() {
+function RootLayout() {
   Appearance.setColorScheme("dark");
 
   return (
@@ -224,6 +229,9 @@ export default function RootLayout() {
     </GestureHandlerRootView>
   );
 }
+
+// Sentry.wrap is inert while the SDK is not initialized (crash reporting off).
+export default Sentry.wrap(RootLayout);
 
 // Set up online manager for network-aware query behavior
 onlineManager.setEventListener((setOnline) => {

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@react-native-community/netinfo": "12.0.1",
         "@react-navigation/material-top-tabs": "7.6.13",
         "@react-navigation/native": "7.3.14",
+        "@sentry/react-native": "^8.23.0",
         "@shopify/flash-list": "2.3.2",
         "@tanstack/query-sync-storage-persister": "5.101.4",
         "@tanstack/react-query": "5.101.4",
@@ -109,6 +110,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "@sentry/cli",
+  ],
   "patchedDependencies": {
     "react-native-udp@4.1.7": "patches/react-native-udp@4.1.7.patch",
   },
@@ -582,6 +586,46 @@
 
     "@react-navigation/routers": ["@react-navigation/routers@7.6.4", "", { "dependencies": { "nanoid": "^3.3.11" } }, "sha512-GI7eJm8/KsZUQaYcXvEExikKurRZRgEsSzyZ7faENfi65yqJBCXjDMwyN1pF6pNW1MoLH1ErDwDivFxY6BzD3w=="],
 
+    "@sentry/browser": ["@sentry/browser@10.69.0", "", { "dependencies": { "@sentry/browser-utils": "10.69.0", "@sentry/conventions": "^0.16.0", "@sentry/core": "10.69.0", "@sentry/feedback": "10.69.0", "@sentry/replay": "10.69.0", "@sentry/replay-canvas": "10.69.0" } }, "sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q=="],
+
+    "@sentry/browser-utils": ["@sentry/browser-utils@10.69.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0", "@sentry/core": "10.69.0" } }, "sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ=="],
+
+    "@sentry/bundler-plugins": ["@sentry/bundler-plugins@10.69.0", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/cli": "^2.58.6", "@sentry/core": "10.69.0", "dotenv": "^17.4.2", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" }, "peerDependencies": { "rollup": ">=3.2.0", "webpack": ">=5.0.0" }, "optionalPeers": ["rollup", "webpack"] }, "sha512-I1otnSJIH4IOugLp+kcBbT0Kcex+J8xnHuUyzMAwCYSpZ0FMVvA723uNmkMdW0PxRRw0oEhe0qDB+t+ZjHxUiA=="],
+
+    "@sentry/cli": ["@sentry/cli@3.6.2", "", { "dependencies": { "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "undici": "^6.22.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "3.6.2", "@sentry/cli-linux-arm": "3.6.2", "@sentry/cli-linux-arm64": "3.6.2", "@sentry/cli-linux-i686": "3.6.2", "@sentry/cli-linux-x64": "3.6.2", "@sentry/cli-win32-arm64": "3.6.2", "@sentry/cli-win32-i686": "3.6.2", "@sentry/cli-win32-x64": "3.6.2" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-/OcDsuz005C1tuauNhTd8/XNBHCfHiy46Wru4hAKBaziywgSA52lMSEznh6mWmHjPe/FoaDLpYt3Zd9qk3G0RA=="],
+
+    "@sentry/cli-darwin": ["@sentry/cli-darwin@3.6.2", "", { "os": "darwin" }, "sha512-/ZIMLblj6ncwguhOPw5YL9018iaD2RBhxhbHBxjaowy1vrmnzoCurGe4n5Vv7PaS21ldAHtHNqJwNqHJS4XHUw=="],
+
+    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@3.6.2", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-b2M+1ujgf7jHig9r88T2l2HEkg0XR/1Tmo1LCiPg4dsPKtTMC2Rb/f0Mto83//zkVijAA2WDBhznOz9a9Ouo7Q=="],
+
+    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@3.6.2", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-KMHW+CIT5H046I1hIYJ6vZmwlbBELZDOTt9Bgue3kqpW5CuvviMeMuuIKXM2oKHr/l4Q1Xnj07oTbVNb1opTsg=="],
+
+    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@3.6.2", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-tsLTOfJBoUkHfcCjUKxb/w1/WGLU00WJUO5zJztgLHKlebrjGAEiKM+8EPexb2hiW4F/P6UXL+4xXPKANk5JXQ=="],
+
+    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@3.6.2", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-CHwfSJYkPe4w96EovIY/iWfxHnf5gvRYh0BGHCPcQ9knhrgWUJqbHqi3lNfEDZmzCxJ76RqPrnLMW6syoSqXow=="],
+
+    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@3.6.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-lTqOPbLexkKnXmuIK8qszv+trpX8fQiZAJoeClVA1+hOerVyrLP9eU2tUqTm/8YW8G/M+mu3ZxAtDvS3OpHvZw=="],
+
+    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@3.6.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-niUPoxN8p7jWrkvC0ekgpcIYEJNb5YxmuXRjUnOJrArwQs+4OPzRM+3e6JIYRXe7RDoUP63j1voYakEncuxioQ=="],
+
+    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@3.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Xg6ieuJr/1Ewtdpm9Kudb029lJxnfs3Ae/fLZNAOnvWOie/V4V/X+tgZ+lETC3lU+7yz7Gb0f25gKnU6sPBKVg=="],
+
+    "@sentry/conventions": ["@sentry/conventions@0.16.0", "", {}, "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ=="],
+
+    "@sentry/core": ["@sentry/core@10.69.0", "", { "dependencies": { "@sentry/conventions": "^0.16.0" } }, "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg=="],
+
+    "@sentry/expo-upload-sourcemaps": ["@sentry/expo-upload-sourcemaps@8.23.0", "", { "dependencies": { "@sentry/cli": "3.6.2" }, "peerDependencies": { "@expo/env": "*", "dotenv": "*" }, "optionalPeers": ["@expo/env", "dotenv"], "bin": { "expo-upload-sourcemaps": "cli.js" } }, "sha512-WO8ibN5j3Lb0D+f38yXmSzaRVuoOVa+6uNMfO27+lVrJGZJc2dOgNXabAc9/UVM5XHE/LZI7Ll0XCkvVfju6Vg=="],
+
+    "@sentry/feedback": ["@sentry/feedback@10.69.0", "", { "dependencies": { "@sentry/core": "10.69.0" } }, "sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg=="],
+
+    "@sentry/react": ["@sentry/react@10.69.0", "", { "dependencies": { "@sentry/browser": "10.69.0", "@sentry/conventions": "^0.16.0", "@sentry/core": "10.69.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-f0Il/JMteHjdWPNZQB3rtp1Pcj2Leb3p0KSZuv3rh0EUril9CbWtQVy5zJhoAppi+MWWmgRWa+6BpHbQf+ABQA=="],
+
+    "@sentry/react-native": ["@sentry/react-native@8.23.0", "", { "dependencies": { "@sentry/browser": "10.69.0", "@sentry/bundler-plugins": "10.69.0", "@sentry/cli": "3.6.2", "@sentry/core": "10.69.0", "@sentry/expo-upload-sourcemaps": "8.23.0", "@sentry/react": "10.69.0" }, "peerDependencies": { "expo": ">=49.0.0", "react": ">=17.0.0", "react-native": ">=0.65.0" }, "optionalPeers": ["expo"], "bin": { "sentry-eas-build-on-error": "scripts/eas-build-hook.js", "sentry-eas-build-on-success": "scripts/eas-build-hook.js", "sentry-eas-build-on-complete": "scripts/eas-build-hook.js", "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js" } }, "sha512-oF91ErmHokUBzMpoZwXC13gQKoOnJpGMDMFhwsauXigH5iyXJrBU9AWSwb7VhJWjz+VN3MIYu3E0S0cr0laqtQ=="],
+
+    "@sentry/replay": ["@sentry/replay@10.69.0", "", { "dependencies": { "@sentry/browser-utils": "10.69.0", "@sentry/core": "10.69.0" } }, "sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg=="],
+
+    "@sentry/replay-canvas": ["@sentry/replay-canvas@10.69.0", "", { "dependencies": { "@sentry/core": "10.69.0", "@sentry/replay": "10.69.0" } }, "sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A=="],
+
     "@shopify/flash-list": ["@shopify/flash-list@2.3.2", "", { "peerDependencies": { "@babel/runtime": "*", "react": "*", "react-native": "*" } }, "sha512-vQnd0y0Ag11yzS30llaeCrtIU3xYTMe7KEOP3dveLImnVjQEUw6BEg1+Ztja6aODlVNz1BpvxtlQ5eZGxiLwKw=="],
 
     "@sideway/address": ["@sideway/address@4.1.5", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q=="],
@@ -895,6 +939,8 @@
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -1279,6 +1325,8 @@
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
 
@@ -1766,6 +1814,8 @@
 
     "ua-parser-js": ["ua-parser-js@0.7.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg=="],
 
+    "undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
+
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unicode-canonical-property-names-ecmascript": ["unicode-canonical-property-names-ecmascript@2.0.1", "", {}, "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg=="],
@@ -1929,6 +1979,12 @@
     "@react-navigation/elements/color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
 
     "@react-navigation/material-top-tabs/color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
+
+    "@sentry/bundler-plugins/@sentry/cli": ["@sentry/cli@2.58.6", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.6", "@sentry/cli-linux-arm": "2.58.6", "@sentry/cli-linux-arm64": "2.58.6", "@sentry/cli-linux-i686": "2.58.6", "@sentry/cli-linux-x64": "2.58.6", "@sentry/cli-win32-arm64": "2.58.6", "@sentry/cli-win32-i686": "2.58.6", "@sentry/cli-win32-x64": "2.58.6" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg=="],
+
+    "@sentry/bundler-plugins/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "@sentry/cli/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
@@ -2117,6 +2173,24 @@
     "@react-navigation/material-top-tabs/color/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "@react-navigation/material-top-tabs/color/color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
+
+    "@sentry/bundler-plugins/@sentry/cli/@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.6", "", { "os": "darwin" }, "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA=="],
+
+    "@sentry/bundler-plugins/@sentry/cli/@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw=="],
+
+    "@sentry/bundler-plugins/@sentry/cli/@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g=="],
+
+    "@sentry/bundler-plugins/@sentry/cli/@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg=="],
+
+    "@sentry/bundler-plugins/@sentry/cli/@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q=="],
+
+    "@sentry/bundler-plugins/@sentry/cli/@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A=="],
+
+    "@sentry/bundler-plugins/@sentry/cli/@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg=="],
+
+    "@sentry/bundler-plugins/@sentry/cli/@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.6", "", { "os": "win32", "cpu": "x64" }, "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA=="],
+
+    "@sentry/bundler-plugins/@sentry/cli/proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 

--- a/components/IntroSheet.tsx
+++ b/components/IntroSheet.tsx
@@ -11,8 +11,10 @@ import { useTranslation } from "react-i18next";
 import { Linking, Platform, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button } from "@/components/Button";
+import { SettingSwitch } from "@/components/common/SettingSwitch";
 import { Text } from "@/components/common/Text";
 import useRouter from "@/hooks/useAppRouter";
+import { useSettings } from "@/utils/atoms/settings";
 import { storage } from "@/utils/mmkv";
 
 export interface IntroSheetRef {
@@ -25,6 +27,7 @@ export const IntroSheet = forwardRef<IntroSheetRef>((_, ref) => {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const { settings, updateSettings } = useSettings();
 
   useImperativeHandle(ref, () => ({
     present: () => {
@@ -180,6 +183,42 @@ export const IntroSheet = forwardRef<IntroSheetRef>((_, ref) => {
                 </View>
               </View>
             </View>
+          </View>
+
+          <View>
+            <Text className='text-lg font-bold'>
+              {t("home.intro.crash_reports_title")}
+            </Text>
+            {/* The whole row toggles: the Switch itself isn't focusable on TV,
+                so the TouchableOpacity carries the remote-select press there. */}
+            <TouchableOpacity
+              activeOpacity={0.7}
+              onPress={() =>
+                updateSettings({ sentryEnabled: !settings?.sentryEnabled })
+              }
+              className='flex flex-row items-center mt-2'
+            >
+              <View
+                style={{
+                  width: 50,
+                  height: 50,
+                }}
+                className='flex items-center justify-center'
+              >
+                <Ionicons name='bug-outline' size={28} color='white' />
+              </View>
+              <View className='shrink flex-1 ml-2 mr-3'>
+                <Text className='shrink text-xs'>
+                  {t("home.intro.crash_reports_description")}
+                </Text>
+              </View>
+              <SettingSwitch
+                value={settings?.sentryEnabled === true}
+                onValueChange={(sentryEnabled) =>
+                  updateSettings({ sentryEnabled })
+                }
+              />
+            </TouchableOpacity>
           </View>
 
           <View>

--- a/components/IntroSheet.tsx
+++ b/components/IntroSheet.tsx
@@ -212,11 +212,11 @@ export const IntroSheet = forwardRef<IntroSheetRef>((_, ref) => {
                   {t("home.intro.crash_reports_description")}
                 </Text>
               </View>
+              {/* Presentational only — the row press above is the single
+                  mutation path, so a tap on the switch can't double-toggle. */}
               <SettingSwitch
                 value={settings?.sentryEnabled === true}
-                onValueChange={(sentryEnabled) =>
-                  updateSettings({ sentryEnabled })
-                }
+                pointerEvents='none'
               />
             </TouchableOpacity>
           </View>

--- a/components/settings/PluginSettings.tsx
+++ b/components/settings/PluginSettings.tsx
@@ -1,4 +1,6 @@
+import * as Sentry from "@sentry/react-native";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner-native";
 import { SettingSwitch } from "@/components/common/SettingSwitch";
 import useRouter from "@/hooks/useAppRouter";
 import { useSettings } from "@/utils/atoms/settings";
@@ -62,6 +64,28 @@ export const PluginSettings = () => {
           }
         />
       </ListItem>
+      <ListItem
+        title={t("home.settings.plugins.crash_reports")}
+        subtitle={t("home.settings.plugins.crash_reports_hint")}
+      >
+        <SettingSwitch
+          value={settings.sentryEnabled}
+          onValueChange={(value) => updateSettings({ sentryEnabled: value })}
+        />
+      </ListItem>
+      {/* Dev-only smoke test for the Sentry pipeline; never ships in release. */}
+      {__DEV__ && settings.sentryEnabled && (
+        <ListItem
+          title='Send test error to Sentry'
+          textColor='blue'
+          onPress={() => {
+            Sentry.captureException(
+              new Error("Sentry test error — safe to ignore"),
+            );
+            toast.success("Test error sent");
+          }}
+        />
+      )}
     </ListGroup>
   );
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,8 +1,10 @@
 // Learn more https://docs.expo.io/guides/customizing-metro
-const { getDefaultConfig } = require("expo/metro-config");
+// getSentryExpoConfig wraps expo/metro-config's getDefaultConfig and adds
+// debug-ID injection so uploaded source maps match released bundles.
+const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 
 /** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(__dirname);
+const config = getSentryExpoConfig(__dirname);
 
 // Add Hermes parser
 config.transformer.hermesParser = true;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@react-native-community/netinfo": "12.0.1",
     "@react-navigation/material-top-tabs": "7.6.13",
     "@react-navigation/native": "7.3.14",
+    "@sentry/react-native": "^8.23.0",
     "@shopify/flash-list": "2.3.2",
     "@tanstack/query-sync-storage-persister": "5.101.4",
     "@tanstack/react-query": "5.101.4",
@@ -168,6 +169,7 @@
     ]
   },
   "trustedDependencies": [
+    "@sentry/cli",
     "unrs-resolver"
   ],
   "patchedDependencies": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -127,7 +127,9 @@
       "centralised_settings_plugin_description": "Configure settings centrally on your Jellyfin server. Every user's client settings sync automatically.",
       "done_button": "Done",
       "go_to_settings_button": "Go to Settings",
-      "read_more": "Read more"
+      "read_more": "Read more",
+      "crash_reports_title": "Help improve Streamyfin",
+      "crash_reports_description": "Streamyfin sends anonymous crash and error reports to the developers. No account data or server addresses are included. You can turn this off here or anytime in settings."
     },
     "settings": {
       "settings_title": "Settings",
@@ -375,6 +377,8 @@
         "wikidata_awards_hint": "Show Oscar and award status on movie and series pages. This device asks Wikidata directly, not your Jellyfin server.",
         "opensubtitles_enabled": "Search OpenSubtitles",
         "opensubtitles_enabled_hint": "Let this device search OpenSubtitles directly when your Jellyfin server has no subtitle provider. Turning this off keeps subtitle searches on your server and leaves any saved API key alone.",
+        "crash_reports": "Crash reports",
+        "crash_reports_hint": "Send anonymous crash and error reports to the Streamyfin developers via Sentry. Reports contain no account data; server addresses and tokens are removed before anything is sent.",
         "jellyseerr": {
           "server_url": "Server URL",
           "server_url_hint": "Example: http(s)://your-host.url\n(add port if required)",

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -14,6 +14,7 @@ import { BITRATES, type Bitrate } from "@/components/BitrateSelector";
 import * as ScreenOrientation from "@/packages/expo-screen-orientation";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { writeInfoLog } from "@/utils/log";
+import { applySentryConsent } from "@/utils/sentry";
 import { storage } from "../mmkv";
 import {
   type AppliedPluginDefaults,
@@ -435,6 +436,8 @@ export type Settings = {
   openSubtitlesApiKey?: string;
   // TV-only: Inactivity timeout for auto-logout
   inactivityTimeout: InactivityTimeout;
+  /** Anonymous crash/error reporting via Sentry (on by default, opt-out). */
+  sentryEnabled: boolean;
 };
 
 export interface Lockable<T> {
@@ -556,6 +559,8 @@ export const defaultValues: Settings = {
   openSubtitlesEnabled: true,
   // TV-only: Inactivity timeout (disabled by default)
   inactivityTimeout: InactivityTimeout.Disabled,
+  // Crash reporting defaults on; the intro sheet and settings expose the opt-out
+  sentryEnabled: true,
 };
 
 const loadSettings = (): Partial<Settings> => {
@@ -722,6 +727,10 @@ export const useSettings = () => {
       } as Settings;
       setSettings(newSettings);
       saveSettings(newSettings);
+      // Consent changes take effect immediately, not just on next launch
+      if ("sentryEnabled" in sanitizedUpdate) {
+        applySentryConsent(sanitizedUpdate.sentryEnabled === true);
+      }
     }
   };
 

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -14,7 +14,11 @@ import { BITRATES, type Bitrate } from "@/components/BitrateSelector";
 import * as ScreenOrientation from "@/packages/expo-screen-orientation";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { writeInfoLog } from "@/utils/log";
-import { applySentryConsent } from "@/utils/sentry";
+import {
+  PLUGIN_SETTINGS_KEY,
+  readStoredSettings,
+  SETTINGS_KEY,
+} from "@/utils/storedSettings";
 import { storage } from "../mmkv";
 import {
   type AppliedPluginDefaults,
@@ -23,7 +27,7 @@ import {
 } from "./settingsOverrides";
 
 const _STREAMYFIN_PLUGIN_ID = "1e9e5d386e6746158719e98a5c34f004";
-const STREAMYFIN_PLUGIN_SETTINGS = "STREAMYFIN_PLUGIN_SETTINGS";
+const STREAMYFIN_PLUGIN_SETTINGS = PLUGIN_SETTINGS_KEY;
 
 export type DownloadQuality = "original" | "high" | "low";
 
@@ -563,18 +567,8 @@ export const defaultValues: Settings = {
   sentryEnabled: true,
 };
 
-const loadSettings = (): Partial<Settings> => {
-  try {
-    const jsonValue = storage.getString("settings");
-    const loadedValues: Partial<Settings> =
-      jsonValue != null ? JSON.parse(jsonValue) : {};
-
-    return loadedValues;
-  } catch (error) {
-    console.error("Failed to load settings:", error);
-    return {};
-  }
-};
+const loadSettings = (): Partial<Settings> =>
+  readStoredSettings() as Partial<Settings>;
 
 const EXCLUDE_FROM_SAVE = ["home"];
 
@@ -586,7 +580,7 @@ const saveSettings = (settings: Settings) => {
       }
     }
     const jsonValue = JSON.stringify(settings);
-    storage.set("settings", jsonValue);
+    storage.set(SETTINGS_KEY, jsonValue);
   } catch (error) {
     console.error("Failed to save settings:", error);
   }
@@ -727,10 +721,6 @@ export const useSettings = () => {
       } as Settings;
       setSettings(newSettings);
       saveSettings(newSettings);
-      // Consent changes take effect immediately, not just on next launch
-      if ("sentryEnabled" in sanitizedUpdate) {
-        applySentryConsent(sanitizedUpdate.sentryEnabled === true);
-      }
     }
   };
 

--- a/utils/log.tsx
+++ b/utils/log.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react-native";
 import { useQuery } from "@tanstack/react-query";
 import { atomWithStorage, createJSONStorage } from "jotai/utils";
 import type React from "react";
@@ -5,6 +6,13 @@ import { createContext, useContext } from "react";
 import { storage } from "./mmkv";
 
 export type LogLevel = "INFO" | "WARN" | "ERROR" | "DEBUG";
+
+const SENTRY_BREADCRUMB_LEVELS: Record<LogLevel, Sentry.SeverityLevel> = {
+  INFO: "info",
+  WARN: "warning",
+  ERROR: "error",
+  DEBUG: "debug",
+};
 
 interface LogEntry {
   timestamp: string;
@@ -40,6 +48,15 @@ function useLogProvider() {
 }
 
 export const writeToLog = (level: LogLevel, message: string, data?: any) => {
+  // Mirror app logs into Sentry as breadcrumbs (never events) so crash
+  // reports carry the log trail leading up to them. `data` stays local:
+  // it can hold raw URLs and payloads the URL scrubber wouldn't reach.
+  Sentry.addBreadcrumb({
+    category: "app.log",
+    level: SENTRY_BREADCRUMB_LEVELS[level],
+    message,
+  });
+
   const newEntry: LogEntry = {
     timestamp: new Date().toISOString(),
     level: level,

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -1,0 +1,92 @@
+import * as Sentry from "@sentry/react-native";
+import { storage } from "@/utils/mmkv";
+
+// Public Sentry DSN for org "streamyfin", project "react-native". A DSN only
+// allows submitting events, so shipping it in the client bundle is fine.
+// EXPO_PUBLIC_SENTRY_DSN overrides it (e.g. to point a fork at its own org).
+const SENTRY_DSN =
+  process.env.EXPO_PUBLIC_SENTRY_DSN ??
+  "https://5c548edf47663532bb529ba72b2ddbb1@o4509610343596032.ingest.de.sentry.io/4509610370728016";
+
+let initialized = false;
+
+/**
+ * Reads the user's crash-report preference straight from MMKV. This runs at
+ * app startup, before Jotai hydrates settingsAtom, so it parses the persisted
+ * settings JSON directly instead of going through useSettings. Reporting is
+ * on by default; only an explicit opt-out disables it.
+ */
+const hasSentryConsent = (): boolean => {
+  try {
+    const json = storage.getString("settings");
+    return json ? JSON.parse(json).sentryEnabled !== false : true;
+  } catch {
+    return true;
+  }
+};
+
+// Jellyfin/Jellyseerr URLs carry credentials in the query string (api_key=...)
+// and the origin reveals the user's private server address, so both are
+// scrubbed from everything that leaves the app; the request path survives
+// because it's what makes an error debuggable.
+const scrubUrl = (value: string): string =>
+  value
+    .replace(/(https?:\/\/[^\s"'?]+)\?[^\s"']*/g, "$1")
+    .replace(/https?:\/\/[^/\s"']+/g, "https://[server]");
+
+const initializeSentry = () => {
+  if (initialized || !SENTRY_DSN) return;
+  initialized = true;
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: __DEV__ ? "development" : "production",
+    sendDefaultPii: false,
+    // Errors only — no performance tracing, session replay or screenshots.
+    tracesSampleRate: 0,
+    beforeSend(event) {
+      if (event.request?.url) {
+        event.request.url = scrubUrl(event.request.url);
+      }
+      for (const exception of event.exception?.values ?? []) {
+        if (exception.value) {
+          exception.value = scrubUrl(exception.value);
+        }
+      }
+      if (event.message) {
+        event.message = scrubUrl(event.message);
+      }
+      return event;
+    },
+    beforeBreadcrumb(breadcrumb) {
+      if (typeof breadcrumb.data?.url === "string") {
+        breadcrumb.data.url = scrubUrl(breadcrumb.data.url);
+      }
+      if (breadcrumb.message) {
+        breadcrumb.message = scrubUrl(breadcrumb.message);
+      }
+      return breadcrumb;
+    },
+  });
+};
+
+/** Starts Sentry at app launch, unless the user has opted out. */
+export const initializeSentryIfConsented = () => {
+  if (hasSentryConsent()) {
+    initializeSentry();
+  }
+};
+
+/**
+ * Applies a consent change at runtime (called from updateSettings when the
+ * user flips the crash-report switch). Enabling starts the SDK immediately;
+ * disabling stops it for this session, and the startup gate keeps it off on
+ * the next launch.
+ */
+export const applySentryConsent = (enabled: boolean) => {
+  if (enabled) {
+    initializeSentry();
+  } else if (initialized) {
+    initialized = false;
+    Sentry.close();
+  }
+};

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -25,14 +25,41 @@ const hasSentryConsent = (): boolean => {
   }
 };
 
-// Jellyfin/Jellyseerr URLs carry credentials in the query string (api_key=...)
-// and the origin reveals the user's private server address, so both are
-// scrubbed from everything that leaves the app; the request path survives
-// because it's what makes an error debuggable.
+// Jellyfin/Jellyseerr URLs carry credentials in the query string (api_key=...,
+// the WebSocket's ApiKey=...) and the origin reveals the user's private server
+// address, so both are scrubbed from everything that leaves the app; the
+// request path survives because it's what makes an error debuggable.
 const scrubUrl = (value: string): string =>
   value
-    .replace(/(https?:\/\/[^\s"'?]+)\?[^\s"']*/g, "$1")
-    .replace(/https?:\/\/[^/\s"']+/g, "https://[server]");
+    .replace(/((?:https?|wss?):\/\/[^\s"'?]+)\?[^\s"']*/g, "$1")
+    .replace(/((?:https?|wss?):\/\/)[^/\s"']+/g, "$1[server]");
+
+// URLs can hide anywhere in an event, not just the fields with a `url` name:
+// console breadcrumbs keep raw console arguments in data.arguments, and
+// extra/contexts carry arbitrary payloads. So every string in the outgoing
+// object is scrubbed, however deeply nested.
+const scrubDeep = (value: unknown, seen = new WeakSet<object>()): unknown => {
+  if (typeof value === "string") {
+    return scrubUrl(value);
+  }
+  if (value !== null && typeof value === "object") {
+    if (seen.has(value)) {
+      return value;
+    }
+    seen.add(value);
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        value[i] = scrubDeep(value[i], seen);
+      }
+    } else {
+      const record = value as Record<string, unknown>;
+      for (const key of Object.keys(record)) {
+        record[key] = scrubDeep(record[key], seen);
+      }
+    }
+  }
+  return value;
+};
 
 const initializeSentry = () => {
   if (initialized || !SENTRY_DSN) return;
@@ -43,29 +70,9 @@ const initializeSentry = () => {
     sendDefaultPii: false,
     // Errors only — no performance tracing, session replay or screenshots.
     tracesSampleRate: 0,
-    beforeSend(event) {
-      if (event.request?.url) {
-        event.request.url = scrubUrl(event.request.url);
-      }
-      for (const exception of event.exception?.values ?? []) {
-        if (exception.value) {
-          exception.value = scrubUrl(exception.value);
-        }
-      }
-      if (event.message) {
-        event.message = scrubUrl(event.message);
-      }
-      return event;
-    },
-    beforeBreadcrumb(breadcrumb) {
-      if (typeof breadcrumb.data?.url === "string") {
-        breadcrumb.data.url = scrubUrl(breadcrumb.data.url);
-      }
-      if (breadcrumb.message) {
-        breadcrumb.message = scrubUrl(breadcrumb.message);
-      }
-      return breadcrumb;
-    },
+    beforeSend: (event) => scrubDeep(event) as typeof event,
+    beforeBreadcrumb: (breadcrumb) =>
+      scrubDeep(breadcrumb) as typeof breadcrumb,
   });
 };
 

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -1,5 +1,8 @@
 import * as Sentry from "@sentry/react-native";
-import { storage } from "@/utils/mmkv";
+import {
+  readStoredPluginSettings,
+  readStoredSettings,
+} from "@/utils/storedSettings";
 
 // Public Sentry DSN for org "streamyfin", project "react-native". A DSN only
 // allows submitting events, so shipping it in the client bundle is fine.
@@ -11,18 +14,17 @@ const SENTRY_DSN =
 let initialized = false;
 
 /**
- * Reads the user's crash-report preference straight from MMKV. This runs at
- * app startup, before Jotai hydrates settingsAtom, so it parses the persisted
- * settings JSON directly instead of going through useSettings. Reporting is
- * on by default; only an explicit opt-out disables it.
+ * Reads the crash-report preference straight from MMKV. This runs at app
+ * startup, before Jotai hydrates settingsAtom, so it parses the persisted
+ * blobs directly instead of going through useSettings. Reporting is on by
+ * default; an explicit user opt-out — or a server admin lock — disables it.
  */
 const hasSentryConsent = (): boolean => {
-  try {
-    const json = storage.getString("settings");
-    return json ? JSON.parse(json).sentryEnabled !== false : true;
-  } catch {
-    return true;
+  const lock = readStoredPluginSettings().sentryEnabled;
+  if (lock?.locked === true) {
+    return lock.value === true;
   }
+  return readStoredSettings().sentryEnabled !== false;
 };
 
 // Jellyfin/Jellyseerr URLs carry credentials in the query string (api_key=...,
@@ -64,16 +66,21 @@ const scrubDeep = (value: unknown, seen = new WeakSet<object>()): unknown => {
 const initializeSentry = () => {
   if (initialized || !SENTRY_DSN) return;
   initialized = true;
-  Sentry.init({
-    dsn: SENTRY_DSN,
-    environment: __DEV__ ? "development" : "production",
-    sendDefaultPii: false,
-    // Errors only — no performance tracing, session replay or screenshots.
-    tracesSampleRate: 0,
-    beforeSend: (event) => scrubDeep(event) as typeof event,
-    beforeBreadcrumb: (breadcrumb) =>
-      scrubDeep(breadcrumb) as typeof breadcrumb,
-  });
+  try {
+    Sentry.init({
+      dsn: SENTRY_DSN,
+      environment: __DEV__ ? "development" : "production",
+      sendDefaultPii: false,
+      // Errors only — no performance tracing, session replay or screenshots.
+      tracesSampleRate: 0,
+      beforeSend: (event) => scrubDeep(event) as typeof event,
+      beforeBreadcrumb: (breadcrumb) =>
+        scrubDeep(breadcrumb) as typeof breadcrumb,
+    });
+  } catch (error) {
+    initialized = false;
+    console.warn("Failed to initialize Sentry:", error);
+  }
 };
 
 /** Starts Sentry at app launch, unless the user has opted out. */
@@ -83,17 +90,27 @@ export const initializeSentryIfConsented = () => {
   }
 };
 
+// Consent changes run strictly in sequence: Sentry.close() tears the native
+// SDK down asynchronously, and an init racing ahead of an in-flight close
+// (off-then-on double tap) would be shut down by it once it lands.
+let lifecycle: Promise<unknown> = Promise.resolve();
+
 /**
- * Applies a consent change at runtime (called from updateSettings when the
- * user flips the crash-report switch). Enabling starts the SDK immediately;
- * disabling stops it for this session, and the startup gate keeps it off on
- * the next launch.
+ * Applies a consent change at runtime. Enabling starts the SDK; disabling
+ * stops it for this session, and the startup gate keeps it off on the next
+ * launch.
  */
 export const applySentryConsent = (enabled: boolean) => {
-  if (enabled) {
-    initializeSentry();
-  } else if (initialized) {
-    initialized = false;
-    Sentry.close();
-  }
+  lifecycle = lifecycle
+    .then(() => {
+      if (enabled) {
+        initializeSentry();
+      } else if (initialized) {
+        initialized = false;
+        return Sentry.close();
+      }
+    })
+    .catch((error) => {
+      console.warn("Failed to apply Sentry consent change:", error);
+    });
 };

--- a/utils/storedSettings.ts
+++ b/utils/storedSettings.ts
@@ -1,0 +1,29 @@
+import { storage } from "@/utils/mmkv";
+
+// Raw readers for the persisted settings blobs. They exist so early-startup
+// code (Sentry consent runs before Jotai hydrates) and the settings atoms
+// parse the same storage the same way — keep key names and parsing in sync
+// here, not in call sites.
+export const SETTINGS_KEY = "settings";
+export const PLUGIN_SETTINGS_KEY = "STREAMYFIN_PLUGIN_SETTINGS";
+
+export const readStoredSettings = (): Record<string, unknown> => {
+  try {
+    const json = storage.getString(SETTINGS_KEY);
+    return json ? JSON.parse(json) : {};
+  } catch {
+    return {};
+  }
+};
+
+export const readStoredPluginSettings = (): Record<
+  string,
+  { locked?: boolean; value?: unknown } | undefined
+> => {
+  try {
+    const json = storage.getString(PLUGIN_SETTINGS_KEY);
+    return json ? JSON.parse(json) : {};
+  } catch {
+    return {};
+  }
+};


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Add anonymous crash and error reporting via Sentry. It's on by default, the first-install intro sheet discloses it with a switch to turn it off, and there are toggles in mobile settings (Plugins group) and TV settings.

The config is errors only, no tracing, replay or PII. Query strings and origins are scrubbed from every URL before sending, so Jellyfin tokens and server addresses never leave the device. The SDK only starts when reporting is enabled (checked synchronously from MMKV at launch) and flipping the switch takes effect immediately.

The DSN in `utils/sentry.ts` is public by design, it can only submit events. Set `SENTRY_AUTH_TOKEN` in CI/EAS to get source maps and dSYMs uploaded for readable release stack traces. We should also declare Diagnostics/Crash Data in the App Store privacy label and Play data safety form before this ships.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-08-17 at 11 19 46" src="https://github.com/user-attachments/assets/6651a5bc-8f4e-4984-9269-8d8ec6d78dc4" />


## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Run a dev build, go to Settings > Plugins and verify "Crash reports" is on by default
2. Tap "Send test error to Sentry" (dev builds only) and check the event shows up in the Sentry project (verified on iOS)
3. Turn the toggle off, restart the app and verify nothing is sent
4. Re-show the intro (Settings > Intro) and verify the sheet has the crash report switch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional crash reporting to help diagnose app issues.
  * Added crash-reporting preferences during onboarding and in Settings, including TV controls.
  * Crash reports are anonymized and sensitive data is scrubbed.
  * Added a development-only option to send a test crash report.
  * Application logs can now provide additional context for troubleshooting.
* **Documentation**
  * Added translations explaining crash reporting, consent, and data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->