### PR TITLE
feat(sentry): capture handled errors with global hooks and rich context

### DIFF
--- a/app/(auth)/(tabs)/(search)/index.tsx
+++ b/app/(auth)/(tabs)/(search)/index.tsx
@@ -45,6 +45,7 @@ import { useTVItemActionModal } from "@/hooks/useTVItemActionModal";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { useSettings } from "@/utils/atoms/settings";
 import { getIntegrationHeaders } from "@/utils/customHeaders";
+import { isAbortLikeError } from "@/utils/errors";
 import { eventBus } from "@/utils/eventBus";
 import { getPrimaryImageUrl } from "@/utils/jellyfin/image/getPrimaryImageUrl";
 import { MediaType } from "@/utils/jellyseerr/server/constants/media";
@@ -53,6 +54,7 @@ import type {
   PersonResult,
   TvResult,
 } from "@/utils/jellyseerr/server/models/Search";
+import { logAndCaptureError } from "@/utils/log";
 import { createStreamystatsApi } from "@/utils/streamystats";
 
 type SearchType = "Library" | "Discover";
@@ -227,9 +229,10 @@ export default function SearchPage() {
 
         return (response2.data.Items as BaseItemDto[]) || [];
       } catch (error) {
-        // Silently handle aborted requests
-        if (error instanceof Error && error.name === "AbortError") {
-          return [];
+        // Aborted requests are routine; anything else used to render as
+        // "no results" with no trace of the failure.
+        if (!isAbortLikeError(error)) {
+          logAndCaptureError("Search request failed", error);
         }
         return [];
       }
@@ -266,9 +269,8 @@ export default function SearchPage() {
 
         return (searchApi.data.Items as BaseItemDto[]) || [];
       } catch (error) {
-        // Silently handle aborted requests
-        if (error instanceof Error && error.name === "AbortError") {
-          return [];
+        if (!isAbortLikeError(error)) {
+          logAndCaptureError("Music search request failed", error);
         }
         return [];
       }

--- a/app/(auth)/(tabs)/_layout.tsx
+++ b/app/(auth)/(tabs)/_layout.tsx
@@ -32,6 +32,10 @@ const MusicPlaybackEngine = Platform.isTV
   ? () => null
   : require("@/components/music/MusicPlaybackEngine").MusicPlaybackEngine;
 
+// A crash inside a tab screen keeps the tab shell alive and offers a retry,
+// instead of blanking the whole app (the root layout has the outer boundary).
+export { RouteErrorBoundary as ErrorBoundary } from "@/components/RouteErrorBoundary";
+
 const { Navigator } = createNativeBottomTabNavigator();
 
 export const NativeTabs = withLayoutContext<

--- a/app/(auth)/(tabs)/_layout.tsx
+++ b/app/(auth)/(tabs)/_layout.tsx
@@ -32,8 +32,10 @@ const MusicPlaybackEngine = Platform.isTV
   ? () => null
   : require("@/components/music/MusicPlaybackEngine").MusicPlaybackEngine;
 
-// A crash inside a tab screen keeps the tab shell alive and offers a retry,
-// instead of blanking the whole app (the root layout has the outer boundary).
+// Catches render crashes inside the tab navigator before they bubble to the
+// root boundary. The fallback replaces the whole navigator (tab bar
+// included) and retry remounts it fresh, discarding navigation state — but
+// the session, providers, and root layout survive.
 export { RouteErrorBoundary as ErrorBoundary } from "@/components/RouteErrorBoundary";
 
 const { Navigator } = createNativeBottomTabNavigator();

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -68,7 +68,7 @@ import {
   getMpvAudioId,
   isImageBasedSubtitle,
 } from "@/utils/jellyfin/subtitleUtils";
-import { writeToLog } from "@/utils/log";
+import { logAndCaptureError, writeToLog } from "@/utils/log";
 import {
   isLocalSubtitleIndex,
   localSubtitleIndex,
@@ -356,7 +356,9 @@ export default function DirectPlayerPage() {
         setItem(fetchedItem);
         setItemStatus({ isLoading: false, isError: false });
       } catch (error) {
-        console.error("Failed to fetch item:", error);
+        logAndCaptureError("Failed to fetch item for player", error, {
+          offline,
+        });
         setItemStatus({ isLoading: false, isError: true });
       }
     };
@@ -509,14 +511,31 @@ export default function DirectPlayerPage() {
               audioMode: settings.audioTranscodeMode,
             }),
           });
-          if (!res) return null;
+          if (!res) {
+            // Without flipping isError this path used to leave the loading
+            // spinner up forever.
+            logAndCaptureError("getStreamUrl returned no stream", null, {
+              itemType: item.Type,
+              player: getActivePlayerType(settings),
+            });
+            setStreamStatus({ isLoading: false, isError: true });
+            return null;
+          }
           const { mediaSource, sessionId, url, requiredHttpHeaders } = res;
 
           if (!sessionId || !mediaSource || !url) {
+            logAndCaptureError("Stream response incomplete", null, {
+              itemType: item.Type,
+              player: getActivePlayerType(settings),
+              hasSessionId: !!sessionId,
+              hasMediaSource: !!mediaSource,
+              hasUrl: !!url,
+            });
             Alert.alert(
               t("player.error"),
               t("player.failed_to_get_stream_url"),
             );
+            setStreamStatus({ isLoading: false, isError: true });
             return null;
           }
           result = { mediaSource, sessionId, url, requiredHttpHeaders };
@@ -525,7 +544,11 @@ export default function DirectPlayerPage() {
         setStreamStatus({ isLoading: false, isError: false });
         return result;
       } catch (error) {
-        console.error("Failed to fetch stream:", error);
+        logAndCaptureError("Failed to fetch stream", error, {
+          itemType: item?.Type,
+          player: getActivePlayerType(settings),
+          offline,
+        });
         setStreamStatus({ isLoading: false, isError: true });
         return null;
       }
@@ -1600,7 +1623,25 @@ export default function DirectPlayerPage() {
                     t("player.error"),
                     t("player.an_error_occurred_while_playing_the_video"),
                   );
