### PR TITLE
fix(login): honor a typed http:// scheme and time out server probes

### DIFF
--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -52,6 +52,24 @@ interface Server {
   address: string;
 }
 
+// Compact wire-level description of a failed request for the in-app log —
+// the user-facing alert only shows a translated message, which hides whether
+// the failure was DNS, TLS, a timeout or an HTTP status.
+const describeRequestError = (error: unknown): string => {
+  if (axios.isAxiosError(error)) {
+    return [
+      error.code,
+      error.response ? `HTTP ${error.response.status}` : "no response",
+      error.message,
+    ]
+      .filter(Boolean)
+      .join(", ");
+  }
+  return error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : String(error);
+};
+
 const initialApi = (() => {
   try {
     const token = storage.getString("token") || null;
@@ -415,6 +433,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
 
       if (!apiInstance?.basePath) throw new Error("Failed to connect");
 
+      writeInfoLog(`Server set: ${server.address}`);
       setApi(apiInstance);
       storage.set("serverUrl", server.address);
     },
@@ -487,6 +506,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       if (!api || !jellyfin) throw new Error("API not initialized");
 
       try {
+        writeInfoLog(`Login: authenticating against ${api.basePath}`);
         const auth = await api.authenticateUserByName(username, password);
 
         if (auth.data.AccessToken && auth.data.User) {
@@ -584,6 +604,9 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           }
         }
       } catch (error) {
+        writeErrorLog(
+          `Login failed against ${api.basePath}: ${describeRequestError(error)}`,
+        );
         if (axios.isAxiosError(error)) {
           switch (error.response?.status) {
             case 401:
@@ -745,7 +768,15 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       }
 
       // Authenticate with password
-      const auth = await apiInstance.authenticateUserByName(username, password);
+      writeInfoLog(`Login (saved server): authenticating against ${serverUrl}`);
+      const auth = await apiInstance
+        .authenticateUserByName(username, password)
+        .catch((error) => {
+          writeErrorLog(
+            `Login (saved server) failed against ${serverUrl}: ${describeRequestError(error)}`,
+          );
+          throw error;
+        });
 
       if (auth.data.AccessToken && auth.data.User) {
         // Clear React Query cache to prevent data from previous account lingering

--- a/utils/jellyfin/checkServer.test.ts
+++ b/utils/jellyfin/checkServer.test.ts
@@ -1,0 +1,274 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { normalizeCustomHeaders } from "@/utils/customHeaders/normalize";
+import { optionsWithOptionalHeaders } from "@/utils/customHeaders/optionalHeaders";
+import type { CustomHeader } from "@/utils/customHeaders/types";
+
+// checkServer pulls the two helpers through the barrel file, which also
+// re-exports modules with native dependencies (MMKV, SecureStore) — so the
+// barrel is replaced with just the real implementations of what it needs.
+mock.module("@/utils/customHeaders", () => ({
+  normalizeCustomHeaders,
+  optionsWithOptionalHeaders,
+}));
+
+// Bun's mock.module retroactively re-links every module already importing the
+// specifier, so a log mock must cover the module's full function surface —
+// a missing name breaks OTHER test files' modules that import it.
+const infoLogs: string[] = [];
+const errorLogs: string[] = [];
+mock.module("@/utils/log", () => ({
+  writeToLog: () => undefined,
+  writeInfoLog: (message: string) => {
+    infoLogs.push(message);
+  },
+  writeErrorLog: (message: string) => {
+    errorLogs.push(message);
+  },
+  writeDebugLog: () => undefined,
+  readFromLog: () => [],
+}));
+
+const savedHeaders = new Map<string, CustomHeader[]>();
+const persistedHeaders: Array<{ url: string; headers: CustomHeader[] }> = [];
+mock.module("@/utils/secureCredentials", () => ({
+  getServerCustomHeaders: (url: string) => savedHeaders.get(url) ?? [],
+  updateServerCustomHeaders: (url: string, headers: CustomHeader[]) => {
+    persistedHeaders.push({ url, headers });
+  },
+}));
+
+const { checkJellyfinServer, ServerTooOldError } = await import(
+  "./checkServer"
+);
+
+// --- fetch stub ------------------------------------------------------------
+
+interface FetchCall {
+  url: string;
+  init?: RequestInit;
+}
+
+let fetchCalls: FetchCall[] = [];
+let fetchImpl: (url: string, init?: RequestInit) => Promise<Response>;
+
+const realFetch = globalThis.fetch;
+globalThis.fetch = ((url: string, init?: RequestInit) => {
+  fetchCalls.push({ url, init });
+  return fetchImpl(url, init);
+}) as typeof fetch;
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+const okResponse = (body: Record<string, unknown> = {}): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({ Version: "10.10.7", ServerName: "Homelab", ...body }),
+  }) as Response;
+
+const statusResponse = (status: number): Response =>
+  ({ ok: false, status, json: async () => ({}) }) as Response;
+
+const networkError = () =>
+  Promise.reject(new TypeError("Network request failed"));
+
+/** Simulates a socket that accepts but never answers — only the caller's
+ * abort signal ends it, like a plain-HTTP port receiving a TLS handshake. */
+const hangUntilAborted = (init?: RequestInit) =>
+  new Promise<Response>((_, reject) => {
+    init?.signal?.addEventListener("abort", () => reject(new Error("Aborted")));
+  });
+
+/** Routes by protocol so tests can script https and http independently. */
+const routes = (impl: {
+  https?: (init?: RequestInit) => Promise<Response>;
+  http?: (init?: RequestInit) => Promise<Response>;
+}) => {
+  fetchImpl = (url, init) =>
+    url.startsWith("https://")
+      ? (impl.https ?? networkError)(init)
+      : (impl.http ?? networkError)(init);
+};
+
+beforeEach(() => {
+  fetchCalls = [];
+  infoLogs.length = 0;
+  errorLogs.length = 0;
+  savedHeaders.clear();
+  persistedHeaders.length = 0;
+  fetchImpl = networkError;
+});
+
+const header = (key: string, value: string): CustomHeader => ({
+  key,
+  value,
+  enabled: true,
+});
+
+// --- scheme handling -------------------------------------------------------
+// Regression tests for "local IP with a typed http:// won't connect": the
+// probe used to discard the typed scheme and always try https first, which
+// can hang against a plain-HTTP port on a LAN IP.
+
+describe("checkJellyfinServer scheme handling", () => {
+  test("a typed http:// is trusted as-is — no https probe is ever made", async () => {
+    routes({ http: async () => okResponse() });
+
+    const result = await checkJellyfinServer("http://192.168.1.10:8096");
+
+    expect(result).toEqual({
+      url: "http://192.168.1.10:8096",
+      name: "Homelab",
+    });
+    expect(fetchCalls.map((c) => c.url)).toEqual([
+      "http://192.168.1.10:8096/System/Info/Public",
+    ]);
+  });
+
+  test("a typed https:// is never silently downgraded to http", async () => {
+    routes({}); // everything unreachable
+
+    const result = await checkJellyfinServer("https://media.example.com");
+
+    expect(result).toBeUndefined();
+    expect(fetchCalls.map((c) => c.url)).toEqual([
+      "https://media.example.com/System/Info/Public",
+    ]);
+  });
+
+  test("schemeless input probes https first, then falls back to http", async () => {
+    routes({ https: networkError, http: async () => okResponse() });
+
+    const result = await checkJellyfinServer("192.168.1.10:8096");
+
+    expect(result).toEqual({
+      url: "http://192.168.1.10:8096",
+      name: "Homelab",
+    });
+    expect(fetchCalls.map((c) => c.url)).toEqual([
+      "https://192.168.1.10:8096/System/Info/Public",
+      "http://192.168.1.10:8096/System/Info/Public",
+    ]);
+  });
+
+  test("the typed scheme survives casing and surrounding whitespace", async () => {
+    routes({ http: async () => okResponse() });
+
+    const result = await checkJellyfinServer("  HTTP://192.168.1.10:8096  ");
+
+    expect(result?.url).toBe("http://192.168.1.10:8096");
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("port and path are preserved verbatim", async () => {
+    routes({ http: async () => okResponse() });
+
+    const result = await checkJellyfinServer("http://10.0.0.5:3000/jellyfin");
+
+    expect(result?.url).toBe("http://10.0.0.5:3000/jellyfin");
+    expect(fetchCalls[0]?.url).toBe(
+      "http://10.0.0.5:3000/jellyfin/System/Info/Public",
+    );
+  });
+});
+
+// --- probe robustness ------------------------------------------------------
+
+describe("checkJellyfinServer probing", () => {
+  test("a hanging candidate is aborted after the timeout instead of blocking the fallback", async () => {
+    routes({ https: hangUntilAborted, http: async () => okResponse() });
+
+    const result = await checkJellyfinServer(
+      "192.168.1.10:8096",
+      undefined,
+      20,
+    );
+
+    expect(result?.url).toBe("http://192.168.1.10:8096");
+    expect(
+      errorLogs.some((m) => m.includes("timed out after 20ms")),
+    ).toBeTrue();
+  });
+
+  test("a non-OK https answer (e.g. a gateway 403) still falls through to http", async () => {
+    routes({
+      https: async () => statusResponse(403),
+      http: async () => okResponse(),
+    });
+
+    const result = await checkJellyfinServer("192.168.1.10:8096");
+
+    expect(result?.url).toBe("http://192.168.1.10:8096");
+    expect(errorLogs.some((m) => m.includes("HTTP 403"))).toBeTrue();
+  });
+
+  test("returns undefined when nothing answers", async () => {
+    routes({});
+
+    const result = await checkJellyfinServer("192.168.1.10:8096");
+
+    expect(result).toBeUndefined();
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  test("a server older than 10.10 throws ServerTooOldError", async () => {
+    routes({ http: async () => okResponse({ Version: "10.8.13" }) });
+
+    await expect(
+      checkJellyfinServer("http://192.168.1.10:8096"),
+    ).rejects.toThrow(ServerTooOldError);
+  });
+
+  test("an unparseable version is given the benefit of the doubt", async () => {
+    routes({ http: async () => okResponse({ Version: "unstable" }) });
+
+    const result = await checkJellyfinServer("http://192.168.1.10:8096");
+
+    expect(result?.url).toBe("http://192.168.1.10:8096");
+  });
+});
+
+// --- custom headers --------------------------------------------------------
+
+describe("checkJellyfinServer custom headers", () => {
+  test("typed headers are sent with the probe and persisted only for the URL that answered", async () => {
+    routes({ https: networkError, http: async () => okResponse() });
+    const typed = [header("CF-Access-Client-Id", "abc")];
+
+    await checkJellyfinServer("192.168.1.10:8096", typed);
+
+    const httpCall = fetchCalls.find((c) => c.url.startsWith("http://"));
+    expect(
+      (httpCall?.init as { headers?: Record<string, string> })?.headers,
+    ).toEqual({ "CF-Access-Client-Id": "abc" });
+    expect(persistedHeaders).toEqual([
+      { url: "http://192.168.1.10:8096", headers: typed },
+    ]);
+  });
+
+  test("saved headers are reused when none are passed, and nothing is re-persisted", async () => {
+    savedHeaders.set("http://192.168.1.10:8096", [
+      header("CF-Access-Client-Id", "saved"),
+    ]);
+    routes({ http: async () => okResponse() });
+
+    await checkJellyfinServer("http://192.168.1.10:8096");
+
+    expect(
+      (fetchCalls[0]?.init as { headers?: Record<string, string> })?.headers,
+    ).toEqual({ "CF-Access-Client-Id": "saved" });
+    expect(persistedHeaders).toHaveLength(0);
+  });
+
+  test("headers that fail to reach the server are not persisted", async () => {
+    routes({});
+
+    await checkJellyfinServer("192.168.1.10:8096", [
+      header("CF-Access-Client-Id", "abc"),
+    ]);
+
+    expect(persistedHeaders).toHaveLength(0);
+  });
+});

--- a/utils/jellyfin/checkServer.ts
+++ b/utils/jellyfin/checkServer.ts
@@ -4,6 +4,7 @@ import {
   normalizeCustomHeaders,
   optionsWithOptionalHeaders,
 } from "@/utils/customHeaders";
+import { writeErrorLog, writeInfoLog } from "@/utils/log";
 import {
   getServerCustomHeaders,
   updateServerCustomHeaders,
@@ -23,6 +24,10 @@ export interface CheckedServer {
   name: string;
 }
 
+/** LAN probes either answer near-instantly or never; don't let one candidate
+ * hang the whole check. */
+const PROBE_TIMEOUT_MS = 10_000;
+
 /** Streamyfin needs 10.10 or newer. Anything unparseable is given the benefit
  * of the doubt — a server that answers but reports an odd version string must
  * not be locked out. */
@@ -33,8 +38,10 @@ function isSupportedVersion(version?: string | null): boolean {
 }
 
 /**
- * Probes a user-entered address for a Jellyfin server, https first, and
- * returns the URL that answered.
+ * Probes a user-entered address for a Jellyfin server and returns the URL
+ * that answered. An explicitly typed scheme is trusted as-is — a typed
+ * `http://` is never upgraded and a typed `https://` never silently
+ * downgraded; only schemeless input probes https first, http as fallback.
  *
  * Custom proxy headers are attached so a server behind Cloudflare Access (or a
  * similar gateway) can be reached at all. Passing `customHeaders` — even as an
@@ -47,20 +54,41 @@ function isSupportedVersion(version?: string | null): boolean {
 export async function checkJellyfinServer(
   input: string,
   customHeaders?: CustomHeader[],
+  probeTimeoutMs: number = PROBE_TIMEOUT_MS,
 ): Promise<CheckedServer | undefined> {
-  const host = input.trim().replace(/^https?:\/\//i, "");
+  const trimmed = input.trim();
+  const typedScheme = /^(https?):\/\//i.exec(trimmed)?.[1]?.toLowerCase();
+  const host = trimmed.replace(/^https?:\/\//i, "");
+  const protocols = typedScheme ? [typedScheme] : ["https", "http"];
+  writeInfoLog(
+    `Server check: input "${input}" -> probing host "${host}" via ${protocols.join(
+      ", ",
+    )} (custom headers: ${
+      customHeaders === undefined ? "saved" : customHeaders.length
+    })`,
+  );
 
-  for (const protocol of ["https", "http"]) {
+  for (const protocol of protocols) {
     const url = `${protocol}://${host}`;
+    // A dead HTTPS port on a LAN IP can leave the connection hanging instead
+    // of refusing it, which would block the http fallback forever.
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(), probeTimeoutMs);
     try {
       const headers = normalizeCustomHeaders(
         customHeaders ?? getServerCustomHeaders(url),
       );
       const response = await fetch(
         `${url}/System/Info/Public`,
-        optionsWithOptionalHeaders({ mode: "cors" as const }, headers),
+        optionsWithOptionalHeaders(
+          { mode: "cors" as const, signal: abort.signal },
+          headers,
+        ),
       );
-      if (!response.ok) continue;
+      if (!response.ok) {
+        writeErrorLog(`Server check: ${url} answered HTTP ${response.status}`);
+        continue;
+      }
 
       const data = (await response.json()) as PublicSystemInfo;
       if (!isSupportedVersion(data.Version)) throw new ServerTooOldError();
@@ -69,11 +97,26 @@ export async function checkJellyfinServer(
       if (customHeaders !== undefined) {
         updateServerCustomHeaders(url, customHeaders);
       }
+      writeInfoLog(
+        `Server check: ${url} OK — "${data.ServerName}" v${data.Version}`,
+      );
       return { url, name: data.ServerName || "" };
     } catch (e) {
       if (e instanceof ServerTooOldError) throw e;
+      writeErrorLog(
+        `Server check: ${url} failed — ${
+          abort.signal.aborted
+            ? `timed out after ${probeTimeoutMs}ms`
+            : e instanceof Error
+              ? `${e.name}: ${e.message}`
+              : String(e)
+        }`,
+      );
+    } finally {
+      clearTimeout(timeout);
     }
   }
 
+  writeErrorLog(`Server check: no protocol worked for "${host}"`);
   return undefined;
 }

--- a/utils/seriesTrackMemory.test.ts
+++ b/utils/seriesTrackMemory.test.ts
@@ -10,7 +10,16 @@ mock.module("react-native-mmkv", () => ({
     delete: (key: string) => void store.delete(key),
   }),
 }));
-mock.module("@/utils/log", () => ({ writeInfoLog: () => undefined }));
+// Bun's mock.module retroactively re-links every module already importing the
+// specifier, so a log mock must cover the module's full function surface —
+// a missing name breaks OTHER test files' modules that import it.
+mock.module("@/utils/log", () => ({
+  writeToLog: () => undefined,
+  writeInfoLog: () => undefined,
+  writeErrorLog: () => undefined,
+  writeDebugLog: () => undefined,
+  readFromLog: () => [],
+}));
 
 const { getSeriesTrackMemory, rememberSeriesTrackFromRow } = await import(
   "./seriesTrackMemory"


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Fix connecting to a server typed as `http://<lan-ip>:8096`. The probe threw away the typed scheme and always tried https first, with no timeout. A plain HTTP port often just sits on the TLS handshake instead of refusing it, so connecting could hang for a minute before the http fallback ran. A reverse proxy URL answers https right away, which is why only local IPs looked broken.

The probe now trusts a typed scheme (`http://` is never upgraded, `https://` never silently downgraded) and every candidate is aborted after 10s. I also added logging around connect and login so failures show up in Settings → Logs with the actual reason instead of the generic alert.

New tests lock in the scheme handling, the timeout fallback and the header persistence rules. I also widened the `@/utils/log` mock in `seriesTrackMemory.test.ts`. Bun's `mock.module` re-links modules in other test files, and the narrow mock broke the new ones.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. On the login screen, enter `http://<lan-ip>:8096` and connect. It should connect directly, with no https attempt first.
2. Enter the same address without a scheme. https is probed first, then http as fallback.
3. Enter a bogus address and check Settings → Logs for the `Server check:` lines showing each probe and its failure reason.
4. `bun test` runs the new `utils/jellyfin/checkServer.test.ts` suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Jellyfin server detection with HTTPS-to-HTTP fallback when no scheme is specified.
  - Preserved explicitly entered HTTP or HTTPS schemes during server checks.
  - Added timeout handling to prevent stalled server checks.
  - Improved handling and reporting of connection, authentication, and server-response failures.
  - Reused custom headers consistently during server verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->