-                  writeToLog("ERROR", "Video Error", e.nativeEvent);
+                  // Attach the negotiation and decode facts that make a
+                  // player error diagnosable; the native probe is
+                  // best-effort and must never block the error path.
+                  void (async () => {
+                    const technical = await getTechnicalInfo().catch(
+                      () => ({}),
+                    );
+                    logAndCaptureError(
+                      "Video playback error",
+                      e.nativeEvent?.error ?? e.nativeEvent,
+                      {
+                        playMethod,
+                        transcodeReasons,
+                        container: stream?.mediaSource?.Container,
+                        offline,
+                        technical,
+                      },
+                    );
+                  })();
                 }}
                 onTracksReady={() => {
                   setTracksReady(true);

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -1625,11 +1625,16 @@ export default function DirectPlayerPage() {
                   );
                   // Attach the negotiation and decode facts that make a
                   // player error diagnosable; the native probe is
-                  // best-effort and must never block the error path.
+                  // best-effort and must never block or swallow the error
+                  // path — a wedged player may never settle the promise, so
+                  // it races a timeout.
                   void (async () => {
-                    const technical = await getTechnicalInfo().catch(
-                      () => ({}),
-                    );
+                    const technical = await Promise.race([
+                      getTechnicalInfo().catch(() => ({})),
+                      new Promise<Record<string, never>>((resolve) =>
+                        setTimeout(() => resolve({}), 2000),
+                      ),
+                    ]);
                     logAndCaptureError(
                       "Video playback error",
                       e.nativeEvent?.error ?? e.nativeEvent,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -40,7 +40,12 @@ import {
   registerBackgroundFetchAsyncSessions,
 } from "@/utils/background-tasks";
 import { getOrSetDeviceId } from "@/utils/device";
-import { isErrorReported, isExpectedError } from "@/utils/errors";
+import {
+  isAbortLikeError,
+  isConnectivityError,
+  isErrorReported,
+  isExpectedError,
+} from "@/utils/errors";
 import {
   LogProvider,
   writeErrorLog,
@@ -268,18 +273,23 @@ onlineManager.setEventListener((setOnline) => {
 });
 
 // Every React Query failure funnels through here instead of needing per-call
-// handlers. Skipped: anything while offline, plain connectivity failures (an
-// unreachable server is the user's environment, not an app bug), and 401s
-// (session expiry has its own interceptor in JellyfinProvider).
+// handlers. Skipped: anything while offline, aborted requests, connectivity
+// failures with no HTTP response — axios or fetch — (an unreachable server
+// is the user's environment, not an app bug), and 401s (session expiry has
+// its own interceptor in JellyfinProvider).
 const shouldReportDataError = (error: unknown): boolean => {
   if (!onlineManager.isOnline()) return false;
   if (isExpectedError(error) || isErrorReported(error)) return false;
-  if (isAxiosError(error)) {
-    if (!error.response) return false;
-    if (error.response.status === 401) return false;
-  }
+  if (isAbortLikeError(error) || isConnectivityError(error)) return false;
+  if (isAxiosError(error) && error.response?.status === 401) return false;
   return true;
 };
+
+// A persistently failing query refetches on every mount (staleTime 0), and
+// Sentry's Dedupe integration only drops an event identical to the
+// immediately-previous one — two alternating failing queries defeat it. One
+// report per (source, key, status) per session is enough.
+const reportedDataErrors = new Set<string>();
 
 const reportDataError = (
   source: "query" | "mutation",
@@ -287,6 +297,14 @@ const reportDataError = (
   error: unknown,
 ) => {
   if (!shouldReportDataError(error)) return;
+  const dedupeKey = [
+    source,
+    typeof key?.[0] === "string" ? key[0] : "?",
+    isAxiosError(error) ? (error.response?.status ?? "no-status") : "no-http",
+    error instanceof Error ? error.name : typeof error,
+  ].join("|");
+  if (reportedDataErrors.has(dedupeKey)) return;
+  if (reportedDataErrors.size < 200) reportedDataErrors.add(dedupeKey);
   Sentry.withScope((scope) => {
     // Only the key's first element (the query's name) is sent — later
     // elements can carry search text or item titles, and the name alone

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,8 +3,14 @@ import { ActionSheetProvider } from "@expo/react-native-action-sheet";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import NetInfo from "@react-native-community/netinfo";
 import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
-import { onlineManager, QueryClient } from "@tanstack/react-query";
+import {
+  MutationCache,
+  onlineManager,
+  QueryCache,
+  QueryClient,
+} from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import { isAxiosError } from "axios";
 import * as BackgroundTask from "expo-background-task";
 import * as Device from "expo-device";
 import { Image } from "expo-image";
@@ -34,6 +40,7 @@ import {
   registerBackgroundFetchAsyncSessions,
 } from "@/utils/background-tasks";
 import { getOrSetDeviceId } from "@/utils/device";
+import { isErrorReported, isExpectedError } from "@/utils/errors";
 import {
   LogProvider,
   writeErrorLog,
@@ -249,6 +256,10 @@ function RootLayout() {
 // Sentry.wrap is inert while the SDK is not initialized (crash reporting off).
 export default Sentry.wrap(RootLayout);
 
+// Render-phase crashes anywhere in the tree get a retry screen instead of a
+// blank app, and the error reaches Sentry with its component stack.
+export { RouteErrorBoundary as ErrorBoundary } from "@/components/RouteErrorBoundary";
+
 // Set up online manager for network-aware query behavior
 onlineManager.setEventListener((setOnline) => {
   return NetInfo.addEventListener((state) => {
@@ -256,7 +267,46 @@ onlineManager.setEventListener((setOnline) => {
   });
 });
 
+// Every React Query failure funnels through here instead of needing per-call
+// handlers. Skipped: anything while offline, plain connectivity failures (an
+// unreachable server is the user's environment, not an app bug), and 401s
+// (session expiry has its own interceptor in JellyfinProvider).
+const shouldReportDataError = (error: unknown): boolean => {
+  if (!onlineManager.isOnline()) return false;
+  if (isExpectedError(error) || isErrorReported(error)) return false;
+  if (isAxiosError(error)) {
+    if (!error.response) return false;
+    if (error.response.status === 401) return false;
+  }
+  return true;
+};
+
+const reportDataError = (
+  source: "query" | "mutation",
+  key: readonly unknown[] | undefined,
+  error: unknown,
+) => {
+  if (!shouldReportDataError(error)) return;
+  Sentry.withScope((scope) => {
+    let serializedKey: string | undefined;
+    try {
+      serializedKey = JSON.stringify(key)?.slice(0, 300);
+    } catch {
+      // Query keys are usually JSON-safe; a circular one just goes unlabeled.
+    }
+    scope.setContext("data_layer", { source, key: serializedKey });
+    Sentry.captureException(error);
+  });
+};
+
 const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error, query) => reportDataError("query", query.queryKey, error),
+  }),
+  mutationCache: new MutationCache({
+    onError: (error, _variables, _context, mutation) =>
+      reportDataError("mutation", mutation.options.mutationKey, error),
+  }),
   defaultOptions: {
     queries: {
       staleTime: 0, // Always stale - triggers background refetch on mount

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -288,13 +288,14 @@ const reportDataError = (
 ) => {
   if (!shouldReportDataError(error)) return;
   Sentry.withScope((scope) => {
-    let serializedKey: string | undefined;
-    try {
-      serializedKey = JSON.stringify(key)?.slice(0, 300);
-    } catch {
-      // Query keys are usually JSON-safe; a circular one just goes unlabeled.
-    }
-    scope.setContext("data_layer", { source, key: serializedKey });
+    // Only the key's first element (the query's name) is sent — later
+    // elements can carry search text or item titles, and the name alone
+    // already says which data path failed.
+    scope.setContext("data_layer", {
+      source,
+      key: typeof key?.[0] === "string" ? key[0] : undefined,
+      keyLength: key?.length,
+    });
     Sentry.captureException(error);
   });
 };

--- a/components/Chromecast.tsx
+++ b/components/Chromecast.tsx
@@ -8,6 +8,7 @@ import GoogleCast, {
   useMediaStatus,
   useRemoteMediaClient,
 } from "react-native-google-cast";
+import { logAndCaptureError } from "@/utils/log";
 import { HeaderButton, type HeaderButtonProps } from "./common/HeaderButton";
 import { HeaderIcon } from "./common/HeaderIcon";
 
@@ -33,7 +34,10 @@ export function Chromecast(props: Props) {
       }
 
       await discoveryManager.startDiscovery();
-    })();
+    })().catch((error) => {
+      // Previously an unhandled rejection: cast devices just never appear.
+      logAndCaptureError("Chromecast discovery failed to start", error);
+    });
   }, [client, devices, castDevice, sessionManager, discoveryManager]);
 
   return (

--- a/components/PlayButton.tsx
+++ b/components/PlayButton.tsx
@@ -43,6 +43,7 @@ import {
   getExternalSubtitleUrl,
   isExternalSubtitle,
 } from "@/utils/jellyfin/subtitleUtils";
+import { logAndCaptureError } from "@/utils/log";
 import type { PlayRequest } from "@/utils/nativePlayer/playRequest";
 import { formatDuration, runtimeTicksToMinutes } from "@/utils/time";
 import { chromecast } from "../utils/profiles/chromecast";
@@ -317,8 +318,10 @@ export const PlayButton: React.FC<Props> = ({
                           client
                             .setActiveTrackIds([activeSubtitle.id])
                             .catch((e) => {
-                              console.error(
-                                "Chromecast setActiveTrackIds failed:",
+                              // Subtitles are silently missing on the cast
+                              // device when this fails.
+                              logAndCaptureError(
+                                "Chromecast setActiveTrackIds failed",
                                 e,
                               );
                             });
@@ -330,14 +333,14 @@ export const PlayButton: React.FC<Props> = ({
                         CastContext.showExpandedControls();
                       })
                       .catch((e) => {
-                        console.error("Chromecast loadMedia failed:", e);
+                        logAndCaptureError("Chromecast loadMedia failed", e);
                         Alert.alert(
                           t("player.client_error"),
                           t("player.chromecast_playback_failed"),
                         );
                       });
                   } catch (e) {
-                    console.error("Chromecast stream setup failed:", e);
+                    logAndCaptureError("Chromecast stream setup failed", e);
                     Alert.alert(
                       t("player.client_error"),
                       t("player.could_not_create_stream_for_chromecast"),

--- a/components/RouteErrorBoundary.tsx
+++ b/components/RouteErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import * as Sentry from "@sentry/react-native";
+import type { ErrorBoundaryProps } from "expo-router";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Platform, Pressable, Text, View } from "react-native";
+
+/**
+ * Fallback UI for render-phase crashes, exported as `ErrorBoundary` from
+ * route layouts so expo-router mounts it instead of a blank screen. Kept
+ * free of app providers and styling systems (plain RN primitives, inline
+ * styles, no TVTypography) so it still renders when the crash happened
+ * inside a provider or the style pipeline itself.
+ */
+export function RouteErrorBoundary({ error, retry }: ErrorBoundaryProps) {
+  const { t } = useTranslation();
+  const [focused, setFocused] = useState(false);
+
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: "black",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 32,
+        gap: 16,
+      }}
+    >
+      <Text
+        allowFontScaling={false}
+        style={{
+          color: "white",
+          fontSize: Platform.isTV ? 32 : 18,
+          fontWeight: "600",
+        }}
+      >
+        {t("common.something_went_wrong")}
+      </Text>
+      {error?.message ? (
+        <Text
+          allowFontScaling={false}
+          numberOfLines={4}
+          style={{
+            color: "#9ca3af",
+            fontSize: Platform.isTV ? 22 : 13,
+            textAlign: "center",
+            maxWidth: 600,
+          }}
+        >
+          {error.message}
+        </Text>
+      ) : null}
+      <Pressable
+        onPress={retry}
+        hasTVPreferredFocus
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        style={({ pressed }) => ({
+          marginTop: 8,
+          paddingHorizontal: Platform.isTV ? 40 : 28,
+          paddingVertical: Platform.isTV ? 16 : 12,
+          borderRadius: 999,
+          backgroundColor: "white",
+          opacity: pressed ? 0.7 : focused || !Platform.isTV ? 1 : 0.8,
+        })}
+      >
+        <Text
+          allowFontScaling={false}
+          style={{
+            color: "black",
+            fontSize: Platform.isTV ? 24 : 15,
+            fontWeight: "600",
+          }}
+        >
+          {t("home.retry")}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/components/jellyseerr/JellyseerrAutoLogin.tsx
+++ b/components/jellyseerr/JellyseerrAutoLogin.tsx
@@ -4,7 +4,7 @@ import { JellyseerrApi, useJellyseerr } from "@/hooks/useJellyseerr";
 import { userAtom } from "@/providers/JellyfinProvider";
 import { useSettings } from "@/utils/atoms/settings";
 import { getIntegrationHeaders } from "@/utils/customHeaders";
-import { writeErrorLog, writeInfoLog } from "@/utils/log";
+import { writeInfoLog, writeToLog } from "@/utils/log";
 import { storage } from "@/utils/mmkv";
 import { getJellyseerrPassword } from "@/utils/secureCredentials";
 
@@ -69,7 +69,10 @@ export const JellyseerrAutoLogin: React.FC = () => {
       } catch (e) {
         // Silent on purpose: this runs unprompted at launch, so a failure
         // belongs in the log rather than as a toast over the home screen.
-        writeErrorLog(
+        // WARN keeps it out of Sentry too — server-side failures are already
+        // captured once by the JellyseerrApi response interceptor.
+        writeToLog(
+          "WARN",
           `Jellyseerr auto-login failed: ${e instanceof Error ? e.message : e}`,
         );
       }

--- a/hooks/useJellyseerr.ts
+++ b/hooks/useJellyseerr.ts
@@ -449,7 +449,9 @@ export class JellyseerrApi {
           // Jellyseerr surface. The response body stays in the local log.
           logAndCaptureError("Jellyseerr response error", error, {
             status: error.response.status,
-            url: error.config?.url,
+            // Relative URLs escape the scheme-anchored scrubber, and search
+            // requests put the user's typed query in the query string.
+            url: error.config?.url?.split("?")[0],
           });
           writeToLog("DEBUG", "Jellyseerr response body", error.response.data);
         } else {

--- a/hooks/useJellyseerr.ts
+++ b/hooks/useJellyseerr.ts
@@ -117,6 +117,38 @@ export type TestResult =
       isValid: false;
     };
 
+// The response interceptor fires once per axios attempt, and React Query
+// retries a failing request up to 3× — without a throttle one user-visible
+// failure emits several Sentry events. 401/403 are excluded entirely:
+// expired cookies are routine and self-heal via auto-login.
+const recentJellyseerrReports = new Map<string, number>();
+const JELLYSEERR_REPORT_THROTTLE_MS = 60_000;
+
+const shouldReportJellyseerrError = (
+  status: number | undefined,
+  path: string | undefined,
+): boolean => {
+  if (status === 401 || status === 403) return false;
+  const key = `${status}|${path}`;
+  const now = Date.now();
+  const last = recentJellyseerrReports.get(key);
+  if (last !== undefined && now - last < JELLYSEERR_REPORT_THROTTLE_MS) {
+    return false;
+  }
+  recentJellyseerrReports.set(key, now);
+  return true;
+};
+
+const truncateForLog = (value: unknown): string | undefined => {
+  if (value === null || value === undefined) return undefined;
+  try {
+    const text = typeof value === "string" ? value : JSON.stringify(value);
+    return text.slice(0, 500);
+  } catch {
+    return String(value).slice(0, 500);
+  }
+};
+
 export class JellyseerrApi {
   axios: AxiosInstance;
   /** Proxy auth headers for a Jellyseerr behind an access gateway. */
@@ -444,20 +476,34 @@ export class JellyseerrApi {
         return response;
       },
       (error: AxiosError) => {
-        if (error.response) {
+        const status = error.response?.status;
+        const path = error.config?.url?.split("?")[0];
+        if (error.response && shouldReportJellyseerrError(status, path)) {
           // A real server response — one capture covers the entire
-          // Jellyseerr surface. The response body stays in the local log.
+          // Jellyseerr surface. 401/403 are excluded (expired cookies are
+          // routine and self-heal via auto-login), and repeats of the same
+          // status+path are throttled: this fires once per axios attempt,
+          // so React Query retries would otherwise emit several events for
+          // one user-visible failure.
           logAndCaptureError("Jellyseerr response error", error, {
-            status: error.response.status,
+            status,
             // Relative URLs escape the scheme-anchored scrubber, and search
             // requests put the user's typed query in the query string.
-            url: error.config?.url?.split("?")[0],
+            url: path,
           });
-          writeToLog("DEBUG", "Jellyseerr response body", error.response.data);
-        } else {
+        } else if (!error.response) {
           // No response = connectivity; routine when away from the server,
           // so keep it out of Sentry but in the local log trail.
           writeToLog("WARN", `Jellyseerr unreachable: ${error.toString()}`);
+        }
+        if (error.response) {
+          // Body stays local-only and truncated — a proxy's HTML error page
+          // must not bloat the 100-entry log blob.
+          writeToLog(
+            "DEBUG",
+            "Jellyseerr response body",
+            truncateForLog(error.response.data),
+          );
         }
         if (error.response?.status === 403) {
           clearJellyseerrStorageData();

--- a/hooks/useJellyseerr.ts
+++ b/hooks/useJellyseerr.ts
@@ -51,7 +51,7 @@ import type {
   SeasonWithEpisodes,
   TvDetails,
 } from "@/utils/jellyseerr/server/models/Tv";
-import { writeErrorLog } from "@/utils/log";
+import { logAndCaptureError, writeErrorLog, writeToLog } from "@/utils/log";
 import { isVersionBelow } from "@/utils/serverUrl/semver";
 
 interface SearchParams {
@@ -444,10 +444,19 @@ export class JellyseerrApi {
         return response;
       },
       (error: AxiosError) => {
-        writeErrorLog(
-          `Jellyseerr response error\nerror: ${error.toString()}\nurl: ${error?.config?.url}`,
-          error.response?.data,
-        );
+        if (error.response) {
+          // A real server response — one capture covers the entire
+          // Jellyseerr surface. The response body stays in the local log.
+          logAndCaptureError("Jellyseerr response error", error, {
+            status: error.response.status,
+            url: error.config?.url,
+          });
+          writeToLog("DEBUG", "Jellyseerr response body", error.response.data);
+        } else {
+          // No response = connectivity; routine when away from the server,
+          // so keep it out of Sentry but in the local log trail.
+          writeToLog("WARN", `Jellyseerr unreachable: ${error.toString()}`);
+        }
         if (error.response?.status === 403) {
           clearJellyseerrStorageData();
         }
@@ -480,7 +489,10 @@ export class JellyseerrApi {
         return config;
       },
       (error) => {
-        console.error("Jellyseerr request error", error);
+        logAndCaptureError("Jellyseerr request setup failed", error);
+        // Without re-rejecting, axios would proceed with an undefined config
+        // and fail somewhere unrelated.
+        return Promise.reject(error);
       },
     );
   }

--- a/hooks/useMarkAsPlayed.ts
+++ b/hooks/useMarkAsPlayed.ts
@@ -1,6 +1,7 @@
 import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import { logAndCaptureError } from "@/utils/log";
 import { useHaptic } from "./useHaptic";
 import { usePlaybackManager } from "./usePlaybackManager";
 import { useInvalidatePlaybackProgressCache } from "./useRevalidatePlaybackProgressCache";
@@ -50,7 +51,13 @@ export const useMarkAsPlayed = (items: BaseItemDto[]) => {
             return played ? markItemPlayed(item.Id) : markItemUnplayed(item.Id);
           }),
         );
-      } catch (_error) {
+      } catch (error) {
+        // The optimistic update is rolled back, so without a report this
+        // user action fails with zero trace anywhere.
+        logAndCaptureError("Marking item played/unplayed failed", error, {
+          played,
+          itemCount: itemIds.length,
+        });
         for (const { queries } of previousQueriesByItemId) {
           for (const [queryKey, data] of queries) {
             queryClient.setQueryData(queryKey, data);

--- a/hooks/useMusicCast.ts
+++ b/hooks/useMusicCast.ts
@@ -10,6 +10,7 @@ import CastContext, {
 } from "react-native-google-cast";
 import { getAudioContentType } from "@/utils/jellyfin/audio/getAudioContentType";
 import { getAudioStreamUrl } from "@/utils/jellyfin/audio/getAudioStreamUrl";
+import { logAndCaptureError } from "@/utils/log";
 
 interface UseMusicCastOptions {
   api: Api | null;
@@ -124,7 +125,9 @@ export const useMusicCast = ({ api, userId }: UseMusicCastOptions) => {
 
         return true;
       } catch (error) {
-        console.error("Failed to cast music queue:", error);
+        // Returning false gives the caller no user feedback either, so this
+        // is the only trace that casting failed.
+        logAndCaptureError("Casting music queue failed", error);
         return false;
       }
     },

--- a/hooks/usePlayMedia.ts
+++ b/hooks/usePlayMedia.ts
@@ -10,6 +10,7 @@ import {
   VideoPlayer,
 } from "@/utils/atoms/settings";
 import { shuffleQueueAtom } from "@/utils/atoms/shuffleQueue";
+import { writeErrorLog } from "@/utils/log";
 import {
   type PlayRequest,
   toDirectPlayerQuery,
@@ -63,8 +64,14 @@ export const usePlayMedia = () => {
       }
 
       // Never stack the JS route under a still-presented native player (a
-      // failed in-place swap keeps the old native session on screen).
-      if (isNativePlayerPresented()) return;
+      // failed in-place swap keeps the old native session on screen). From
+      // the user's side this is a Play tap that did nothing, so record it.
+      if (isNativePlayerPresented()) {
+        writeErrorLog(
+          "Play request dropped: native player still presented after failed present",
+        );
+        return;
+      }
 
       router.push(`/player/direct-player?${toDirectPlayerQuery(req)}`);
     },

--- a/hooks/useTVItemActionModal.ts
+++ b/hooks/useTVItemActionModal.ts
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Alert } from "react-native";
 import { usePlaybackManager } from "@/hooks/usePlaybackManager";
 import { useInvalidatePlaybackProgressCache } from "@/hooks/useRevalidatePlaybackProgressCache";
+import { logAndCaptureError } from "@/utils/log";
 
 export const useTVItemActionModal = () => {
   const { t } = useTranslation();
@@ -54,8 +55,12 @@ export const useTVItemActionModal = () => {
               } else {
                 await markItemUnplayed(item.Id);
               }
-            } catch {
-              // Revert on failure
+            } catch (error) {
+              // Revert on failure — and report it, since the user gets no
+              // other signal that the action didn't stick.
+              logAndCaptureError("Marking item played/unplayed failed", error, {
+                played: !isPlayed,
+              });
               queryClient.invalidateQueries({
                 queryKey: ["item", item.Id],
               });

--- a/hooks/useTwoWaySync.ts
+++ b/hooks/useTwoWaySync.ts
@@ -2,6 +2,7 @@ import { getItemsApi, getUserLibraryApi } from "@jellyfin/sdk/lib/utils/api";
 import { AxiosError } from "axios";
 import { useAtomValue } from "jotai";
 import { useDownload } from "@/providers/DownloadProvider";
+import { logAndCaptureError } from "@/utils/log";
 import { apiAtom, userAtom } from "../providers/JellyfinProvider";
 import { useNetworkStatus } from "./useNetworkStatus";
 
@@ -41,8 +42,8 @@ export const useTwoWaySync = () => {
         // A 404 means the item was deleted server-side while still downloaded
         // locally, there is nothing to sync and no error worth surfacing.
         if (!(error instanceof AxiosError && error.response?.status === 404)) {
-          console.error(
-            "Failed to fetch remote item during syncPlaybackState:",
+          logAndCaptureError(
+            "Fetching remote item during playback sync failed",
             error,
           );
         }
@@ -90,8 +91,10 @@ export const useTwoWaySync = () => {
           },
         });
       } catch (error) {
-        console.error(
-          "Failed to update item user data during syncPlaybackState:",
+        // Offline watch progress silently never reaches the server when
+        // this fails, so report it.
+        logAndCaptureError(
+          "Pushing offline playback state to server failed",
           error,
         );
         // The write never reached the server, so the caller must not treat

--- a/modules/background-downloader/ios/BackgroundDownloaderModule.swift
+++ b/modules/background-downloader/ios/BackgroundDownloaderModule.swift
@@ -505,6 +505,35 @@ public class BackgroundDownloaderModule: Module {
       return
     }
 
+    // A non-2xx response still "completes" the transfer, but the file on disk
+    // is the server's error body (auth page, JSON error), not the media.
+    // Recording it as a successful download only fails much later, at
+    // playback, so surface it as a download error here. (Android already
+    // rejects these in OkHttpDownloadManager.)
+    if let httpResponse = downloadTask.response as? HTTPURLResponse,
+       !(200...299).contains(httpResponse.statusCode) {
+      backgroundDownloaderLog.error(
+        "Task \(taskId) finished with HTTP \(httpResponse.statusCode); treating as failure"
+      )
+      finishLiveActivity(taskId: taskId, state: .failed)
+
+      var payload: [String: Any] = [
+        "taskId": taskId,
+        "error": "Server responded with HTTP \(httpResponse.statusCode)"
+      ]
+      if let itemId = taskInfo.metadata?.itemId {
+        payload["itemId"] = itemId
+      }
+      sendEvent("onDownloadError", payload)
+
+      downloadTasks.removeValue(forKey: taskId)
+      lastProgressTime.removeValue(forKey: taskId)
+      persistTasksLocked()
+
+      processNextInQueueSafelyLocked()
+      return
+    }
+
     let fileManager = FileManager.default
 
     do {

--- a/providers/Downloads/hooks/useDownloadEventHandlers.ts
+++ b/providers/Downloads/hooks/useDownloadEventHandlers.ts
@@ -8,6 +8,7 @@ import type {
   DownloadStartedEvent,
 } from "@/modules";
 import { BackgroundDownloader } from "@/modules";
+import { logAndCaptureError } from "@/utils/log";
 import {
   getNotificationContent,
   sendDownloadNotification,
@@ -230,7 +231,11 @@ export function useDownloadEventHandlers({
             removeProcess(itemId);
           }, 2000);
         } catch (error) {
-          console.error("Error handling download completion:", error);
+          // A download that finished on disk gets discarded here — one of
+          // the worst silent failures the app has, so always report it.
+          logAndCaptureError("Handling download completion failed", error, {
+            itemType: getPendingDownload(itemId)?.item?.Type,
+          });
           removePendingDownload(itemId);
           updateProcess(itemId, { status: "error" });
           clearSpeedData(itemId);
@@ -252,7 +257,9 @@ export function useDownloadEventHandlers({
         const record = getPendingDownload(itemId);
         if (!record) return;
 
-        console.error(`Download error for ${itemId}:`, event.error);
+        logAndCaptureError("Download failed", event.error, {
+          itemType: record.item?.Type,
+        });
 
         removePendingDownload(itemId);
         updateProcess(itemId, { status: "error" });

--- a/providers/Downloads/hooks/useDownloadEventHandlers.ts
+++ b/providers/Downloads/hooks/useDownloadEventHandlers.ts
@@ -8,7 +8,7 @@ import type {
   DownloadStartedEvent,
 } from "@/modules";
 import { BackgroundDownloader } from "@/modules";
-import { logAndCaptureError } from "@/utils/log";
+import { logAndCaptureError, writeToLog } from "@/utils/log";
 import {
   getNotificationContent,
   sendDownloadNotification,
@@ -233,8 +233,10 @@ export function useDownloadEventHandlers({
         } catch (error) {
           // A download that finished on disk gets discarded here — one of
           // the worst silent failures the app has, so always report it.
+          // (`record` from the top of the handler — the pending store may
+          // already have been cleared by finalizePendingDownload.)
           logAndCaptureError("Handling download completion failed", error, {
-            itemType: getPendingDownload(itemId)?.item?.Type,
+            itemType: record.item?.Type,
           });
           removePendingDownload(itemId);
           updateProcess(itemId, { status: "error" });
@@ -257,9 +259,21 @@ export function useDownloadEventHandlers({
         const record = getPendingDownload(itemId);
         if (!record) return;
 
-        logAndCaptureError("Download failed", event.error, {
-          itemType: record.item?.Type,
-        });
+        // Native error payloads are plain strings, so connectivity failures
+        // (walking out of Wi-Fi range is the normal downloads scenario) are
+        // classified by keyword and kept out of Sentry; the scrubbers redact
+        // any scheme-less host/IP the native message embeds.
+        if (
+          /connect|network|internet|offline|time.?out|timed out|unreachable|resolve|dns|route/i.test(
+            event.error,
+          )
+        ) {
+          writeToLog("WARN", "Download failed (connectivity)", event.error);
+        } else {
+          logAndCaptureError("Download failed", event.error, {
+            itemType: record.item?.Type,
+          });
+        }
 
         removePendingDownload(itemId);
         updateProcess(itemId, { status: "error" });

--- a/providers/Downloads/hooks/useDownloadOperations.ts
+++ b/providers/Downloads/hooks/useDownloadOperations.ts
@@ -13,6 +13,7 @@ import { BackgroundDownloader } from "@/modules";
 import { getJellyfinHeadersForUrl } from "@/utils/customHeaders";
 import { getOrSetDeviceId } from "@/utils/device";
 import useDownloadHelper, { estimateDownloadSize } from "@/utils/download";
+import { logAndCaptureError } from "@/utils/log";
 import { downloadAdditionalAssets } from "../additionalDownloads";
 import {
   clearAllDownloadedItems,
@@ -204,7 +205,9 @@ export function useDownloadOperations({
           }),
         );
       } catch (error) {
-        console.error("Failed to start download:", error);
+        logAndCaptureError("Failed to start download", error, {
+          itemType: item.Type,
+        });
         if (item.Id) {
           removePendingDownload(item.Id);
           removeProcess(item.Id);

--- a/providers/Downloads/hooks/useDownloadReconciliation.ts
+++ b/providers/Downloads/hooks/useDownloadReconciliation.ts
@@ -4,6 +4,7 @@ import { Platform } from "react-native";
 import type { ActiveDownload } from "@/modules";
 import { BackgroundDownloader } from "@/modules";
 import { getHeadersForUrl } from "@/utils/customHeaders";
+import { logAndCaptureError } from "@/utils/log";
 import {
   finalizePendingDownload,
   getPendingDownload,
@@ -70,10 +71,11 @@ async function reEnqueue(
     }
     return true;
   } catch (error) {
-    console.warn(
-      `[RECONCILE] Re-enqueue failed for ${record.item.Name}:`,
-      error,
-    );
+    // Dropping the record permanently loses the download without any user
+    // signal, so report it.
+    logAndCaptureError("Re-enqueueing interrupted download failed", error, {
+      itemType: record.item?.Type,
+    });
     removePendingDownload(record.itemId);
     return false;
   }
@@ -111,7 +113,9 @@ export function useDownloadReconciliation({
       try {
         active = await BackgroundDownloader.getActiveDownloads();
       } catch (error) {
-        console.warn("[RECONCILE] Failed to query native downloads:", error);
+        // An empty list here makes the loop below misclassify every
+        // in-flight download as lost or completed.
+        logAndCaptureError("Querying native downloads failed", error);
       }
       const nativeByItemId = new Map(
         active

--- a/providers/Downloads/pendingDownloads.ts
+++ b/providers/Downloads/pendingDownloads.ts
@@ -5,6 +5,7 @@ import type {
 import { File, Paths } from "expo-file-system";
 import type { Bitrate } from "@/components/BitrateSelector";
 import type { DownloadActivityMetadata } from "@/modules/background-downloader";
+import { logAndCaptureError } from "@/utils/log";
 import { storage } from "@/utils/mmkv";
 import { addDownloadedItem } from "./database";
 import type { DownloadedItem, MediaTimeSegment, TrickPlayData } from "./types";
@@ -49,12 +50,22 @@ export interface PendingDownload {
 
 const PENDING_DOWNLOADS_KEY = "downloads.pending.v1.json";
 
+// readAll runs on every accessor call, so report corruption only once per
+// session instead of flooding the log and Sentry.
+let reportedCorruptStore = false;
+
 function readAll(): Record<string, PendingDownload> {
   const raw = storage.getString(PENDING_DOWNLOADS_KEY);
   if (!raw) return {};
   try {
     return JSON.parse(raw) as Record<string, PendingDownload>;
-  } catch {
+  } catch (error) {
+    // Falling back to {} forgets every in-flight download, so make the
+    // corruption visible instead of losing them silently.
+    if (!reportedCorruptStore) {
+      reportedCorruptStore = true;
+      logAndCaptureError("Pending-downloads store is corrupt", error);
+    }
     return {};
   }
 }

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -28,8 +28,14 @@ import { JellyseerrApi, useJellyseerr } from "@/hooks/useJellyseerr";
 import { settingsAtom, useSettings } from "@/utils/atoms/settings";
 import { getIntegrationHeaders } from "@/utils/customHeaders";
 import { getOrSetDeviceId } from "@/utils/device";
+import { markExpectedError } from "@/utils/errors";
 import { createApiWithCustomHeaders } from "@/utils/jellyfin/createApi";
-import { writeErrorLog, writeInfoLog } from "@/utils/log";
+import {
+  logAndCaptureError,
+  writeErrorLog,
+  writeInfoLog,
+  writeToLog,
+} from "@/utils/log";
 import { storage } from "@/utils/mmkv";
 import {
   type AccountSecurityType,
@@ -604,31 +610,51 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           }
         }
       } catch (error) {
-        writeErrorLog(
+        // Wrong credentials are user input, not an app defect — WARN keeps
+        // them out of Sentry; anything else becomes an event.
+        writeToLog(
+          axios.isAxiosError(error) && error.response?.status === 401
+            ? "WARN"
+            : "ERROR",
           `Login failed against ${api.basePath}: ${describeRequestError(error)}`,
         );
         if (axios.isAxiosError(error)) {
+          // The writeErrorLog above already reported the technical failure;
+          // what's thrown from here is only a translated message for the
+          // login form, so it's marked expected to keep it out of Sentry.
           switch (error.response?.status) {
             case 401:
-              throw new Error(t("login.invalid_username_or_password"));
+              throw markExpectedError(
+                new Error(t("login.invalid_username_or_password")),
+              );
             case 403:
-              throw new Error(
-                t("login.user_does_not_have_permission_to_log_in"),
+              throw markExpectedError(
+                new Error(t("login.user_does_not_have_permission_to_log_in")),
               );
             case 408:
-              throw new Error(
-                t("login.server_is_taking_too_long_to_respond_try_again_later"),
+              throw markExpectedError(
+                new Error(
+                  t(
+                    "login.server_is_taking_too_long_to_respond_try_again_later",
+                  ),
+                ),
               );
             case 429:
-              throw new Error(
-                t("login.server_received_too_many_requests_try_again_later"),
+              throw markExpectedError(
+                new Error(
+                  t("login.server_received_too_many_requests_try_again_later"),
+                ),
               );
             case 500:
-              throw new Error(t("login.there_is_a_server_error"));
+              throw markExpectedError(
+                new Error(t("login.there_is_a_server_error")),
+              );
             default:
-              throw new Error(
-                t(
-                  "login.an_unexpected_error_occurred_did_you_enter_the_correct_url",
+              throw markExpectedError(
+                new Error(
+                  t(
+                    "login.an_unexpected_error_occurred_did_you_enter_the_correct_url",
+                  ),
                 ),
               );
           }
@@ -720,12 +746,12 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
             error.response?.status === 403
           ) {
             await deleteAccountCredential(serverUrl, userId);
-            throw new Error(t("server.session_expired"));
+            throw markExpectedError(new Error(t("server.session_expired")));
           }
 
           // Network error - server not reachable (no response means server didn't respond)
           if (!error.response) {
-            throw new Error(t("home.server_unreachable"));
+            throw markExpectedError(new Error(t("home.server_unreachable")));
           }
         }
 
@@ -736,7 +762,7 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
             error.message.toLowerCase().includes("econnrefused") ||
             error.message.toLowerCase().includes("timeout"))
         ) {
-          throw new Error(t("home.server_unreachable"));
+          throw markExpectedError(new Error(t("home.server_unreachable")));
         }
 
         throw error;
@@ -772,7 +798,10 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
       const auth = await apiInstance
         .authenticateUserByName(username, password)
         .catch((error) => {
-          writeErrorLog(
+          writeToLog(
+            axios.isAxiosError(error) && error.response?.status === 401
+              ? "WARN"
+              : "ERROR",
             `Login (saved server) failed against ${serverUrl}: ${describeRequestError(error)}`,
           );
           throw error;
@@ -936,7 +965,9 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
             });
         }
       } catch (e) {
-        console.error(e);
+        // A failure here silently drops the user into an unauthenticated
+        // state at launch, so it must be visible in crash reports.
+        logAndCaptureError("Jellyfin startup initialization failed", e);
       } finally {
         setInitialLoaded(true);
       }

--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -610,18 +610,21 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
           }
         }
       } catch (error) {
-        // Wrong credentials are user input, not an app defect — WARN keeps
-        // them out of Sentry; anything else becomes an event.
+        // Wrong credentials and unreachable servers are the user's input and
+        // environment, not app defects — log them as WARN locally. Nothing
+        // here reaches Sentry directly; unexpected errors rethrown below are
+        // reported once by the global mutation handler.
         writeToLog(
-          axios.isAxiosError(error) && error.response?.status === 401
+          axios.isAxiosError(error) &&
+            (!error.response || error.response.status === 401)
             ? "WARN"
             : "ERROR",
           `Login failed against ${api.basePath}: ${describeRequestError(error)}`,
         );
         if (axios.isAxiosError(error)) {
-          // The writeErrorLog above already reported the technical failure;
-          // what's thrown from here is only a translated message for the
-          // login form, so it's marked expected to keep it out of Sentry.
+          // What's thrown from here is only a translated message for the
+          // login form, so it's marked expected to keep it out of Sentry's
+          // global mutation handler.
           switch (error.response?.status) {
             case 401:
               throw markExpectedError(
@@ -799,7 +802,8 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
         .authenticateUserByName(username, password)
         .catch((error) => {
           writeToLog(
-            axios.isAxiosError(error) && error.response?.status === 401
+            axios.isAxiosError(error) &&
+              (!error.response || error.response.status === 401)
               ? "WARN"
               : "ERROR",
             `Login (saved server) failed against ${serverUrl}: ${describeRequestError(error)}`,

--- a/providers/MusicPlayerProvider.tsx
+++ b/providers/MusicPlayerProvider.tsx
@@ -28,6 +28,7 @@ import { useNetworkStatus } from "@/providers/NetworkStatusProvider";
 import { settingsAtom } from "@/utils/atoms/settings";
 import { getJellyfinHeadersForUrl } from "@/utils/customHeaders";
 import { getAudioStreamUrl } from "@/utils/jellyfin/audio/getAudioStreamUrl";
+import { logAndCaptureError } from "@/utils/log";
 import { storage } from "@/utils/mmkv";
 
 // Conditionally import TrackPlayer only on non-TV platforms
@@ -916,7 +917,8 @@ const MobileMusicPlayerProvider: React.FC<MusicPlayerProviderProps> = ({
           loadRemainingTracksInBackground(finalQueue, finalIndex, preferLocal);
         }
       } catch (error) {
-        console.error("[MusicPlayer] Error loading queue:", error);
+        // Tapping a track just stops spinning when this fails.
+        logAndCaptureError("Loading music queue failed", error);
         setState((prev) => ({
           ...prev,
           isLoading: false,
@@ -1023,8 +1025,9 @@ const MobileMusicPlayerProvider: React.FC<MusicPlayerProviderProps> = ({
         if (tracks.length > 0) {
           playQueue(tracks, startIndex);
         }
-      } catch {
-        // Silently fail
+      } catch (error) {
+        // Tapping play on an album does nothing at all when this fails.
+        logAndCaptureError("Fetching album tracks for playback failed", error);
       }
     },
     [api, user?.Id, playQueue],
@@ -1047,8 +1050,12 @@ const MobileMusicPlayerProvider: React.FC<MusicPlayerProviderProps> = ({
         if (tracks.length > 0) {
           playQueue(tracks, startIndex);
         }
-      } catch {
-        // Silently fail
+      } catch (error) {
+        // Tapping play on a playlist does nothing at all when this fails.
+        logAndCaptureError(
+          "Fetching playlist tracks for playback failed",
+          error,
+        );
       }
     },
     [api, user?.Id, playQueue],

--- a/providers/NativePlayerProvider.tsx
+++ b/providers/NativePlayerProvider.tsx
@@ -85,7 +85,7 @@ import {
   isImageBasedSubtitle,
   type SubtitleSelectablePlayer,
 } from "@/utils/jellyfin/subtitleUtils";
-import { writeToLog } from "@/utils/log";
+import { logAndCaptureError, writeToLog } from "@/utils/log";
 import {
   buildNativePlayerConfig,
   buildNativePlayerStrings,
@@ -598,11 +598,9 @@ const NativePlayerProviderInner: React.FC<{
         strings: buildNativePlayerStrings(t),
         item: options.item,
       }).catch((error) => {
-        writeToLog(
-          "ERROR",
-          "NativePlayer config build failed",
-          error instanceof Error ? error.message : String(error),
-        );
+        logAndCaptureError("NativePlayer config build failed", error, {
+          offline: req.offline,
+        });
         return null;
       });
       if (!built) return false;
@@ -665,11 +663,9 @@ const NativePlayerProviderInner: React.FC<{
           await presentNativePlayer(built.config);
         }
       } catch (error) {
-        writeToLog(
-          "ERROR",
-          "NativePlayer present/load failed",
-          error instanceof Error ? error.message : String(error),
-        );
+        logAndCaptureError("NativePlayer present/load failed", error, {
+          replace: !!options.replace,
+        });
         if (options.replace && previous) {
           // The in-place swap failed midway: the old server session is
           // already closed and the stream state is unknown — tear the whole
@@ -1488,7 +1484,13 @@ const NativePlayerProviderInner: React.FC<{
       }),
 
       addNativePlayerListener("onError", (payload) => {
-        writeToLog("ERROR", "NativePlayer playback error", payload.error);
+        const session = sessionRef.current;
+        logAndCaptureError("NativePlayer playback error", payload.error, {
+          container: session?.stream?.mediaSource?.Container,
+          transcoding: !!session?.stream?.mediaSource?.TranscodingUrl,
+          offline: session?.offline,
+          itemType: session?.item?.Type,
+        });
       }),
 
       addNativePlayerListener("onPlaybackEnded", (payload) => {

--- a/providers/PlaySettingsProvider.tsx
+++ b/providers/PlaySettingsProvider.tsx
@@ -9,6 +9,7 @@ import { Platform } from "react-native";
 import type { Bitrate } from "@/components/BitrateSelector";
 import { getActivePlayerType, settingsAtom } from "@/utils/atoms/settings";
 import { getStreamUrl } from "@/utils/jellyfin/media/getStreamUrl";
+import { logAndCaptureError } from "@/utils/log";
 import { generateDeviceProfile } from "../utils/profiles/native";
 import { apiAtom, userAtom } from "./JellyfinProvider";
 
@@ -107,7 +108,13 @@ export const PlaySettingsProvider: React.FC<{ children: React.ReactNode }> = ({
 
         return data;
       } catch (error) {
-        console.warn("Error getting stream URL:", error);
+        // Callers treat null as "playback can't start" — without a report
+        // this is a Play button that silently does nothing.
+        logAndCaptureError("Getting stream URL failed", error, {
+          itemType: newSettings?.item?.Type,
+          player: getActivePlayerType(settings),
+          bitrate: newSettings?.bitrate?.value,
+        });
         return null;
       }
     },

--- a/providers/WebSocketProvider.tsx
+++ b/providers/WebSocketProvider.tsx
@@ -17,7 +17,7 @@ import { apiAtom } from "@/providers/JellyfinProvider";
 import { useNetworkStatus } from "@/providers/NetworkStatusProvider";
 import { getJellyfinHeaders, hasHeaders } from "@/utils/customHeaders";
 import { getOrSetDeviceId } from "@/utils/device";
-import { logAndCaptureError, writeErrorLog } from "@/utils/log";
+import { logAndCaptureError } from "@/utils/log";
 
 // Query keys that depend on the set of library items and should be refreshed
 // when the server reports that the library changed (items added/removed/updated).
@@ -94,7 +94,14 @@ type RNWebSocketConstructor = new (
 
 export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
   const api = useAtomValue(apiAtom);
-  const { isConnected: isNetworkConnected } = useNetworkStatus();
+  const { isConnected: isNetworkConnected, serverConnected } =
+    useNetworkStatus();
+  // The give-up report fires at most once per session: after the first
+  // exhaustion the attempt counter stays maxed, so every later foreground/
+  // network flip would re-trigger it.
+  const reportedSocketGiveUpRef = useRef(false);
+  const serverConnectedRef = useRef(serverConnected);
+  serverConnectedRef.current = serverConnected;
   const [ws, setWs] = useState<WebSocket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const [lastMessage, setLastMessage] = useState<WebSocketMessage | null>(null);
@@ -229,11 +236,19 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
           reconnectTimeoutRef.current = null;
           connectWebSocket();
         }, reconnectDelay);
-      } else if (isNetworkConnected) {
-        // All retries burned while the network is up: the server itself is
-        // rejecting the socket, which silently kills remote control and live
-        // updates until the next app foreground.
-        writeErrorLog("WebSocket gave up reconnecting while online");
+      } else if (
+        serverConnectedRef.current === true &&
+        !reportedSocketGiveUpRef.current
+      ) {
+        // All retries burned while the SERVER is reachable (a real probe,
+        // not just device connectivity): the server itself is rejecting the
+        // socket, which silently kills remote control and live updates
+        // until the next app foreground.
+        reportedSocketGiveUpRef.current = true;
+        logAndCaptureError(
+          "WebSocket gave up reconnecting while server is reachable",
+          null,
+        );
       }
     };
 
@@ -375,9 +390,10 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
           },
         });
       } catch (error) {
-        // A connectivity failure is expected noise, but a server rejection
-        // means remote control silently never works for this session.
-        if (isAxiosError(error) && !error.response) return;
+        // Connectivity failures are filtered centrally; 401 is routine
+        // session expiry (the auth interceptor handles it). What remains is
+        // a server rejection that silently breaks remote control.
+        if (isAxiosError(error) && error.response?.status === 401) return;
         logAndCaptureError("Posting session capabilities failed", error);
       }
     };

--- a/providers/WebSocketProvider.tsx
+++ b/providers/WebSocketProvider.tsx
@@ -1,4 +1,5 @@
 import { getSessionApi } from "@jellyfin/sdk/lib/utils/api";
+import { isAxiosError } from "axios";
 import { useAtomValue } from "jotai";
 import {
   createContext,
@@ -16,6 +17,7 @@ import { apiAtom } from "@/providers/JellyfinProvider";
 import { useNetworkStatus } from "@/providers/NetworkStatusProvider";
 import { getJellyfinHeaders, hasHeaders } from "@/utils/customHeaders";
 import { getOrSetDeviceId } from "@/utils/device";
+import { logAndCaptureError, writeErrorLog } from "@/utils/log";
 
 // Query keys that depend on the set of library items and should be refreshed
 // when the server reports that the library changed (items added/removed/updated).
@@ -157,10 +159,9 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
       try {
         handler(message.Data, message);
       } catch (error) {
-        console.error(
-          `Error handling WebSocket message type "${message.MessageType}":`,
-          error,
-        );
+        logAndCaptureError("WebSocket message handler threw", error, {
+          messageType: message.MessageType,
+        });
       }
     }
   }, []);
@@ -228,6 +229,11 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
           reconnectTimeoutRef.current = null;
           connectWebSocket();
         }, reconnectDelay);
+      } else if (isNetworkConnected) {
+        // All retries burned while the network is up: the server itself is
+        // rejecting the socket, which silently kills remote control and live
+        // updates until the next app foreground.
+        writeErrorLog("WebSocket gave up reconnecting while online");
       }
     };
 
@@ -245,7 +251,7 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
         // Pub/sub: deliver to every subscriber without coalescing.
         dispatchMessage(message);
       } catch (error) {
-        console.error("Error parsing WebSocket message:", error);
+        logAndCaptureError("Error parsing WebSocket message", error);
       }
     };
     setWs(newWebSocket);
@@ -368,8 +374,11 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
             SupportsPersistentIdentifier: true,
           },
         });
-      } catch {
-        // Silently fail - expected when offline or server unreachable
+      } catch (error) {
+        // A connectivity failure is expected noise, but a server rejection
+        // means remote control silently never works for this session.
+        if (isAxiosError(error) && !error.response) return;
+        logAndCaptureError("Posting session capabilities failed", error);
       }
     };
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -588,7 +588,8 @@
     "movies": "Movies",
     "loading": "Loading...",
     "seeAll": "See all",
-    "close": "Close"
+    "close": "Close",
+    "something_went_wrong": "Something went wrong"
   },
   "search": {
     "search": "Search...",

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -13,7 +13,7 @@ import { Platform } from "react-native";
 import { BITRATES, type Bitrate } from "@/components/BitrateSelector";
 import * as ScreenOrientation from "@/packages/expo-screen-orientation";
 import { apiAtom } from "@/providers/JellyfinProvider";
-import { writeInfoLog } from "@/utils/log";
+import { logAndCaptureError, writeInfoLog } from "@/utils/log";
 import {
   PLUGIN_SETTINGS_KEY,
   readStoredSettings,
@@ -613,7 +613,8 @@ const saveSettings = (settings: Settings) => {
     const jsonValue = JSON.stringify(settings);
     storage.set(SETTINGS_KEY, jsonValue);
   } catch (error) {
-    console.error("Failed to save settings:", error);
+    // The user's change is silently lost when this fails.
+    logAndCaptureError("Saving settings failed", error);
   }
 };
 
@@ -622,7 +623,8 @@ const loadPluginSettings = () => {
   try {
     return storage.get<PluginLockableSettings>(STREAMYFIN_PLUGIN_SETTINGS);
   } catch (error) {
-    console.error("Failed to load plugin settings:", error);
+    // Without the plugin settings the server admin's policy is not applied.
+    logAndCaptureError("Loading plugin settings failed", error);
     return undefined;
   }
 };

--- a/utils/customHeaders/integrations.ts
+++ b/utils/customHeaders/integrations.ts
@@ -1,3 +1,4 @@
+import { logAndCaptureError } from "@/utils/log";
 import { storage } from "@/utils/mmkv";
 import { normalizeCustomHeaders } from "./normalize";
 import {
@@ -11,6 +12,8 @@ import type { HeaderConfig, HeaderSource, IntegrationKey } from "./types";
 export const INTEGRATION_CONFIG_KEY_PREFIX = "custom_headers_config_";
 
 const DEFAULT_CONFIG: HeaderConfig = { source: "none", customHeaders: [] };
+
+let reportedCorruptHeaderConfig = false;
 
 function configStorageKey(integrationKey: IntegrationKey): string {
   return `${INTEGRATION_CONFIG_KEY_PREFIX}${integrationKey}`;
@@ -32,7 +35,14 @@ function parseHeaderConfig(stored?: string): HeaderConfig {
         ? parsed.customHeaders
         : [],
     };
-  } catch {
+  } catch (error) {
+    // Falling back silently drops the user's custom auth headers, which then
+    // looks exactly like a server outage on every request. Report once per
+    // session — this parser can run on every outgoing request.
+    if (!reportedCorruptHeaderConfig) {
+      reportedCorruptHeaderConfig = true;
+      logAndCaptureError("Custom-header config failed to parse", error);
+    }
     return { ...DEFAULT_CONFIG, customHeaders: [] };
   }
 }

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -1,4 +1,4 @@
-import { isCancel } from "axios";
+import { isAxiosError, isCancel } from "axios";
 
 /**
  * Marks errors that are user-facing outcomes rather than app defects — a
@@ -41,6 +41,19 @@ export const isAbortLikeError = (error: unknown): boolean =>
   isCancel(error) ||
   (error instanceof Error &&
     (error.name === "AbortError" || error.name === "CanceledError"));
+
+/**
+ * True for requests that never got an HTTP response — the server is
+ * unreachable (LAN-only server while roaming, DNS failure, timeout). That is
+ * the user's environment, not an app bug, so it must never become a Sentry
+ * event. Covers both axios errors and React Native's fetch TypeError.
+ */
+export const isConnectivityError = (error: unknown): boolean => {
+  if (isAxiosError(error)) return !error.response;
+  return (
+    error instanceof TypeError && /network request failed/i.test(error.message)
+  );
+};
 
 export const isExpectedError = (error: unknown): boolean =>
   error !== null &&

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -1,0 +1,48 @@
+import { isCancel } from "axios";
+
+/**
+ * Marks errors that are user-facing outcomes rather than app defects — a
+ * wrong password, a denied permission — so the global React Query error
+ * reporting in app/_layout.tsx doesn't send them to Sentry. The underlying
+ * technical failure should already have been logged (writeErrorLog /
+ * logAndCaptureError) before the marked error is thrown for the UI.
+ */
+const EXPECTED_ERROR = Symbol.for("streamyfin.expectedError");
+
+export const markExpectedError = <T>(error: T): T => {
+  if (error !== null && typeof error === "object") {
+    (error as Record<symbol, unknown>)[EXPECTED_ERROR] = true;
+  }
+  return error;
+};
+
+/**
+ * Marks errors that have already been sent to Sentry (by logAndCaptureError)
+ * so the global React Query handler doesn't report them a second time when
+ * they're rethrown into a query/mutation.
+ */
+const REPORTED_ERROR = Symbol.for("streamyfin.reportedError");
+
+export const markErrorReported = <T>(error: T): T => {
+  if (error !== null && typeof error === "object") {
+    (error as Record<symbol, unknown>)[REPORTED_ERROR] = true;
+  }
+  return error;
+};
+
+export const isErrorReported = (error: unknown): boolean =>
+  error !== null &&
+  typeof error === "object" &&
+  (error as Record<symbol, unknown>)[REPORTED_ERROR] === true;
+
+/** True for cancelled/aborted requests (navigation away, new keystroke) —
+ * routine control flow that should never be reported as a failure. */
+export const isAbortLikeError = (error: unknown): boolean =>
+  isCancel(error) ||
+  (error instanceof Error &&
+    (error.name === "AbortError" || error.name === "CanceledError"));
+
+export const isExpectedError = (error: unknown): boolean =>
+  error !== null &&
+  typeof error === "object" &&
+  (error as Record<symbol, unknown>)[EXPECTED_ERROR] === true;

--- a/utils/jellyfin/checkServer.test.ts
+++ b/utils/jellyfin/checkServer.test.ts
@@ -14,17 +14,21 @@ mock.module("@/utils/customHeaders", () => ({
 // Bun's mock.module retroactively re-links every module already importing the
 // specifier, so a log mock must cover the module's full function surface —
 // a missing name breaks OTHER test files' modules that import it.
-const infoLogs: string[] = [];
-const errorLogs: string[] = [];
+const loggedMessages: Array<{ level: string; message: string }> = [];
 mock.module("@/utils/log", () => ({
-  writeToLog: () => undefined,
+  writeToLog: (level: string, message: string) => {
+    loggedMessages.push({ level, message });
+  },
   writeInfoLog: (message: string) => {
-    infoLogs.push(message);
+    loggedMessages.push({ level: "INFO", message });
   },
   writeErrorLog: (message: string) => {
-    errorLogs.push(message);
+    loggedMessages.push({ level: "ERROR", message });
   },
   writeDebugLog: () => undefined,
+  logAndCaptureError: (message: string) => {
+    loggedMessages.push({ level: "ERROR", message });
+  },
   readFromLog: () => [],
 }));
 
@@ -94,8 +98,7 @@ const routes = (impl: {
 
 beforeEach(() => {
   fetchCalls = [];
-  infoLogs.length = 0;
-  errorLogs.length = 0;
+  loggedMessages.length = 0;
   savedHeaders.clear();
   persistedHeaders.length = 0;
   fetchImpl = networkError;
@@ -187,8 +190,12 @@ describe("checkJellyfinServer probing", () => {
     );
 
     expect(result?.url).toBe("http://192.168.1.10:8096");
+    // Probe failures are routine (fallback still succeeds here), so they log
+    // as WARN — local trail only, never a Sentry event.
     expect(
-      errorLogs.some((m) => m.includes("timed out after 20ms")),
+      loggedMessages.some(
+        (m) => m.level === "WARN" && m.message.includes("timed out after 20ms"),
+      ),
     ).toBeTrue();
   });
 
@@ -201,7 +208,11 @@ describe("checkJellyfinServer probing", () => {
     const result = await checkJellyfinServer("192.168.1.10:8096");
 
     expect(result?.url).toBe("http://192.168.1.10:8096");
-    expect(errorLogs.some((m) => m.includes("HTTP 403"))).toBeTrue();
+    expect(
+      loggedMessages.some(
+        (m) => m.level === "WARN" && m.message.includes("HTTP 403"),
+      ),
+    ).toBeTrue();
   });
 
   test("returns undefined when nothing answers", async () => {

--- a/utils/jellyfin/checkServer.ts
+++ b/utils/jellyfin/checkServer.ts
@@ -4,7 +4,7 @@ import {
   normalizeCustomHeaders,
   optionsWithOptionalHeaders,
 } from "@/utils/customHeaders";
-import { writeErrorLog, writeInfoLog } from "@/utils/log";
+import { writeInfoLog, writeToLog } from "@/utils/log";
 import {
   getServerCustomHeaders,
   updateServerCustomHeaders,
@@ -86,7 +86,13 @@ export async function checkJellyfinServer(
         ),
       );
       if (!response.ok) {
-        writeErrorLog(`Server check: ${url} answered HTTP ${response.status}`);
+        // WARN, not ERROR: probe failures are routine (http probe against an
+        // https-only server, typos, offline) and must not become Sentry
+        // events — they stay in the local log and breadcrumb trail.
+        writeToLog(
+          "WARN",
+          `Server check: ${url} answered HTTP ${response.status}`,
+        );
         continue;
       }
 
@@ -103,7 +109,8 @@ export async function checkJellyfinServer(
       return { url, name: data.ServerName || "" };
     } catch (e) {
       if (e instanceof ServerTooOldError) throw e;
-      writeErrorLog(
+      writeToLog(
+        "WARN",
         `Server check: ${url} failed — ${
           abort.signal.aborted
             ? `timed out after ${probeTimeoutMs}ms`
@@ -117,6 +124,8 @@ export async function checkJellyfinServer(
     }
   }
 
-  writeErrorLog(`Server check: no protocol worked for "${host}"`);
+  // Environmental (wrong address, server down), not an app defect — local
+  // log only.
+  writeToLog("WARN", `Server check: no protocol worked for "${host}"`);
   return undefined;
 }

--- a/utils/jellyfin/media/getDownloadUrl.ts
+++ b/utils/jellyfin/media/getDownloadUrl.ts
@@ -4,6 +4,7 @@ import type {
   MediaSourceInfo,
 } from "@jellyfin/sdk/lib/generated-client/models";
 import { Bitrate } from "@/components/BitrateSelector";
+import { logAndCaptureError } from "@/utils/log";
 import {
   type AudioTranscodeModeType,
   generateDeviceProfile,
@@ -34,18 +35,31 @@ export const getDownloadUrl = async ({
   url: string | null;
   mediaSource: MediaSourceInfo | null;
 } | null> => {
-  const streamDetails = await getStreamUrl({
-    api,
-    item,
-    userId,
-    startTimeTicks: 0,
-    mediaSourceId: mediaSource.Id,
-    maxStreamingBitrate: maxBitrate.value,
-    audioStreamIndex,
-    subtitleStreamIndex,
-    deviceId,
-    deviceProfile: generateDeviceProfile({ audioMode }),
-  });
+  // getStreamUrl throws on failed negotiation (no media source). The
+  // download UI handles a null url per item (alert + continue with the
+  // rest of a season), so map the throw back to null here — an unhandled
+  // rejection out of DownloadItem's setTimeout would fail silently and
+  // abort the whole batch.
+  let streamDetails: Awaited<ReturnType<typeof getStreamUrl>>;
+  try {
+    streamDetails = await getStreamUrl({
+      api,
+      item,
+      userId,
+      startTimeTicks: 0,
+      mediaSourceId: mediaSource.Id,
+      maxStreamingBitrate: maxBitrate.value,
+      audioStreamIndex,
+      subtitleStreamIndex,
+      deviceId,
+      deviceProfile: generateDeviceProfile({ audioMode }),
+    });
+  } catch (error) {
+    logAndCaptureError("Getting download stream URL failed", error, {
+      itemType: item.Type,
+    });
+    return null;
+  }
 
   if (maxBitrate.key === "Max" && !streamDetails?.mediaSource?.TranscodingUrl) {
     console.log("Downloading item directly");

--- a/utils/jellyfin/media/getStreamUrl.ts
+++ b/utils/jellyfin/media/getStreamUrl.ts
@@ -213,6 +213,11 @@ export const getStreamUrl = async ({
 
     sessionId = res.data.PlaySessionId || null;
     mediaSource = res.data.MediaSources?.[0];
+    if (!mediaSource) {
+      throw new Error(
+        `PlaybackInfo returned no media source for live channel (${res.data.ErrorCode ?? "no ErrorCode"})`,
+      );
+    }
     const url = getPlaybackUrl(api, item.ChannelId!, mediaSource, {
       subtitleStreamIndex,
       audioStreamIndex,
@@ -258,6 +263,16 @@ export const getStreamUrl = async ({
 
   sessionId = res.data.PlaySessionId || null;
   mediaSource = res.data.MediaSources?.[0];
+
+  // Jellyfin reports negotiation failures as HTTP 200 with an ErrorCode
+  // (NoCompatibleStream, RateLimitExceeded, …) and no MediaSources.
+  // Fabricating a stream URL anyway just moves the failure into an opaque
+  // decoder error minutes later, so fail here where the reason is known.
+  if (!mediaSource) {
+    throw new Error(
+      `PlaybackInfo returned no media source (${res.data.ErrorCode ?? "no ErrorCode"})`,
+    );
+  }
 
   const url = getPlaybackUrl(api, item.Id!, mediaSource, {
     subtitleStreamIndex,

--- a/utils/log.tsx
+++ b/utils/log.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { atomWithStorage, createJSONStorage } from "jotai/utils";
 import type React from "react";
 import { createContext, useContext } from "react";
+import { markErrorReported } from "./errors";
 import { storage } from "./mmkv";
 
 export type LogLevel = "INFO" | "WARN" | "ERROR" | "DEBUG";
@@ -47,21 +48,32 @@ function useLogProvider() {
   };
 }
 
-export const writeToLog = (level: LogLevel, message: string, data?: any) => {
-  // Mirror app logs into Sentry as breadcrumbs (never events) so crash
-  // reports carry the log trail leading up to them. `data` stays local:
-  // it can hold raw URLs and payloads the URL scrubber wouldn't reach.
+// Mirror app logs into Sentry as breadcrumbs so crash reports carry the log
+// trail leading up to them. `data` stays local: it can hold raw URLs and
+// payloads the URL scrubber wouldn't reach (hosts without a scheme, tokens).
+const appendLogEntry = (level: LogLevel, message: string, data?: any) => {
   Sentry.addBreadcrumb({
     category: "app.log",
     level: SENTRY_BREADCRUMB_LEVELS[level],
     message,
   });
 
+  // `data` is often a caught error now — guard against non-serializable
+  // payloads (circular refs) so the logging path itself can never throw.
+  let safeData = data;
+  if (data !== undefined) {
+    try {
+      JSON.stringify(data);
+    } catch {
+      safeData = String(data);
+    }
+  }
+
   const newEntry: LogEntry = {
     timestamp: new Date().toISOString(),
     level: level,
     message: message,
-    data: data,
+    data: safeData,
   };
 
   const currentLogs = storage.getString("logs");
@@ -72,6 +84,65 @@ export const writeToLog = (level: LogLevel, message: string, data?: any) => {
   const recentLogs = logs.slice(Math.max(logs.length - maxLogs, 0));
 
   storage.set("logs", JSON.stringify(recentLogs));
+};
+
+export const writeToLog = (level: LogLevel, message: string, data?: any) => {
+  appendLogEntry(level, message, data);
+  // ERROR-level logs become real Sentry events (not just breadcrumbs): the
+  // message alone is sent, so grouping stays stable and `data` stays local.
+  if (level === "ERROR") {
+    Sentry.captureMessage(message, "error");
+  }
+};
+
+const stringifyErrorValue = (value: unknown): string | undefined => {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return undefined;
+  try {
+    return JSON.stringify(value).slice(0, 500);
+  } catch {
+    return String(value);
+  }
+};
+
+/**
+ * Records a failure both in the local log and as a Sentry exception. Prefer
+ * this over writeErrorLog when the caught error object is available — a real
+ * stack trace groups and debugs far better than a message string.
+ *
+ * `context` is SENT to Sentry (after URL scrubbing), so pass only curated
+ * values (codecs, status codes, item IDs) — never raw payloads or settings
+ * blobs. The `error` value doubles as the local log's `data`.
+ */
+export const logAndCaptureError = (
+  message: string,
+  error: unknown,
+  context?: Record<string, unknown>,
+) => {
+  appendLogEntry("ERROR", message, error);
+  // If this error is later rethrown into React Query, the global handler in
+  // app/_layout.tsx must not report it again.
+  markErrorReported(error);
+  Sentry.withScope((scope) => {
+    if (context) {
+      scope.setContext("details", context);
+    }
+    if (error instanceof Error) {
+      scope.setExtra("log_message", message);
+      Sentry.captureException(error);
+    } else {
+      // Non-Error values (native event strings, rejected payloads) get
+      // wrapped in a synthetic Error whose stack points here, so group by
+      // log message + detail instead: one issue per distinct failure, not
+      // one blob per call site. (Fingerprints are scrubbed like the rest of
+      // the event, so URLs in the detail don't fragment grouping.)
+      const detail = stringifyErrorValue(error);
+      scope.setFingerprint(detail ? [message, detail] : [message]);
+      Sentry.captureException(
+        new Error(detail ? `${message}: ${detail}` : message),
+      );
+    }
+  });
 };
 
 export const writeInfoLog = (message: string, data?: any) =>

--- a/utils/log.tsx
+++ b/utils/log.tsx
@@ -1,9 +1,14 @@
 import * as Sentry from "@sentry/react-native";
 import { useQuery } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 import { atomWithStorage, createJSONStorage } from "jotai/utils";
 import type React from "react";
 import { createContext, useContext } from "react";
-import { markErrorReported } from "./errors";
+import {
+  isAbortLikeError,
+  isConnectivityError,
+  markErrorReported,
+} from "./errors";
 import { storage } from "./mmkv";
 
 export type LogLevel = "INFO" | "WARN" | "ERROR" | "DEBUG";
@@ -58,41 +63,47 @@ const appendLogEntry = (level: LogLevel, message: string, data?: any) => {
     message,
   });
 
-  // `data` is often a caught error now — guard against non-serializable
-  // payloads (circular refs) so the logging path itself can never throw.
-  let safeData = data;
-  if (data !== undefined) {
-    try {
-      JSON.stringify(data);
-    } catch {
-      safeData = String(data);
-    }
-  }
-
   const newEntry: LogEntry = {
     timestamp: new Date().toISOString(),
     level: level,
     message: message,
-    data: safeData,
+    data: data,
   };
 
-  const currentLogs = storage.getString("logs");
-  const logs: LogEntry[] = currentLogs ? JSON.parse(currentLogs) : [];
+  // The logging path itself must never throw: a corrupt persisted blob or a
+  // non-serializable `data` payload (circular refs) falls back instead of
+  // taking down the caller — which is often itself a catch block.
+  let logs: LogEntry[];
+  try {
+    const currentLogs = storage.getString("logs");
+    logs = currentLogs ? JSON.parse(currentLogs) : [];
+  } catch {
+    logs = [];
+  }
   logs.push(newEntry);
 
   const maxLogs = 100;
   const recentLogs = logs.slice(Math.max(logs.length - maxLogs, 0));
 
-  storage.set("logs", JSON.stringify(recentLogs));
+  try {
+    storage.set("logs", JSON.stringify(recentLogs));
+  } catch {
+    newEntry.data = String(data);
+    try {
+      storage.set("logs", JSON.stringify(recentLogs));
+    } catch {
+      // Even the fallback failed — drop the write rather than throw.
+    }
+  }
 };
 
+// Sentry capture is always explicit (logAndCaptureError), never a side
+// effect of log level: writeErrorLog has dozens of legacy call sites that
+// include routine environmental noise (permission denials, servers without
+// the plugin), and a level-triggered capture would silently opt in every
+// present and future one of them.
 export const writeToLog = (level: LogLevel, message: string, data?: any) => {
   appendLogEntry(level, message, data);
-  // ERROR-level logs become real Sentry events (not just breadcrumbs): the
-  // message alone is sent, so grouping stays stable and `data` stays local.
-  if (level === "ERROR") {
-    Sentry.captureMessage(message, "error");
-  }
 };
 
 const stringifyErrorValue = (value: unknown): string | undefined => {
@@ -105,21 +116,53 @@ const stringifyErrorValue = (value: unknown): string | undefined => {
   }
 };
 
+// The local log is exportable (Settings → Logs shares it as logs.txt), so a
+// caught error is reduced to a curated shape before it is persisted: a raw
+// AxiosError serializes its request config INCLUDING the Authorization and
+// X-Api-Key headers, and a plain Error stringifies to "{}" (message/stack
+// are non-enumerable) — both wrong, in opposite directions.
+const describeErrorForLog = (error: unknown): unknown => {
+  if (isAxiosError(error)) {
+    return {
+      name: error.name,
+      message: error.message,
+      code: error.code,
+      status: error.response?.status,
+      url: error.config?.url?.split("?")[0],
+    };
+  }
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack?.split("\n").slice(0, 8).join("\n"),
+    };
+  }
+  return error;
+};
+
 /**
- * Records a failure both in the local log and as a Sentry exception. Prefer
- * this over writeErrorLog when the caught error object is available — a real
- * stack trace groups and debugs far better than a message string.
+ * Records a failure both in the local log and as a Sentry exception — the
+ * ONLY path that turns handled errors into Sentry events. Prefer it over
+ * writeErrorLog when the caught error object is available.
+ *
+ * Connectivity failures (aborted requests, no HTTP response) stay in the
+ * local log but are never sent: an unreachable server is the user's
+ * environment, not an app bug.
  *
  * `context` is SENT to Sentry (after URL scrubbing), so pass only curated
  * values (codecs, status codes, item IDs) — never raw payloads or settings
- * blobs. The `error` value doubles as the local log's `data`.
+ * blobs.
  */
 export const logAndCaptureError = (
   message: string,
   error: unknown,
   context?: Record<string, unknown>,
 ) => {
-  appendLogEntry("ERROR", message, error);
+  appendLogEntry("ERROR", message, describeErrorForLog(error));
+  if (isAbortLikeError(error) || isConnectivityError(error)) {
+    return;
+  }
   // If this error is later rethrown into React Query, the global handler in
   // app/_layout.tsx must not report it again.
   markErrorReported(error);

--- a/utils/secureCredentials.ts
+++ b/utils/secureCredentials.ts
@@ -7,6 +7,7 @@ import {
   secureCustomHeaderMetadata,
 } from "./customHeaders/secureValues";
 import type { CustomHeader } from "./customHeaders/types";
+import { logAndCaptureError } from "./log";
 import { storage } from "./mmkv";
 
 const CREDENTIAL_KEY_PREFIX = "credential_";
@@ -557,8 +558,13 @@ export async function migrateToMultiAccount(): Promise<void> {
 
     storage.set("previousServers", JSON.stringify(migratedServers));
     storage.set(MULTI_ACCOUNT_MIGRATED_KEY, true);
-  } catch {
-    // If parsing fails, reset to empty array
+  } catch (error) {
+    // If parsing fails, reset to empty array. This destroys the user's saved
+    // server list, so it must never happen silently.
+    logAndCaptureError(
+      "Saved-servers migration failed; resetting previousServers",
+      error,
+    );
     storage.set("previousServers", "[]");
     storage.set(MULTI_ACCOUNT_MIGRATED_KEY, true);
   }

--- a/utils/sentry.test.ts
+++ b/utils/sentry.test.ts
@@ -32,7 +32,50 @@ mock.module("react-native", () => ({
   Platform: { OS: "ios", isTV: false },
 }));
 
-const { scrubDeep } = await import("./sentry");
+const { scrubDeep, isUserInteractionBreadcrumb } = await import("./sentry");
+
+describe("isUserInteractionBreadcrumb — no behaviour tracking, no titles", () => {
+  test("drops touch breadcrumbs, whose labels are media titles", () => {
+    // Shape taken from a real event: the label is a media card's
+    // accessibility label, i.e. the title of what the user was browsing.
+    expect(
+      isUserInteractionBreadcrumb({
+        type: "user",
+        category: "touch",
+        message: "Touch event within element: Map 1213",
+        data: { path: [{ label: "Map 1213", name: "Text" }] },
+      }),
+    ).toBe(true);
+  });
+
+  test("drops ui.* interaction breadcrumbs", () => {
+    expect(
+      isUserInteractionBreadcrumb({
+        category: "ui.multiClick",
+        message: "HeroCarousel",
+      }),
+    ).toBe(true);
+    expect(isUserInteractionBreadcrumb({ category: "ui.lifecycle" })).toBe(
+      true,
+    );
+  });
+
+  test("keeps app logs and http breadcrumbs", () => {
+    expect(
+      isUserInteractionBreadcrumb({
+        category: "app.log",
+        message: "Download failed",
+      }),
+    ).toBe(false);
+    expect(
+      isUserInteractionBreadcrumb({
+        type: "http",
+        category: "xhr",
+        data: { url: "https://[server]/Sessions" },
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("scrubDeep — the privacy boundary for outgoing Sentry data", () => {
   test("server origin is replaced and query strings are stripped", () => {
@@ -73,13 +116,19 @@ describe("scrubDeep — the privacy boundary for outgoing Sentry data", () => {
   test("credential params are redacted even in server-relative URLs", () => {
     expect(
       scrubDeep("/videos/xyz/master.m3u8?DeviceId=abc&api_key=SECRET"),
-    ).toBe("/videos/xyz/[media].m3u8?DeviceId=abc&api_key=[redacted]");
+    ).toBe("/videos/xyz/[media].m3u8?DeviceId=[redacted]&api_key=[redacted]");
   });
 
   test("credential params survive an unencoded space breaking the URL regex", () => {
     expect(
       scrubDeep("https://host.example.com/My Show S01E02.mp4?ApiKey=SECRET"),
     ).toBe("https://[server]/[media].mp4?ApiKey=[redacted]");
+  });
+
+  test("identifying query params are redacted in relative URLs", () => {
+    expect(scrubDeep("/Items/Latest?userId=5403820992&limit=8")).toBe(
+      "/Items/Latest?userId=[redacted]&limit=8",
+    );
   });
 
   test("scheme-less hosts in native error strings are redacted", () => {

--- a/utils/sentry.test.ts
+++ b/utils/sentry.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// utils/sentry imports the SDK and app modules with native dependencies;
+// only the pure scrubbers are under test here. Bun's mock.module is
+// retroactive and process-wide, so each mock covers the full surface the
+// module under test touches.
+mock.module("@sentry/react-native", () => ({
+  init: () => undefined,
+  close: () => Promise.resolve(),
+  breadcrumbsIntegration: () => ({ name: "Breadcrumbs" }),
+}));
+mock.module("@/utils/storedSettings", () => ({
+  readStoredSettings: () => ({}),
+  readStoredPluginSettings: () => ({}),
+  SETTINGS_KEY: "settings",
+  PLUGIN_SETTINGS_KEY: "STREAMYFIN_PLUGIN_SETTINGS",
+}));
+mock.module("@/utils/version", () => ({
+  getVersionInfo: () => ({
+    version: "0.0.0",
+    build: "1",
+    commit: null,
+    branch: null,
+    profile: null,
+    runNumber: null,
+    isDev: true,
+    isProduction: false,
+    display: "test",
+  }),
+}));
+mock.module("react-native", () => ({
+  Platform: { OS: "ios", isTV: false },
+}));
+
+const { scrubDeep } = await import("./sentry");
+
+describe("scrubDeep — the privacy boundary for outgoing Sentry data", () => {
+  test("server origin is replaced and query strings are stripped", () => {
+    expect(
+      scrubDeep("https://jellyfin.example.com:8096/Items?api_key=secret"),
+    ).toBe("https://[server]/Items");
+  });
+
+  test("WebSocket URLs with ApiKey are scrubbed too", () => {
+    expect(scrubDeep("wss://10.0.0.5:8096/socket?ApiKey=abc&deviceId=x")).toBe(
+      "wss://[server]/socket",
+    );
+  });
+
+  test("media titles in local file paths are redacted, extension kept", () => {
+    expect(
+      scrubDeep(
+        "Failed to open /var/mobile/Documents/Inception (2010) S01E02.mp4",
+      ),
+    ).toBe("Failed to open /var/mobile/Documents/[media].mp4");
+  });
+
+  test("downloaded subtitle and image filenames are redacted", () => {
+    expect(scrubDeep("/Documents/subs/My Show - Pilot.en.srt")).toBe(
+      "/Documents/subs/[media].srt",
+    );
+    expect(scrubDeep("file:///data/user/0/app/files/Poster Name.jpg")).toBe(
+      "file:///data/user/0/app/files/[media].jpg",
+    );
+  });
+
+  test("media basenames inside server URL paths are redacted as well", () => {
+    expect(scrubDeep("https://x.example.com/videos/abc-123/stream.mp4")).toBe(
+      "https://[server]/videos/abc-123/[media].mp4",
+    );
+  });
+
+  test("non-media strings pass through untouched", () => {
+    expect(scrubDeep("Marking item played/unplayed failed")).toBe(
+      "Marking item played/unplayed failed",
+    );
+    expect(scrubDeep("hwdec=videotoolbox codec=hevc")).toBe(
+      "hwdec=videotoolbox codec=hevc",
+    );
+  });
+
+  test("scrubs every nested string in objects and arrays", () => {
+    const event = {
+      message: "boot",
+      extra: {
+        urls: ["http://192.168.1.5:8096?api_key=k"],
+        detail: { path: "/Documents/Movie Title.mkv" },
+      },
+    };
+    expect(scrubDeep(event)).toEqual({
+      message: "boot",
+      extra: {
+        urls: ["http://[server]"],
+        detail: { path: "/Documents/[media].mkv" },
+      },
+    });
+  });
+
+  test("tolerates circular structures", () => {
+    const node: Record<string, unknown> = {
+      url: "https://srv.example.com?token=t",
+    };
+    node.self = node;
+    const scrubbed = scrubDeep(node) as Record<string, unknown>;
+    expect(scrubbed.url).toBe("https://[server]");
+    expect(scrubbed.self).toBe(scrubbed);
+  });
+});

--- a/utils/sentry.test.ts
+++ b/utils/sentry.test.ts
@@ -64,6 +64,33 @@ describe("scrubDeep — the privacy boundary for outgoing Sentry data", () => {
     );
   });
 
+  test("titles with apostrophes are redacted too", () => {
+    expect(scrubDeep("/var/mobile/Documents/Don't Look Up (2021).mp4")).toBe(
+      "/var/mobile/Documents/[media].mp4",
+    );
+  });
+
+  test("credential params are redacted even in server-relative URLs", () => {
+    expect(
+      scrubDeep("/videos/xyz/master.m3u8?DeviceId=abc&api_key=SECRET"),
+    ).toBe("/videos/xyz/[media].m3u8?DeviceId=abc&api_key=[redacted]");
+  });
+
+  test("credential params survive an unencoded space breaking the URL regex", () => {
+    expect(
+      scrubDeep("https://host.example.com/My Show S01E02.mp4?ApiKey=SECRET"),
+    ).toBe("https://[server]/[media].mp4?ApiKey=[redacted]");
+  });
+
+  test("scheme-less hosts in native error strings are redacted", () => {
+    expect(
+      scrubDeep("Failed to connect to jellyfin.local/192.168.1.5:8096"),
+    ).toBe("Failed to connect to [server]");
+    expect(scrubDeep("Connection refused by 192.168.1.5:8096")).toBe(
+      "Connection refused by [ip]",
+    );
+  });
+
   test("media basenames inside server URL paths are redacted as well", () => {
     expect(scrubDeep("https://x.example.com/videos/abc-123/stream.mp4")).toBe(
       "https://[server]/videos/abc-123/[media].mp4",

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -1,8 +1,10 @@
 import * as Sentry from "@sentry/react-native";
+import { Platform } from "react-native";
 import {
   readStoredPluginSettings,
   readStoredSettings,
 } from "@/utils/storedSettings";
+import { getVersionInfo } from "@/utils/version";
 
 // Public Sentry DSN for org "streamyfin", project "react-native". A DSN only
 // allows submitting events, so shipping it in the client bundle is fine.
@@ -67,12 +69,26 @@ const initializeSentry = () => {
   if (initialized || !SENTRY_DSN) return;
   initialized = true;
   try {
+    // Build-identity tags so an event can be pinned to an exact source state.
+    // `release`/`dist` stay at the SDK's native defaults — overriding them
+    // would break the association with the source maps the Expo plugin
+    // uploads under those default names.
+    const build = getVersionInfo();
     Sentry.init({
       dsn: SENTRY_DSN,
       environment: __DEV__ ? "development" : "production",
       sendDefaultPii: false,
       // Errors only — no performance tracing, session replay or screenshots.
       tracesSampleRate: 0,
+      initialScope: {
+        tags: {
+          tv: String(Platform.isTV),
+          "build.commit": build.commit ?? "unknown",
+          "build.branch": build.branch ?? "unknown",
+          "build.profile": build.profile ?? "local",
+          "build.run": build.runNumber ?? "none",
+        },
+      },
       beforeSend: (event) => scrubDeep(event) as typeof event,
       beforeBreadcrumb: (breadcrumb) =>
         scrubDeep(breadcrumb) as typeof breadcrumb,

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -33,8 +33,24 @@ const hasSentryConsent = (): boolean => {
 // sidecar subs, poster staging), so any path basename with a media extension
 // reveals what the user watches. Replace the basename, keep the extension —
 // the container is what makes a decode error debuggable, the title never is.
+// Apostrophes stay in the basename class: excluding them punched a hole for
+// every title containing one ("Don't Look Up").
 const MEDIA_FILENAME_PATTERN =
-  /([/\\])([^/\\"'\n]+)\.(mp4|mkv|m4v|mov|avi|webm|mpg|mpeg|wmv|flv|m2ts|mts|m3u8|mpd|mp3|m4a|m4b|flac|aac|ogg|oga|opus|wav|wma|srt|ass|ssa|vtt|sub|idx|jpg|jpeg|png|webp|gif|bif|nfo)\b/gi;
+  /([/\\])([^/\\"\n]+)\.(mp4|mkv|m4v|mov|avi|webm|mpg|mpeg|wmv|flv|m2ts|mts|m3u8|mpd|mp3|m4a|m4b|flac|aac|ogg|oga|opus|wav|wma|srt|ass|ssa|vtt|sub|idx|jpg|jpeg|png|webp|gif|bif|nfo)\b/gi;
+
+// Credential query parameters can appear outside scheme-anchored URLs:
+// server-relative paths ("/Videos/{id}/stream?ApiKey=...") and URLs broken by
+// an unencoded space escape the URL regexes, so known credential params are
+// redacted wherever they occur.
+const CREDENTIAL_PARAM_PATTERN =
+  /([?&](?:api_key|apikey|x-emby-token|access_token|token)=)[^&\s"']+/gi;
+
+// Native error strings can embed the private server address without a scheme:
+// Android's OkHttp writes "Failed to connect to host/1.2.3.4:8096". Redact the
+// known phrases plus any bare IPv4 (LAN servers are usually IPs).
+const SCHEMELESS_HOST_PATTERN =
+  /((?:failed to connect to|unable to resolve host)[: ]+)[^\s"']+/gi;
+const IPV4_PATTERN = /\b\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?\b/g;
 
 // Jellyfin/Jellyseerr URLs carry credentials in the query string (api_key=...,
 // the WebSocket's ApiKey=...) and the origin reveals the user's private server
@@ -44,6 +60,9 @@ const scrubUrl = (value: string): string =>
   value
     .replace(/((?:https?|wss?):\/\/[^\s"'?]+)\?[^\s"']*/g, "$1")
     .replace(/((?:https?|wss?):\/\/)[^/\s"']+/g, "$1[server]")
+    .replace(CREDENTIAL_PARAM_PATTERN, "$1[redacted]")
+    .replace(SCHEMELESS_HOST_PATTERN, "$1[server]")
+    .replace(IPV4_PATTERN, "[ip]")
     .replace(MEDIA_FILENAME_PATTERN, "$1[media].$3");
 
 // URLs can hide anywhere in an event, not just the fields with a `url` name:

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -42,8 +42,10 @@ const MEDIA_FILENAME_PATTERN =
 // server-relative paths ("/Videos/{id}/stream?ApiKey=...") and URLs broken by
 // an unencoded space escape the URL regexes, so known credential params are
 // redacted wherever they occur.
+// `userId`/`deviceId` are not credentials, but they identify the person and
+// their install across events, so they are redacted alongside the secrets.
 const CREDENTIAL_PARAM_PATTERN =
-  /([?&](?:api_key|apikey|x-emby-token|access_token|token)=)[^&\s"']+/gi;
+  /([?&](?:api_key|apikey|x-emby-token|access_token|token|userid|deviceid)=)[^&\s"']+/gi;
 
 // Native error strings can embed the private server address without a scheme:
 // Android's OkHttp writes "Failed to connect to host/1.2.3.4:8096". Redact the
@@ -95,6 +97,36 @@ export const scrubDeep = (
   return value;
 };
 
+// Touch and UI-interaction breadcrumbs record which control was tapped, and
+// their labels are accessibility labels — on a media card that IS the title.
+// They are also behaviour tracking, which this app deliberately doesn't do.
+export const isUserInteractionBreadcrumb = (
+  breadcrumb: Sentry.Breadcrumb,
+): boolean =>
+  breadcrumb.type === "user" ||
+  breadcrumb.category === "touch" ||
+  breadcrumb.category?.startsWith("ui.") === true;
+
+/**
+ * sentry-cocoa options that the React Native SDK forwards verbatim (it hands
+ * the whole options object to the native SDK) but doesn't declare in its
+ * TypeScript surface.
+ *
+ * These matter because natively-created breadcrumbs and natively-captured
+ * events (native crashes, watchdog terminations) are assembled and sent by
+ * the native layer — they NEVER pass through the `beforeSend` /
+ * `beforeBreadcrumb` scrubbers below. Swizzling is what feeds them: it adds a
+ * breadcrumb per NSURLSession request carrying the raw server URL and query
+ * string (the user's private domain, and `userId=`), plus UIKit touch and
+ * view-controller breadcrumbs. None of that is usable here — tracing is off,
+ * and the JS layer already emits its own scrubbed XHR breadcrumbs — so it is
+ * disabled at the source rather than filtered after the fact.
+ */
+const NATIVE_SDK_OPTIONS = {
+  enableSwizzling: false,
+  enableNetworkBreadcrumbs: false,
+} as Partial<Parameters<typeof Sentry.init>[0]>;
+
 const initializeSentry = () => {
   if (initialized || !SENTRY_DSN) return;
   initialized = true;
@@ -105,6 +137,7 @@ const initializeSentry = () => {
     // uploads under those default names.
     const build = getVersionInfo();
     Sentry.init({
+      ...NATIVE_SDK_OPTIONS,
       dsn: SENTRY_DSN,
       environment: __DEV__ ? "development" : "production",
       sendDefaultPii: false,
@@ -126,7 +159,9 @@ const initializeSentry = () => {
       },
       beforeSend: (event) => scrubDeep(event) as typeof event,
       beforeBreadcrumb: (breadcrumb) =>
-        scrubDeep(breadcrumb) as typeof breadcrumb,
+        isUserInteractionBreadcrumb(breadcrumb)
+          ? null
+          : (scrubDeep(breadcrumb) as typeof breadcrumb),
     });
   } catch (error) {
     initialized = false;

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -29,6 +29,13 @@ const hasSentryConsent = (): boolean => {
   return readStoredSettings().sentryEnabled !== false;
 };
 
+// Media filenames are derived from titles ("Show S01E02.mp4", downloaded
+// sidecar subs, poster staging), so any path basename with a media extension
+// reveals what the user watches. Replace the basename, keep the extension —
+// the container is what makes a decode error debuggable, the title never is.
+const MEDIA_FILENAME_PATTERN =
+  /([/\\])([^/\\"'\n]+)\.(mp4|mkv|m4v|mov|avi|webm|mpg|mpeg|wmv|flv|m2ts|mts|m3u8|mpd|mp3|m4a|m4b|flac|aac|ogg|oga|opus|wav|wma|srt|ass|ssa|vtt|sub|idx|jpg|jpeg|png|webp|gif|bif|nfo)\b/gi;
+
 // Jellyfin/Jellyseerr URLs carry credentials in the query string (api_key=...,
 // the WebSocket's ApiKey=...) and the origin reveals the user's private server
 // address, so both are scrubbed from everything that leaves the app; the
@@ -36,13 +43,17 @@ const hasSentryConsent = (): boolean => {
 const scrubUrl = (value: string): string =>
   value
     .replace(/((?:https?|wss?):\/\/[^\s"'?]+)\?[^\s"']*/g, "$1")
-    .replace(/((?:https?|wss?):\/\/)[^/\s"']+/g, "$1[server]");
+    .replace(/((?:https?|wss?):\/\/)[^/\s"']+/g, "$1[server]")
+    .replace(MEDIA_FILENAME_PATTERN, "$1[media].$3");
 
 // URLs can hide anywhere in an event, not just the fields with a `url` name:
-// console breadcrumbs keep raw console arguments in data.arguments, and
-// extra/contexts carry arbitrary payloads. So every string in the outgoing
-// object is scrubbed, however deeply nested.
-const scrubDeep = (value: unknown, seen = new WeakSet<object>()): unknown => {
+// breadcrumbs and extra/contexts carry arbitrary payloads. So every string in
+// the outgoing object is scrubbed, however deeply nested. Exported for tests —
+// this is the privacy boundary for everything that leaves the app.
+export const scrubDeep = (
+  value: unknown,
+  seen = new WeakSet<object>(),
+): unknown => {
   if (typeof value === "string") {
     return scrubUrl(value);
   }
@@ -80,6 +91,11 @@ const initializeSentry = () => {
       sendDefaultPii: false,
       // Errors only — no performance tracing, session replay or screenshots.
       tracesSampleRate: 0,
+      // Console output is unvetted — it interpolates whatever the code logs,
+      // including media titles — so it must never become breadcrumbs. App
+      // logs still flow via writeToLog's curated messages, and XHR
+      // breadcrumbs stay on (their URLs go through the scrubbers).
+      integrations: [Sentry.breadcrumbsIntegration({ console: false })],
       initialScope: {
         tags: {
           tv: String(Platform.isTV),

--- a/utils/seriesTrackMemory.test.ts
+++ b/utils/seriesTrackMemory.test.ts
@@ -18,6 +18,7 @@ mock.module("@/utils/log", () => ({
   writeInfoLog: () => undefined,
   writeErrorLog: () => undefined,
   writeDebugLog: () => undefined,
+  logAndCaptureError: () => undefined,
   readFromLog: () => [],
 }));
 

--- a/utils/storedSettings.ts
+++ b/utils/storedSettings.ts
@@ -1,3 +1,4 @@
+import { logAndCaptureError } from "@/utils/log";
 import { storage } from "@/utils/mmkv";
 
 // Raw readers for the persisted settings blobs. They exist so early-startup
@@ -7,11 +8,21 @@ import { storage } from "@/utils/mmkv";
 export const SETTINGS_KEY = "settings";
 export const PLUGIN_SETTINGS_KEY = "STREAMYFIN_PLUGIN_SETTINGS";
 
+// A corrupt blob silently resets every setting to defaults, so report it —
+// once per blob per session, since these readers run on every consent check.
+// (Reads that happen before Sentry initializes only reach the local log.)
+let reportedCorruptSettings = false;
+let reportedCorruptPluginSettings = false;
+
 export const readStoredSettings = (): Record<string, unknown> => {
   try {
     const json = storage.getString(SETTINGS_KEY);
     return json ? JSON.parse(json) : {};
-  } catch {
+  } catch (error) {
+    if (!reportedCorruptSettings) {
+      reportedCorruptSettings = true;
+      logAndCaptureError("Stored settings blob failed to parse", error);
+    }
     return {};
   }
 };
@@ -23,7 +34,11 @@ export const readStoredPluginSettings = (): Record<
   try {
     const json = storage.getString(PLUGIN_SETTINGS_KEY);
     return json ? JSON.parse(json) : {};
-  } catch {
+  } catch (error) {
+    if (!reportedCorruptPluginSettings) {
+      reportedCorruptPluginSettings = true;
+      logAndCaptureError("Stored plugin-settings blob failed to parse", error);
+    }
     return {};
   }
 };


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Sentry previously only saw unhandled crashes: nothing in the app called `captureException`, `writeErrorLog` produced breadcrumbs but never events, and an audit found ~150 catch blocks that swallow failures silently — including login, playback start, downloads, and mark-as-played. This PR adds an error-capture layer on top of #1976 while keeping its privacy posture: **errors only, no tracing, no analytics, log `data` payloads never leave the device**, and everything stays behind the existing consent gate.

**Global capture hooks**
- `QueryCache`/`MutationCache` `onError` in `app/_layout.tsx` covers all ~149 React Query sites. Skipped: anything while offline, aborted requests, connectivity failures with no HTTP response (axios or fetch — unreachable server = environment, not a bug), 401s, and errors marked expected/already-reported; deduped per (source, key, status) per session.
- **Explicit capture only**: new `logAndCaptureError(message, error, context)` is the single path that turns handled errors into Sentry events — real exception with curated context, non-Error values fingerprinted by message + detail, aborts/connectivity centrally skipped, and the error reduced to a curated `name/message/stack/status` shape before persisting to the exportable local log (a raw AxiosError would serialize its auth headers into logs.txt). `writeToLog`/`writeErrorLog` stay local + breadcrumb only, so legacy call sites never opt into Sentry by accident.
- New `RouteErrorBoundary` exported as expo-router `ErrorBoundary` from the root and tabs layouts: render crashes now show a retry screen (TV-focusable, dependency-light so it survives provider crashes) and reach Sentry with component stacks — previously the app just went blank.
- Every event is tagged with `build.commit` / `build.branch` / `build.profile` / `build.run` / `tv` from `getVersionInfo()`. `release`/`dist` deliberately stay at the SDK's native defaults so source-map association keeps working.
- New `utils/errors.ts`: `markExpectedError` (user-facing outcomes like wrong password — never reported), `markErrorReported` (prevents double-reporting when a captured error is rethrown into React Query), `isAbortLikeError`.

**Direct captures at previously-silent sites**: player `onError` (JS + native player, with play method, transcode reasons, container, mpv technical info), stream-URL/PlaybackInfo failures, download errors/reconciliation drops/corrupt stores, auth startup failure, the saved-servers migration that wipes the list on parse errors, mark-as-played, search (rendered as "no results"), settings saves, offline progress sync, music album/playlist play, Chromecast, WebSocket handler throws + reconnect exhaustion while online.

**Noise control**: wrong-password 401s, unreachable-server login failures, server probes, and Jellyseerr connectivity/auto-login failures are local-only (WARN); the Jellyseerr interceptor skips self-healing 401/403s and throttles repeats per status+path; download errors matching connectivity keywords stay local; the WebSocket give-up report gates on a real server probe and fires once per session; per-request parsers report corruption once per session.

**Privacy — no identity, no viewing habits**: events carry no user, IP (`sendDefaultPii: false`), or server address (origins → `[server]`, query strings stripped). On top of that, media titles never leave the device: console breadcrumbs are disabled entirely (console output is unvetted and can interpolate item names), `scrubDeep` redacts media-file basenames anywhere in an event (`/Documents/Show S01E02.mp4` → `/Documents/[media].mp4` — download filenames are title-derived), React Query error context sends only the query key's *name* (later elements can hold search text), and Jellyseerr error URLs are stripped of query strings. The scrubber also redacts credential query params scheme-independently (relative stream URLs, space-broken URLs), `userId`/`deviceId`, scheme-less hosts/IPv4s from native error strings, and titles with apostrophes. `scrubDeep` is exported and unit-tested as the privacy boundary.

**Native layer** (found by inspecting a real event): sentry-cocoa creates its own breadcrumbs and sends natively-captured events (native crashes, watchdog terminations) itself — they never pass through the JS `beforeSend`/`beforeBreadcrumb`, so the scrubbers did not apply to them. A single event showed both `https://[server]/Sessions` (JS, scrubbed) and `https://fredflix.se/Sessions?userId=…` (native, raw). Fixed by disabling native swizzling and network breadcrumbs at the source — they power automatic instrumentation this app doesn't use (tracing is off, and the JS layer emits its own scrubbed XHR breadcrumbs). Touch/`ui.*` breadcrumbs are dropped too: they record which control was tapped and their labels are accessibility labels, which on a media card is the title.

⚠️ Residual limit: a *native crash's own exception string* still can't pass through a JS scrubber (SDK limitation). Worth adding a server-side Advanced Data Scrubbing rule in the Sentry project as defence in depth, since that applies to every event regardless of origin.

**Bug fixes surfaced by the audit**
- iOS background downloader never checked HTTP status: a 401/500 error body was recorded as a completed download, failing only at playback. It now emits `onDownloadError` like Android already does. ⚠️ Behavior change + needs a native rebuild.
- Jellyseerr request interceptor's error callback returned `undefined` instead of re-rejecting.
- `getStreamUrl` now throws with Jellyfin's `ErrorCode` (`NoCompatibleStream`, …) when PlaybackInfo returns no media source, instead of fabricating a direct-play URL that fails later as an opaque decoder error.

## 🏷️ Ticket / Issue

N/A — follow-up to #1976.

### 🖼️ Screenshots / GIFs (if UI)

The only UI change is the new error-boundary fallback screen (black background, "Something went wrong" + error message + Retry button), which only appears when a screen crashes during render. No screenshots yet — will add once device-verified.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms *(pending — device smoke test still to do, see below)*
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. `bun run typecheck`, `bun run test:unit`, and `bun run i18n:check` pass (181 unit tests).
2. **Error boundary**: temporarily throw inside any screen component and reload — the app should show the retry screen instead of going blank; Retry re-renders the route. With crash reporting enabled, the error appears in Sentry with a component stack.
3. **Sentry events**: with reporting enabled (Settings → Plugins), trigger any handled failure — e.g. stop the Jellyfin server mid-session and mark an item played — and verify an event arrives tagged with `build.commit`/`tv`, with the server origin scrubbed to `[server]`.
4. **Opt-out**: disable crash reporting and verify none of the above produces events.
5. **iOS download fix** (needs native rebuild, `bun run ios`): start a download, then invalidate the token server-side (or point at an endpoint returning 401) — the download must now fail with a download error instead of appearing as a completed item that won't play.
6. **No noise**: wrong password at login, a typo'd server address, and Jellyseerr being unreachable must NOT create Sentry events (they stay in Settings → Logs as WARN).

https://claude.ai/code/session_01MV9Z5R1ykEH5Sby5MJ523G

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of playback, search, casting, downloads, synchronization, and connection failures.
  * Failed downloads no longer save invalid response data.
  * Playback negotiation stops cleanly when no media source is available.
  * Corrupted settings and download data safely fall back to empty configurations.

* **Improvements**
  * Added route-level recovery screens with retry support, including TV-friendly controls.
  * Reduced duplicate error reports and improved failure diagnostics.
  * Enhanced Sentry privacy protections and added build and platform context.
  * Added English fallback text for unexpected errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
