### PR TITLE
feat(home): native hero carousel on the iOS home tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ State/Data:
 - `mark-as-played-flow` | PlayedStatus→useMarkAsPlayed→playbackManager with optimistic updates
 
 Native Modules:
+- `expo-view-props-fail-silently` | `try? prop.set()` drops failed prop conversions with NO error; use a JSON string prop
 - `mpv-tvos-player-exit-freeze` | mpv_terminate_destroy deadlocks main thread; use DispatchQueue.global()
 - `mpv-avfoundation-composite-osd-ordering` | MUST follow vo=avfoundation, before hwdec options
 - `thread-safe-state-for-stop-flags` | Stop flags need synchronous setter (stateQueue.sync not async)

--- a/app.json
+++ b/app.json
@@ -89,7 +89,12 @@
           "ios": {
             "deploymentTarget": "16.4",
             "useFrameworks": "static",
-            "forceStaticLinking": ["ExpoUI", "GlassEffectView", "GlassPoster"]
+            "forceStaticLinking": [
+              "ExpoUI",
+              "GlassEffectView",
+              "GlassPoster",
+              "HeroCarousel"
+            ]
           },
           "android": {
             "buildArchs": ["arm64-v8a", "x86_64", "armeabi-v7a"],

--- a/app/(auth)/(tabs)/(home)/settings.tv.tsx
+++ b/app/(auth)/(tabs)/(home)/settings.tv.tsx
@@ -1164,10 +1164,10 @@ export default function SettingsTV() {
             onToggle={(value) => updateSettings({ showHomeBackdrop: value })}
           />
           <TVSettingsToggle
-            disabledByAdmin={pluginSettings?.showTVHeroCarousel?.locked}
+            disabledByAdmin={pluginSettings?.showHeroCarousel?.locked}
             label={t("home.settings.appearance.show_hero_carousel")}
-            value={settings.showTVHeroCarousel}
-            onToggle={(value) => updateSettings({ showTVHeroCarousel: value })}
+            value={settings.showHeroCarousel}
+            onToggle={(value) => updateSettings({ showHeroCarousel: value })}
           />
           <TVSettingsToggle
             disabledByAdmin={pluginSettings?.showSeriesPosterOnEpisode?.locked}

--- a/components/home/Home.tsx
+++ b/components/home/Home.tsx
@@ -28,6 +28,7 @@ import { Button } from "@/components/Button";
 import { HeaderButton } from "@/components/common/HeaderButton";
 import { HeaderIcon } from "@/components/common/HeaderIcon";
 import { Text } from "@/components/common/Text";
+import { HomeHeroCarousel } from "@/components/home/HomeHeroCarousel";
 import { InfiniteScrollingCollectionList } from "@/components/home/InfiniteScrollingCollectionList";
 import { StreamystatsPromotedWatchlists } from "@/components/home/StreamystatsPromotedWatchlists";
 import { StreamystatsRecommendations } from "@/components/home/StreamystatsRecommendations";
@@ -619,6 +620,7 @@ const HomeMobile = () => {
         className='flex flex-col space-y-4'
         style={{ paddingTop: Platform.OS === "android" ? 10 : 0 }}
       >
+        <HomeHeroCarousel />
         {sections.map((section, index) => {
           // Render Streamystats sections after Recently Added sections
           // For default sections: place after Recently Added, before Suggested Movies (if present)

--- a/components/home/Home.tv.tsx
+++ b/components/home/Home.tv.tsx
@@ -561,8 +561,8 @@ export const Home = () => {
   // Determine if hero should be shown (separate setting from backdrop)
   // We need this early to calculate which sections will actually be rendered
   const showHero = useMemo(() => {
-    return heroItems && heroItems.length > 0 && settings.showTVHeroCarousel;
-  }, [heroItems, settings.showTVHeroCarousel]);
+    return heroItems && heroItems.length > 0 && settings.showHeroCarousel;
+  }, [heroItems, settings.showHeroCarousel]);
 
   // Get sections that will actually be rendered (accounting for hero slicing)
   // When hero is shown, skip the first sections since hero already displays that content

--- a/components/home/HomeHeroCarousel.tsx
+++ b/components/home/HomeHeroCarousel.tsx
@@ -1,0 +1,663 @@
+import type { Api } from "@jellyfin/sdk";
+import type {
+  BaseItemDto,
+  BaseItemKind,
+} from "@jellyfin/sdk/lib/generated-client/models";
+import {
+  getItemsApi,
+  getTvShowsApi,
+  getUserLibraryApi,
+} from "@jellyfin/sdk/lib/utils/api";
+import { useQuery } from "@tanstack/react-query";
+import { useSegments } from "expo-router";
+import { useAtomValue } from "jotai";
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useWindowDimensions } from "react-native";
+import useRouter from "@/hooks/useAppRouter";
+import { useHaptic } from "@/hooks/useHaptic";
+import { useHeadersForUrl } from "@/hooks/useHeadersForUrl";
+import {
+  type HeroCarouselFilterSection,
+  type HeroCarouselFilterToggleEvent,
+  type HeroCarouselItem,
+  type HeroCarouselItemPressEvent,
+  HeroCarouselView,
+  isHeroCarouselAvailable,
+} from "@/modules";
+import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
+import {
+  type HomeHeroMediaType,
+  type HomeHeroSection,
+  useSettings,
+} from "@/utils/atoms/settings";
+import { getBackdropUrl } from "@/utils/jellyfin/image/getBackdropUrl";
+import { getLogoImageUrlById } from "@/utils/jellyfin/image/getLogoImageUrlById";
+import { getParentBackdropImageUrl } from "@/utils/jellyfin/image/getParentBackdropImageUrl";
+import { getPrimaryImageUrl } from "@/utils/jellyfin/image/getPrimaryImageUrl";
+import { runtimeTicksToMinutes } from "@/utils/time";
+import { getItemNavigation } from "../common/TouchableItemRouter";
+
+// Space the native view reserves under the cards for the page dots.
+const DOTS_AREA = 24;
+
+/**
+ * Card geometry for the current window width. Derived per render rather than
+ * once at import: on iPad the width changes with rotation and Split View.
+ */
+const heroMetrics = (windowWidth: number) => {
+  // Matches the 36pt page margin inside the native view.
+  const cardWidth = Math.max(windowWidth - 72, 1);
+  return {
+    cardHeight: Math.round(Math.min(cardWidth * 1.15, 440)),
+    backdropWidth: Math.min(Math.round(cardWidth * 2), 1920),
+  };
+};
+
+const IMAGE_TYPES = ["Primary", "Backdrop", "Logo", "Thumb"] as const;
+
+type HeroSection = HomeHeroSection;
+
+/** The carousel always aims for this many slides, whatever is filtered out. */
+const HERO_TARGET_COUNT = 10;
+
+/**
+ * Relative share of the carousel each group gets when everything is enabled:
+ * 2 continue-watching, 2 next-up, 6 recently added (3 movies + 3 TV).
+ * Disabling a group redistributes its share across the ones that remain, in
+ * proportion to these weights, rather than simply shortening the carousel.
+ */
+const GROUP_WEIGHTS: Record<HeroSection, number> = {
+  continueWatching: 2,
+  nextUp: 2,
+  recentlyAdded: 6,
+};
+
+/**
+ * Splits `total` across the given weights so the parts sum to exactly
+ * `total` (largest-remainder apportionment). Entries are passed in priority
+ * order, which is how remainder ties are broken.
+ */
+const apportion = <K extends string>(
+  total: number,
+  weights: [K, number][],
+): Record<K, number> => {
+  const sum = weights.reduce((acc, [, weight]) => acc + weight, 0);
+  const result = {} as Record<K, number>;
+  if (sum <= 0) {
+    for (const [key] of weights) result[key] = 0;
+    return result;
+  }
+
+  const remainders: { key: K; remainder: number }[] = [];
+  let assigned = 0;
+  for (const [key, weight] of weights) {
+    const exact = (total * weight) / sum;
+    const floor = Math.floor(exact);
+    result[key] = floor;
+    assigned += floor;
+    remainders.push({ key, remainder: exact - floor });
+  }
+
+  // Hand out what rounding left over, biggest fractional part first. Sort is
+  // stable, so equal remainders fall to whichever came first in `weights`.
+  const leftover = total - assigned;
+  remainders
+    .sort((a, b) => b.remainder - a.remainder)
+    .slice(0, Math.max(leftover, 0))
+    .forEach(({ key }) => {
+      result[key] += 1;
+    });
+  return result;
+};
+
+/**
+ * How many items to request for a quota of `n`. Dedup (same item or same
+ * series across groups) eats candidates, and the leftovers are what backfill
+ * a bucket that comes up short, so every bucket fetches spare capacity.
+ */
+const overFetch = (quota: number) =>
+  quota <= 0 ? 0 : Math.min(quota * 2 + 4, HERO_TARGET_COUNT * 2);
+
+const SECTION_LABEL_KEYS: Record<HeroSection, string> = {
+  continueWatching: "home.continue_watching",
+  nextUp: "home.next_up",
+  recentlyAdded: "home.recently_added",
+};
+
+const SECTION_ICONS: Record<HeroSection, string> = {
+  continueWatching: "play.fill",
+  nextUp: "forward.fill",
+  recentlyAdded: "sparkles",
+};
+
+type HeroEntry = { item: BaseItemDto; section: HeroSection };
+
+/** Menu row keys, namespaced so one event handler can route every row. */
+const SECTION_KEY_PREFIX = "section:";
+const MEDIA_KEY_PREFIX = "media:";
+/** Turns the whole hero off; also lives in the app's appearance settings. */
+const VISIBILITY_KEY = "visibility:hero";
+
+const ALL_SECTIONS: HomeHeroSection[] = [
+  "continueWatching",
+  "nextUp",
+  "recentlyAdded",
+];
+const ALL_MEDIA_TYPES: HomeHeroMediaType[] = ["movie", "tv"];
+
+const MEDIA_LABEL_KEYS: Record<HomeHeroMediaType, string> = {
+  movie: "common.movies",
+  tv: "home.hero.tv_shows",
+};
+
+const toggleHidden = <T extends string>(hidden: T[], value: T): T[] =>
+  hidden.includes(value)
+    ? hidden.filter((entry) => entry !== value)
+    : [...hidden, value];
+
+/**
+ * Which slide sources survive a filter state. Shared by the query and by the
+ * menu's guard so the two can't drift apart.
+ */
+const resolveSources = (
+  hiddenSections: HomeHeroSection[],
+  hiddenMediaTypes: HomeHeroMediaType[],
+) => {
+  const showMovies = !hiddenMediaTypes.includes("movie");
+  const showTv = !hiddenMediaTypes.includes("tv");
+  const showContinueWatching =
+    !hiddenSections.includes("continueWatching") && (showMovies || showTv);
+  // Next up is episodes only, so it disappears with the TV media type.
+  const showNextUp = !hiddenSections.includes("nextUp") && showTv;
+  const showRecentlyAdded =
+    !hiddenSections.includes("recentlyAdded") && (showMovies || showTv);
+  return {
+    showMovies,
+    showTv,
+    showContinueWatching,
+    showNextUp,
+    showRecentlyAdded,
+  };
+};
+
+/**
+ * Whether a filter state leaves anything to show. The two hidden-lists have
+ * to be judged together, not one at a time: Next Up is episodes-only, so
+ * hiding the other two groups and then hiding TV silences every source even
+ * though each of those toggles is legal on its own. An empty carousel takes
+ * the filter menu down with it, so such a combination is refused.
+ */
+const hasAnySource = (
+  hiddenSections: HomeHeroSection[],
+  hiddenMediaTypes: HomeHeroMediaType[],
+): boolean => {
+  const sources = resolveSources(hiddenSections, hiddenMediaTypes);
+  return (
+    sources.showContinueWatching ||
+    sources.showNextUp ||
+    sources.showRecentlyAdded
+  );
+};
+
+const isTvChild = (item: BaseItemDto) =>
+  item.Type === "Episode" || item.Type === "Season";
+
+/** Everything that isn't a movie is TV (Series, Season, Episode). */
+const mediaTypeOf = (item: BaseItemDto): HomeHeroMediaType =>
+  item.Type === "Movie" ? "movie" : "tv";
+
+const buildSubtitle = (item: BaseItemDto): string | null => {
+  if (item.Type === "Episode") {
+    const season = item.ParentIndexNumber;
+    const episode = item.IndexNumber;
+    const code =
+      season != null && episode != null ? `S${season}E${episode}` : null;
+    if (code && item.Name) return `${code} · ${item.Name}`;
+    return item.Name || code;
+  }
+  if (item.Type === "Season") return item.Name || null;
+  return null;
+};
+
+const buildBackdropUrl = (
+  api: Api,
+  item: BaseItemDto,
+  width: number,
+): string | null => {
+  // Episodes/seasons: prefer the series backdrop over the episode still.
+  if (
+    isTvChild(item) &&
+    item.ParentBackdropItemId &&
+    item.ParentBackdropImageTags?.length
+  ) {
+    return getParentBackdropImageUrl({ api, item, quality: 80, width });
+  }
+  return getBackdropUrl({ api, item, quality: 80, width });
+};
+
+const buildLogoUrl = (api: Api, item: BaseItemDto): string | null => {
+  // Handles the item's own logo and the Episode → parent logo case.
+  const own = getLogoImageUrlById({ api, item, height: 120 });
+  if (own) return own;
+  // Seasons carry the series logo only through the Parent* fields.
+  if (item.ParentLogoItemId && item.ParentLogoImageTag) {
+    const params = new URLSearchParams({
+      tag: item.ParentLogoImageTag,
+      quality: "90",
+      fillHeight: "120",
+    });
+    return `${api.basePath}/Items/${item.ParentLogoItemId}/Images/Logo?${params.toString()}`;
+  }
+  return null;
+};
+
+const buildPosterUrl = (api: Api, item: BaseItemDto): string | null => {
+  // An episode's Primary is a 16:9 still that crops badly in the portrait
+  // thumb slot; use the series poster instead.
+  if (item.Type === "Episode" && item.SeriesId && item.SeriesPrimaryImageTag) {
+    const params = new URLSearchParams({
+      tag: item.SeriesPrimaryImageTag,
+      quality: "90",
+      fillWidth: "240",
+    });
+    return `${api.basePath}/Items/${item.SeriesId}/Images/Primary?${params.toString()}`;
+  }
+  return getPrimaryImageUrl({ api, item, width: 240 });
+};
+
+const buildBadges = (item: BaseItemDto): string[] => {
+  const badges: string[] = [];
+  if (item.ProductionYear) badges.push(String(item.ProductionYear));
+  if (item.OfficialRating) badges.push(item.OfficialRating);
+  if (item.RunTimeTicks) badges.push(runtimeTicksToMinutes(item.RunTimeTicks));
+  return badges;
+};
+
+/**
+ * Native hero carousel at the top of the home tab. All data (image URLs,
+ * localized labels and badges) is prepared here — the native view is purely
+ * presentational. Renders nothing on platforms without the native module.
+ *
+ * Two independent filters narrow the slides, both driven by settings and
+ * both "hidden" lists so the default (empty) shows everything:
+ * `hiddenHomeHeroSections` drops a whole group, `hiddenHomeHeroMediaTypes`
+ * drops movies or TV across every group. A group whose content is entirely
+ * filtered out is never requested from the server.
+ *
+ * The carousel keeps its length at {@link HERO_TARGET_COUNT} regardless: a
+ * filtered-out group's share is reapportioned over whatever remains, and it
+ * lands where the filter implies. Hiding movies pushes the recently-added
+ * share entirely onto TV; hiding next-up grows continue-watching and
+ * recently-added together. Anything still short after that (dedup, a thin
+ * library) is backfilled from the buckets that have candidates to spare.
+ */
+export const HomeHeroCarousel = () => {
+  const api = useAtomValue(apiAtom);
+  const user = useAtomValue(userAtom);
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { settings, updateSettings, pluginSettings } = useSettings();
+  const lightHapticFeedback = useHaptic("light");
+  const { width: windowWidth } = useWindowDimensions();
+  const metrics = useMemo(() => heroMetrics(windowWidth), [windowWidth]);
+  const segments = useSegments();
+  const from = (segments as string[])[2] || "(home)";
+  const imageHeaders = useHeadersForUrl(api?.basePath);
+
+  const hiddenSections = settings?.hiddenHomeHeroSections;
+  const hiddenMediaTypes = settings?.hiddenHomeHeroMediaTypes;
+  // `settings` starts empty before the stored values load; default to on so
+  // the hero doesn't flash out of existence on a cold start.
+  const showHeroCarousel = settings?.showHeroCarousel !== false;
+
+  const filters = useMemo(() => {
+    const {
+      showMovies,
+      showTv,
+      showContinueWatching,
+      showNextUp,
+      showRecentlyAdded,
+    } = resolveSources(hiddenSections ?? [], hiddenMediaTypes ?? []);
+
+    // Share out the target length over the groups still standing, then split
+    // the recently-added share over the media types still standing.
+    const groupQuota = apportion(
+      HERO_TARGET_COUNT,
+      (
+        [
+          ["continueWatching", showContinueWatching],
+          ["nextUp", showNextUp],
+          ["recentlyAdded", showRecentlyAdded],
+        ] as [HeroSection, boolean][]
+      )
+        .filter(([, enabled]) => enabled)
+        .map(([section]) => [section, GROUP_WEIGHTS[section]]),
+    );
+
+    const mediaQuota = apportion(
+      groupQuota.recentlyAdded ?? 0,
+      (
+        [
+          ["movie", showMovies],
+          ["tv", showTv],
+        ] as [HomeHeroMediaType, boolean][]
+      )
+        .filter(([, enabled]) => enabled)
+        .map(([mediaType]) => [mediaType, 1]),
+    );
+
+    return {
+      showMovies,
+      showTv,
+      showContinueWatching,
+      showNextUp,
+      showRecentlyAddedMovies: showRecentlyAdded && showMovies,
+      showRecentlyAddedTv: showRecentlyAdded && showTv,
+      continueWatchingQuota: groupQuota.continueWatching ?? 0,
+      nextUpQuota: groupQuota.nextUp ?? 0,
+      recentlyAddedMovieQuota: mediaQuota.movie ?? 0,
+      recentlyAddedTvQuota: mediaQuota.tv ?? 0,
+    };
+  }, [hiddenSections, hiddenMediaTypes]);
+
+  const { data: entries } = useQuery({
+    queryKey: [
+      "home",
+      "heroCarousel",
+      user?.Id,
+      hiddenSections?.join(",") ?? "",
+      hiddenMediaTypes?.join(",") ?? "",
+    ],
+    queryFn: async (): Promise<HeroEntry[]> => {
+      if (!api || !user?.Id) return [];
+
+      const resumeTypes: BaseItemKind[] = [
+        ...(filters.showMovies ? (["Movie"] as const) : []),
+        ...(filters.showTv ? (["Series", "Episode"] as const) : []),
+      ];
+
+      // Each source degrades independently: a failing endpoint drops its
+      // slides instead of blanking the whole carousel.
+      const [resume, nextUp, latestMovies, latestTv] = await Promise.all([
+        filters.showContinueWatching
+          ? getItemsApi(api)
+              .getResumeItems({
+                userId: user.Id,
+                limit: overFetch(filters.continueWatchingQuota),
+                includeItemTypes: resumeTypes,
+                fields: ["Overview"],
+                enableImageTypes: [...IMAGE_TYPES],
+                imageTypeLimit: 1,
+              })
+              .catch(() => null)
+          : null,
+        filters.showNextUp
+          ? getTvShowsApi(api)
+              .getNextUp({
+                userId: user.Id,
+                limit: overFetch(filters.nextUpQuota),
+                fields: ["Overview"],
+                enableImageTypes: [...IMAGE_TYPES],
+                imageTypeLimit: 1,
+                enableResumable: false,
+              })
+              .catch(() => null)
+          : null,
+        filters.showRecentlyAddedMovies
+          ? getUserLibraryApi(api)
+              .getLatestMedia({
+                userId: user.Id,
+                includeItemTypes: ["Movie"],
+                limit: overFetch(filters.recentlyAddedMovieQuota),
+                fields: ["Overview"],
+                enableImageTypes: [...IMAGE_TYPES],
+                imageTypeLimit: 1,
+                groupItems: false,
+              })
+              .catch(() => null)
+          : null,
+        filters.showRecentlyAddedTv
+          ? getUserLibraryApi(api)
+              .getLatestMedia({
+                userId: user.Id,
+                includeItemTypes: ["Series", "Season", "Episode"],
+                limit: overFetch(filters.recentlyAddedTvQuota),
+                fields: ["Overview"],
+                enableImageTypes: [...IMAGE_TYPES],
+                imageTypeLimit: 1,
+                groupItems: true,
+              })
+              .catch(() => null)
+          : null,
+      ]);
+
+      const result: HeroEntry[] = [];
+      const seenIds = new Set<string>();
+      const seenSeries = new Set<string>();
+      const seriesKey = (item: BaseItemDto) =>
+        item.SeriesId || (item.Type === "Series" ? item.Id : undefined);
+
+      const push = (
+        item: BaseItemDto | null | undefined,
+        section: HeroSection,
+      ): boolean => {
+        if (!item?.Id || seenIds.has(item.Id)) return false;
+        // Endpoints can return a mixed bag (resume covers both kinds), so the
+        // media-type filter is enforced on results, not just on the request.
+        const mediaType = mediaTypeOf(item);
+        if (mediaType === "movie" && !filters.showMovies) return false;
+        if (mediaType === "tv" && !filters.showTv) return false;
+        // One card per show across the whole carousel: with ten slides the
+        // same series could otherwise turn up as continue-watching, next-up
+        // and recently-added all at once.
+        const key = seriesKey(item);
+        if (key && seenSeries.has(key)) return false;
+        seenIds.add(item.Id);
+        if (key) seenSeries.add(key);
+        result.push({ item, section });
+        return true;
+      };
+
+      const buckets = [
+        {
+          section: "continueWatching" as const,
+          candidates: resume?.data.Items ?? [],
+          quota: filters.continueWatchingQuota,
+        },
+        {
+          section: "nextUp" as const,
+          candidates: nextUp?.data.Items ?? [],
+          quota: filters.nextUpQuota,
+        },
+        {
+          section: "recentlyAdded" as const,
+          candidates: latestMovies?.data ?? [],
+          quota: filters.recentlyAddedMovieQuota,
+        },
+        {
+          section: "recentlyAdded" as const,
+          candidates: latestTv?.data ?? [],
+          quota: filters.recentlyAddedTvQuota,
+        },
+      ];
+
+      // Each bucket keeps its own cursor, so the backfill pass resumes where
+      // the quota pass stopped instead of re-testing rejected candidates.
+      const cursors = buckets.map(() => 0);
+      const takeFrom = (index: number): boolean => {
+        const { candidates, section } = buckets[index];
+        while (cursors[index] < candidates.length) {
+          const item = candidates[cursors[index]];
+          cursors[index] += 1;
+          if (push(item, section)) return true;
+        }
+        return false;
+      };
+
+      buckets.forEach((bucket, index) => {
+        for (let taken = 0; taken < bucket.quota; taken++) {
+          if (result.length >= HERO_TARGET_COUNT) return;
+          if (!takeFrom(index)) break;
+        }
+      });
+
+      // Backfill: whatever a bucket couldn't fill (dedup, a thin library)
+      // goes to the buckets that still have candidates, round-robin so no
+      // single group runs away with the remainder.
+      let progressed = true;
+      while (result.length < HERO_TARGET_COUNT && progressed) {
+        progressed = false;
+        for (let index = 0; index < buckets.length; index++) {
+          if (result.length >= HERO_TARGET_COUNT) break;
+          if (takeFrom(index)) progressed = true;
+        }
+      }
+
+      // Backfilled slides are appended wherever they were found, which can
+      // strand e.g. a continue-watching card after the recently-added run.
+      // Sorting is stable, so this regroups them without disturbing the
+      // order within a group.
+      result.sort(
+        (a, b) =>
+          ALL_SECTIONS.indexOf(a.section) - ALL_SECTIONS.indexOf(b.section),
+      );
+
+      return result;
+    },
+    enabled:
+      isHeroCarouselAvailable() && showHeroCarousel && !!api && !!user?.Id,
+    staleTime: 60 * 1000,
+  });
+
+  const items = useMemo<HeroCarouselItem[]>(() => {
+    if (!api || !entries) return [];
+    return entries.map(({ item, section }) => ({
+      id: item.Id!,
+      title: (isTvChild(item) ? item.SeriesName : item.Name) || item.Name || "",
+      subtitle: buildSubtitle(item),
+      overview: item.Overview || "",
+      label: t(SECTION_LABEL_KEYS[section]),
+      labelIcon: SECTION_ICONS[section],
+      backdropUrl: buildBackdropUrl(api, item, metrics.backdropWidth),
+      logoUrl: buildLogoUrl(api, item),
+      posterUrl: buildPosterUrl(api, item),
+      badges: buildBadges(item),
+      communityRating: item.CommunityRating ?? null,
+      progress: item.UserData?.PlayedPercentage
+        ? item.UserData.PlayedPercentage / 100
+        : null,
+    }));
+  }, [api, entries, t, metrics.backdropWidth]);
+
+  // An admin-locked setting is dropped by updateSettings, so offering its row
+  // would just be a dead tap. Omit those rows the way the settings screen
+  // disables their switches; with all three locked the button disappears.
+  const filterSections = useMemo<HeroCarouselFilterSection[]>(() => {
+    const sections: HeroCarouselFilterSection[] = [];
+    if (pluginSettings?.hiddenHomeHeroSections?.locked !== true) {
+      sections.push({
+        key: "groups",
+        title: t("home.hero.groups"),
+        options: ALL_SECTIONS.map((section) => ({
+          key: `${SECTION_KEY_PREFIX}${section}`,
+          label: t(SECTION_LABEL_KEYS[section]),
+          enabled: !(hiddenSections ?? []).includes(section),
+        })),
+      });
+    }
+    if (pluginSettings?.hiddenHomeHeroMediaTypes?.locked !== true) {
+      sections.push({
+        key: "media",
+        title: t("home.hero.media"),
+        options: ALL_MEDIA_TYPES.map((mediaType) => ({
+          key: `${MEDIA_KEY_PREFIX}${mediaType}`,
+          label: t(MEDIA_LABEL_KEYS[mediaType]),
+          enabled: !(hiddenMediaTypes ?? []).includes(mediaType),
+        })),
+      });
+    }
+    if (pluginSettings?.showHeroCarousel?.locked !== true) {
+      sections.push({
+        // Untitled trailing group: this switches the hero off entirely
+        // rather than filtering it, so it reads as its own thing.
+        key: "visibility",
+        options: [
+          {
+            key: VISIBILITY_KEY,
+            label: t("home.hero.disable"),
+            // Only reachable while the hero is on, so it is a one-way
+            // action rather than something that can show a checkmark.
+            enabled: true,
+            destructive: true,
+          },
+        ],
+      });
+    }
+    return sections;
+  }, [t, hiddenSections, hiddenMediaTypes, pluginSettings]);
+
+  const handleFilterToggle = useCallback(
+    (event: { nativeEvent: HeroCarouselFilterToggleEvent }) => {
+      const { key } = event.nativeEvent;
+      lightHapticFeedback();
+      if (key === VISIBILITY_KEY) {
+        // The row only ever shows checked — the hero is gone once it is off,
+        // so the way back is the appearance settings screen.
+        updateSettings({ showHeroCarousel: false });
+        return;
+      }
+      if (key.startsWith(SECTION_KEY_PREFIX)) {
+        const section = key.slice(SECTION_KEY_PREFIX.length) as HomeHeroSection;
+        const next = toggleHidden(hiddenSections ?? [], section);
+        if (!hasAnySource(next, hiddenMediaTypes ?? [])) return;
+        updateSettings({ hiddenHomeHeroSections: next });
+        return;
+      }
+      if (key.startsWith(MEDIA_KEY_PREFIX)) {
+        const mediaType = key.slice(
+          MEDIA_KEY_PREFIX.length,
+        ) as HomeHeroMediaType;
+        const next = toggleHidden(hiddenMediaTypes ?? [], mediaType);
+        if (!hasAnySource(hiddenSections ?? [], next)) return;
+        updateSettings({ hiddenHomeHeroMediaTypes: next });
+      }
+    },
+    [hiddenSections, hiddenMediaTypes, updateSettings, lightHapticFeedback],
+  );
+
+  const handleItemPress = useCallback(
+    (event: { nativeEvent: HeroCarouselItemPressEvent }) => {
+      const entry = entries?.find(
+        ({ item }) => item.Id === event.nativeEvent.id,
+      );
+      if (!entry) return;
+      lightHapticFeedback();
+      router.push(getItemNavigation(entry.item, from) as any);
+    },
+    [entries, from, router, lightHapticFeedback],
+  );
+
+  // Keep the view mounted when filters emptied it, so the filter button (and
+  // the way back) stays reachable over the empty-state skeleton.
+  const hasActiveFilters =
+    (hiddenSections?.length ?? 0) > 0 || (hiddenMediaTypes?.length ?? 0) > 0;
+  if (!isHeroCarouselAvailable() || !showHeroCarousel) return null;
+  if (items.length === 0 && !hasActiveFilters) return null;
+
+  return (
+    <HeroCarouselView
+      items={items}
+      imageHeaders={imageHeaders}
+      filterSections={filterSections}
+      filterLabel={t("home.hero.filter")}
+      onItemPress={handleItemPress}
+      onFilterToggle={handleFilterToggle}
+      style={{
+        width: "100%",
+        height: metrics.cardHeight + DOTS_AREA,
+        marginTop: 8,
+      }}
+    />
+  );
+};

--- a/components/settings/AppearanceSettings.tsx
+++ b/components/settings/AppearanceSettings.tsx
@@ -44,6 +44,21 @@ export const AppearanceSettings: React.FC = () => {
             }
           />
         </ListItem>
+        {Platform.OS === "ios" && (
+          <ListItem
+            title={t("home.settings.appearance.show_hero_carousel")}
+            subtitle={t("home.settings.appearance.show_hero_carousel_hint")}
+            disabled={pluginSettings?.showHeroCarousel?.locked}
+          >
+            <SettingSwitch
+              value={settings.showHeroCarousel}
+              disabled={pluginSettings?.showHeroCarousel?.locked}
+              onValueChange={(value) =>
+                updateSettings({ showHeroCarousel: value })
+              }
+            />
+          </ListItem>
+        )}
         <ListItem
           title={t("home.settings.appearance.merge_next_up_continue_watching")}
           subtitle={t(

--- a/modules/hero-carousel/expo-module.config.json
+++ b/modules/hero-carousel/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["HeroCarouselModule"]
+  }
+}

--- a/modules/hero-carousel/index.ts
+++ b/modules/hero-carousel/index.ts
@@ -1,0 +1,7 @@
+// Hero Carousel - Native SwiftUI paged hero for the iOS home tab
+
+export * from "./src/HeroCarousel.types";
+export {
+  default as HeroCarouselView,
+  isHeroCarouselAvailable,
+} from "./src/HeroCarouselView";

--- a/modules/hero-carousel/ios/HeroCarousel.podspec
+++ b/modules/hero-carousel/ios/HeroCarousel.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name           = 'HeroCarousel'
+  s.version        = '1.0.0'
+  s.summary        = 'Native SwiftUI hero carousel for iOS'
+  s.description    = 'Paged hero carousel with parallax backdrops and glass info panels for the home tab'
+  s.author         = 'Streamyfin'
+  s.homepage       = 'https://github.com/streamyfin/streamyfin'
+  s.platforms      = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_VERSION' => '5.9'
+  }
+
+  s.source_files = "*.{h,m,mm,swift}"
+end

--- a/modules/hero-carousel/ios/HeroCarouselExpoView.swift
+++ b/modules/hero-carousel/ios/HeroCarouselExpoView.swift
@@ -1,0 +1,150 @@
+import Combine
+import ExpoModulesCore
+import SwiftUI
+import UIKit
+
+/// Plain value the SwiftUI layer renders — decoupled from the transport so
+/// the view code has no ExpoModulesCore dependency.
+struct HeroItem: Identifiable, Equatable, Decodable {
+  let id: String
+  let title: String
+  let subtitle: String?
+  let overview: String
+  let label: String?
+  let labelIcon: String?
+  let backdropUrl: String?
+  let logoUrl: String?
+  let posterUrl: String?
+  let badges: [String]
+  let communityRating: Double?
+  /// Watch progress in 0...1; renders a progress bar when > 0.
+  let progress: Double?
+
+  private enum CodingKeys: String, CodingKey {
+    case id, title, subtitle, overview, label, labelIcon
+    case backdropUrl, logoUrl, posterUrl, badges, communityRating, progress
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+    subtitle = try container.decodeIfPresent(String.self, forKey: .subtitle)
+    overview = try container.decodeIfPresent(String.self, forKey: .overview) ?? ""
+    label = try container.decodeIfPresent(String.self, forKey: .label)
+    labelIcon = try container.decodeIfPresent(String.self, forKey: .labelIcon)
+    backdropUrl = try container.decodeIfPresent(String.self, forKey: .backdropUrl)
+    logoUrl = try container.decodeIfPresent(String.self, forKey: .logoUrl)
+    posterUrl = try container.decodeIfPresent(String.self, forKey: .posterUrl)
+    badges = try container.decodeIfPresent([String].self, forKey: .badges) ?? []
+    communityRating = try container.decodeIfPresent(
+      Double.self, forKey: .communityRating)
+    progress = try container.decodeIfPresent(Double.self, forKey: .progress)
+      .map { min(max($0, 0), 1) }
+  }
+}
+
+/// One row of the filter menu. Labels arrive pre-localized.
+struct HeroFilterOption: Identifiable, Equatable, Decodable {
+  let key: String
+  let label: String
+  let enabled: Bool
+  /// Red one-way action rather than a checkmark toggle.
+  let destructive: Bool?
+
+  var id: String { key }
+}
+
+/// A group of filter rows. An absent title renders as a plain divider.
+struct HeroFilterSection: Identifiable, Equatable, Decodable {
+  let key: String
+  let title: String?
+  let options: [HeroFilterOption]
+
+  var id: String { key }
+}
+
+/// Wire format of the `payload` prop.
+private struct HeroPayload: Decodable {
+  let items: [HeroItem]
+  let imageHeaders: [String: String]?
+  let filterSections: [HeroFilterSection]?
+  let filterLabel: String?
+}
+
+/// Observable state so SwiftUI updates in place instead of rebuilding the
+/// hosting controller on every prop change.
+final class HeroCarouselState: ObservableObject {
+  @Published var items: [HeroItem] = []
+  @Published var imageHeaders: [String: String] = [:]
+  @Published var filterSections: [HeroFilterSection] = []
+  @Published var filterLabel: String = ""
+}
+
+class HeroCarouselExpoView: ExpoView {
+  private var hostingController: UIHostingController<HeroCarouselRootView>?
+  private let state = HeroCarouselState()
+
+  let onItemPress = EventDispatcher()
+  let onFilterToggle = EventDispatcher()
+
+  required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+    clipsToBounds = false
+    setupHostingController()
+  }
+
+  private func setupHostingController() {
+    let root = HeroCarouselRootView(
+      state: state,
+      onItemPress: { [weak self] itemId in
+        self?.onItemPress(["id": itemId])
+      },
+      onFilterToggle: { [weak self] key in
+        self?.onFilterToggle(["key": key])
+      }
+    )
+    let hostingController = UIHostingController(rootView: root)
+    hostingController.view.backgroundColor = .clear
+    // Card shadows and the scaled neighbor cards draw outside the hosting
+    // view's bounds while paging.
+    hostingController.view.clipsToBounds = false
+    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+
+    addSubview(hostingController.view)
+
+    NSLayoutConstraint.activate([
+      hostingController.view.topAnchor.constraint(equalTo: topAnchor),
+      hostingController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+      hostingController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
+      hostingController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
+    ])
+
+    self.hostingController = hostingController
+  }
+
+  // MARK: - Props
+
+  func setPayload(_ payload: String) {
+    guard let data = payload.data(using: .utf8),
+      let decoded = try? JSONDecoder().decode(HeroPayload.self, from: data)
+    else {
+      return
+    }
+    if decoded.items != state.items {
+      state.items = decoded.items
+    }
+    let headers = decoded.imageHeaders ?? [:]
+    if headers != state.imageHeaders {
+      state.imageHeaders = headers
+    }
+    let sections = decoded.filterSections ?? []
+    if sections != state.filterSections {
+      state.filterSections = sections
+    }
+    let label = decoded.filterLabel ?? ""
+    if label != state.filterLabel {
+      state.filterLabel = label
+    }
+  }
+}

--- a/modules/hero-carousel/ios/HeroCarouselModule.swift
+++ b/modules/hero-carousel/ios/HeroCarouselModule.swift
@@ -1,0 +1,22 @@
+import ExpoModulesCore
+
+public class HeroCarouselModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("HeroCarousel")
+
+    View(HeroCarouselExpoView.self) {
+      Events("onItemPress", "onFilterToggle")
+
+      // Everything the view renders arrives as one JSON string: the slides
+      // and the image auth headers. Typed Record/Dictionary props proved
+      // unreliable here — expo-modules-core applies view props with
+      // `try? prop.set(...)` (ExpoFabricView.updateProps), so a conversion
+      // that fails is swallowed silently and the view just renders empty
+      // with no error anywhere. A String prop has no such failure mode, and
+      // the payload stays portable for a future Android implementation.
+      Prop("payload") { (view: HeroCarouselExpoView, payload: String) in
+        view.setPayload(payload)
+      }
+    }
+  }
+}

--- a/modules/hero-carousel/ios/HeroCarouselView.swift
+++ b/modules/hero-carousel/ios/HeroCarouselView.swift
@@ -1,0 +1,847 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Root
+
+/// Entry point hosted by the ExpoView. iOS 17+ gets the paged ScrollView with
+/// interactive parallax; iOS 15/16 falls back to a paged TabView without the
+/// scroll-driven effects. tvOS never renders (the TV home has its own hero).
+struct HeroCarouselRootView: View {
+  @ObservedObject var state: HeroCarouselState
+  let onItemPress: (String) -> Void
+  let onFilterToggle: (String) -> Void
+
+  var body: some View {
+    #if os(iOS)
+    Group {
+      if state.items.isEmpty {
+        // Loading / no-data placeholder: a faint card skeleton where the
+        // hero will appear.
+        HeroSkeletonView()
+      } else if #available(iOS 17.0, *) {
+        PagedHeroCarousel(
+          items: state.items,
+          headers: state.imageHeaders,
+          onItemPress: onItemPress
+        )
+      } else {
+        LegacyHeroCarousel(
+          items: state.items,
+          headers: state.imageHeaders,
+          onItemPress: onItemPress
+        )
+      }
+    }
+    // Overlaid here rather than inside a card for two reasons: neighbour
+    // cards peek in at the edges, so a per-card button would show a second
+    // half-clipped copy in the slivers; and filtering down to zero items
+    // must not strand the user without a way to undo it, so the button has
+    // to outlive the carousel and sit over the empty-state skeleton too.
+    .overlay(alignment: .topTrailing) {
+      if filter.isAvailable {
+        HeroFilterMenu(filter: filter)
+          .padding(.top, 12)
+          .padding(.trailing, HeroLayout.pageMargin + 12)
+      }
+    }
+    // The app is dark themed; force dark so the glass materials render dark
+    // regardless of the system setting.
+    .environment(\.colorScheme, .dark)
+    #else
+    EmptyView()
+    #endif
+  }
+
+  #if os(iOS)
+  private var filter: HeroFilterConfig {
+    HeroFilterConfig(
+      sections: state.filterSections,
+      label: state.filterLabel,
+      onToggle: onFilterToggle
+    )
+  }
+  #endif
+}
+
+#if os(iOS)
+
+private enum HeroLayout {
+  /// Horizontal inset of the snapped card. Neighbors peek through it:
+  /// visible sliver ≈ pageMargin - cardSpacing (minus the 0.95 scale shrink).
+  static let pageMargin: CGFloat = 36
+  static let cardSpacing: CGFloat = 12
+  static let cardCornerRadius: CGFloat = 28
+  /// Extra backdrop width on each side, consumed by the parallax pan.
+  static let parallaxAmount: CGFloat = 36
+  /// Vertical space reserved under the cards for the page dots.
+  static let dotsArea: CGFloat = 24
+}
+
+// MARK: - Filter
+
+/// Everything the filter button needs, bundled so both carousel variants can
+/// take it as one parameter.
+struct HeroFilterConfig {
+  let sections: [HeroFilterSection]
+  let label: String
+  let onToggle: (String) -> Void
+
+  var isAvailable: Bool {
+    !sections.isEmpty
+  }
+}
+
+/// Glass button in the card's top-right corner, mirroring the label chip on
+/// the left. Opens a native menu whose rows are `Toggle`s, so iOS renders the
+/// standard checkmark treatment and handles dismissal itself.
+private struct HeroFilterMenu: View {
+  let filter: HeroFilterConfig
+
+  var body: some View {
+    Menu {
+      ForEach(filter.sections) { section in
+        if let title = section.title, !title.isEmpty {
+          Section(title) { rows(section) }
+        } else {
+          Section { rows(section) }
+        }
+      }
+    } label: {
+      Image(systemName: "line.3.horizontal.decrease")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.white.opacity(0.95))
+        .frame(width: 32, height: 32)
+        .background(.ultraThinMaterial, in: Circle())
+        .overlay(Circle().strokeBorder(Color.white.opacity(0.15), lineWidth: 0.5))
+    }
+    .accessibilityLabel(filter.label)
+  }
+
+  @ViewBuilder
+  private func rows(_ section: HeroFilterSection) -> some View {
+    ForEach(section.options) { option in
+      if option.destructive == true {
+        // A one-way action, not a filter: it is only ever reachable while
+        // the thing it turns off is on, so a checkmark would say nothing.
+        Button(role: .destructive) {
+          filter.onToggle(option.key)
+        } label: {
+          Text(option.label)
+        }
+      } else {
+        Toggle(
+          option.label,
+          isOn: Binding(
+            get: { option.enabled },
+            // The caller owns the state; this only reports the intent.
+            set: { _ in filter.onToggle(option.key) }
+          )
+        )
+      }
+    }
+  }
+}
+
+// MARK: - Skeleton
+
+struct HeroSkeletonView: View {
+  var body: some View {
+    GeometryReader { proxy in
+      RoundedRectangle(
+        cornerRadius: HeroLayout.cardCornerRadius, style: .continuous
+      )
+      .fill(Color.white.opacity(0.06))
+      .overlay(
+        RoundedRectangle(
+          cornerRadius: HeroLayout.cardCornerRadius, style: .continuous
+        )
+        .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+      )
+      .padding(.horizontal, HeroLayout.pageMargin)
+      .frame(height: max(proxy.size.height - HeroLayout.dotsArea, 0))
+    }
+  }
+}
+
+// MARK: - Wrap-around slides
+
+/// The carousel wraps by rendering a clone of the last item before the first
+/// and a clone of the first after the last. When the scroll settles on a
+/// clone, the position teleports (without animation) to its real twin —
+/// pixel-identical content, so the jump is invisible.
+private struct HeroSlide: Identifiable, Equatable {
+  let id: String
+  let item: HeroItem
+  /// Index into the real items array (clones map to their twin's index).
+  let realIndex: Int
+  let isSentinel: Bool
+}
+
+private func makeHeroSlides(_ items: [HeroItem]) -> [HeroSlide] {
+  guard items.count > 1, let first = items.first, let last = items.last else {
+    return items.enumerated().map { index, item in
+      HeroSlide(
+        id: "real-\(index)-\(item.id)", item: item, realIndex: index,
+        isSentinel: false)
+    }
+  }
+  var slides: [HeroSlide] = [
+    HeroSlide(
+      id: "lead-\(last.id)", item: last, realIndex: items.count - 1,
+      isSentinel: true)
+  ]
+  for (index, item) in items.enumerated() {
+    slides.append(
+      HeroSlide(
+        id: "real-\(index)-\(item.id)", item: item, realIndex: index,
+        isSentinel: false))
+  }
+  slides.append(
+    HeroSlide(id: "trail-\(first.id)", item: first, realIndex: 0, isSentinel: true)
+  )
+  return slides
+}
+
+// MARK: - iOS 17+ carousel
+
+@available(iOS 17.0, *)
+private struct PagedHeroCarousel: View {
+  let items: [HeroItem]
+  let headers: [String: String]
+  let onItemPress: (String) -> Void
+
+  @State private var scrolledID: String?
+  /// The scroll starts at offset 0, which is the leading wrap clone, and
+  /// `scrollPosition(id:)` cannot be seeded before the first layout. So the
+  /// jump to the first real slide happens right after layout, and wrap
+  /// handling stays disabled until then — otherwise the clone the scroll
+  /// settles on first would wrap us to the *last* item.
+  @State private var hasSeededPosition = false
+
+  private var slides: [HeroSlide] { makeHeroSlides(items) }
+
+  private var firstRealID: String? {
+    slides.first(where: { !$0.isSentinel })?.id
+  }
+
+  var body: some View {
+    GeometryReader { proxy in
+      let dotsArea = items.count > 1 ? HeroLayout.dotsArea : 0
+      VStack(spacing: 0) {
+        ScrollView(.horizontal) {
+          // A plain HStack, not LazyHStack: the scroll position is seeded to
+          // the first real slide before the first layout, and a lazy stack
+          // can't resolve a scroll target it hasn't measured yet — that
+          // renders the whole ScrollView blank. With ≤10 slides laziness
+          // buys nothing (images load per-card via .task anyway).
+          HStack(spacing: HeroLayout.cardSpacing) {
+            ForEach(slides) { slide in
+              HeroCardView(
+                item: slide.item,
+                headers: headers,
+                onPress: { onItemPress(slide.item.id) }
+              )
+              // contentMargins already insets the container, so the full
+              // relative width is the card width; the snapped card sits
+              // centered with a neighbor sliver on each side.
+              .containerRelativeFrame(.horizontal)
+              .scrollTransition(.interactive, axis: .horizontal) { content, phase in
+                content
+                  .scaleEffect(phase.isIdentity ? 1 : 0.95)
+              }
+            }
+          }
+          .scrollTargetLayout()
+        }
+        .frame(height: max(proxy.size.height - dotsArea, 0))
+        .contentMargins(.horizontal, HeroLayout.pageMargin, for: .scrollContent)
+        // `.always`, not the default `.automatic`: automatic only limits a
+        // fling to one page in a compact size class, so on iPad (regular)
+        // a flick would sail past several cards at once.
+        .scrollTargetBehavior(.viewAligned(limitBehavior: .always))
+        .scrollPosition(id: $scrolledID)
+        .scrollIndicators(.hidden)
+        .scrollClipDisabled()
+        // Not `.onChange(of: scrolledID)`: with `.viewAligned` the binding
+        // updates to the target page the moment the finger lifts, i.e. as
+        // deceleration *starts*. Teleporting there cuts the snap animation
+        // dead, which is why only the wrapping swipes looked broken.
+        .heroWrapWhenScrollIdle(trigger: scrolledID) {
+          wrapIfNeeded()
+        }
+        .onChange(of: items) { _, _ in
+          // Data changed under us (e.g. pull-to-refresh); if the current
+          // position no longer exists, snap back to the start.
+          if !slides.contains(where: { $0.id == scrolledID }) {
+            teleport(to: firstRealID)
+          }
+        }
+        .onAppear {
+          guard !hasSeededPosition else { return }
+          // Next runloop tick: the scroll view has laid out by then, so the
+          // position actually takes.
+          DispatchQueue.main.async {
+            teleport(to: firstRealID)
+            hasSeededPosition = true
+          }
+        }
+
+        if items.count > 1 {
+          HeroPageDots(count: items.count, activeIndex: activeIndex) { index in
+            jump(toRealIndex: index)
+          }
+          .frame(height: dotsArea)
+        }
+      }
+    }
+  }
+
+  private var activeIndex: Int {
+    // Before the seed lands the scroll sits on the leading clone; report the
+    // first page rather than briefly lighting up the last dot.
+    guard hasSeededPosition, let scrolledID,
+      let slide = slides.first(where: { $0.id == scrolledID })
+    else { return 0 }
+    return slide.realIndex
+  }
+
+  /// Reads the live `scrolledID` rather than a captured one: this runs after
+  /// the scroll settles, by which point the position may have moved on.
+  private func wrapIfNeeded() {
+    guard hasSeededPosition,
+      let id = scrolledID,
+      let slide = slides.first(where: { $0.id == id }),
+      slide.isSentinel
+    else { return }
+    teleport(
+      to: slides.first(where: { !$0.isSentinel && $0.realIndex == slide.realIndex })?.id
+    )
+  }
+
+  private func teleport(to id: String?) {
+    guard let id else { return }
+    var transaction = Transaction()
+    transaction.disablesAnimations = true
+    withTransaction(transaction) { scrolledID = id }
+  }
+
+  private func jump(toRealIndex index: Int) {
+    guard
+      let target = slides.first(where: { !$0.isSentinel && $0.realIndex == index })
+    else { return }
+    withAnimation(.snappy) { scrolledID = target.id }
+  }
+}
+
+// MARK: - iOS 15/16 fallback
+
+private struct LegacyHeroCarousel: View {
+  let items: [HeroItem]
+  let headers: [String: String]
+  let onItemPress: (String) -> Void
+
+  @State private var selection: Int
+
+  private var slides: [HeroSlide] { makeHeroSlides(items) }
+
+  init(
+    items: [HeroItem],
+    headers: [String: String],
+    onItemPress: @escaping (String) -> Void
+  ) {
+    self.items = items
+    self.headers = headers
+    self.onItemPress = onItemPress
+    // Slide 0 is the leading wrap clone whenever there is more than one item.
+    _selection = State(initialValue: items.count > 1 ? 1 : 0)
+  }
+
+  var body: some View {
+    GeometryReader { proxy in
+      let dotsArea = items.count > 1 ? HeroLayout.dotsArea : 0
+      VStack(spacing: 0) {
+        TabView(selection: $selection) {
+          ForEach(Array(slides.enumerated()), id: \.element.id) { index, slide in
+            HeroCardView(
+              item: slide.item,
+              headers: headers,
+              onPress: { onItemPress(slide.item.id) }
+            )
+            .padding(.horizontal, HeroLayout.pageMargin)
+            .tag(index)
+          }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+        .frame(height: max(proxy.size.height - dotsArea, 0))
+        .onChange(of: selection) { _ in
+          // Wait out the page animation before swapping a wrap clone for its
+          // real twin, otherwise the teleport cuts the animation short.
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            wrapIfNeeded()
+          }
+        }
+        .onChange(of: items) { newItems in
+          // Filtering can shrink the list under us. TabView renders a blank
+          // page when `selection` names a tag that no longer exists, and
+          // every other handler here guards on `indices.contains`, so
+          // nothing would recover it. The iOS 17 path does the same reset.
+          guard !makeHeroSlides(newItems).indices.contains(selection) else {
+            return
+          }
+          var transaction = Transaction()
+          transaction.disablesAnimations = true
+          withTransaction(transaction) {
+            selection = newItems.count > 1 ? 1 : 0
+          }
+        }
+
+        if items.count > 1 {
+          HeroPageDots(count: items.count, activeIndex: currentRealIndex) { index in
+            if let target = slides.firstIndex(where: {
+              !$0.isSentinel && $0.realIndex == index
+            }) {
+              withAnimation { selection = target }
+            }
+          }
+          .frame(height: dotsArea)
+        }
+      }
+    }
+  }
+
+  private var currentRealIndex: Int {
+    guard slides.indices.contains(selection) else { return 0 }
+    return slides[selection].realIndex
+  }
+
+  /// Reads the live `selection` rather than a captured one: this runs after
+  /// the page animation, by which point the selection may have moved on.
+  private func wrapIfNeeded() {
+    guard slides.indices.contains(selection), slides[selection].isSentinel
+    else { return }
+    let realIndex = slides[selection].realIndex
+    guard
+      let target = slides.firstIndex(where: {
+        !$0.isSentinel && $0.realIndex == realIndex
+      })
+    else { return }
+    var transaction = Transaction()
+    transaction.disablesAnimations = true
+    withTransaction(transaction) { selection = target }
+  }
+}
+
+// MARK: - Card
+
+private struct HeroCardView: View {
+  let item: HeroItem
+  let headers: [String: String]
+  let onPress: () -> Void
+
+  var body: some View {
+    GeometryReader { geo in
+      let shape = RoundedRectangle(
+        cornerRadius: HeroLayout.cardCornerRadius, style: .continuous)
+
+      Button(action: onPress) {
+        ZStack {
+          // Backdrop, wider than the card so the parallax pan never
+          // exposes an edge.
+          RemoteHeroImage(urlString: item.backdropUrl, headers: headers)
+            .frame(
+              width: geo.size.width + HeroLayout.parallaxAmount * 2,
+              height: geo.size.height
+            )
+            .clipped()
+            .heroParallax(HeroLayout.parallaxAmount)
+            .frame(width: geo.size.width, height: geo.size.height)
+
+          // Scrim so the glass panel and label stay legible on bright art.
+          LinearGradient(
+            stops: [
+              .init(color: .black.opacity(0.25), location: 0),
+              .init(color: .clear, location: 0.3),
+              .init(color: .clear, location: 0.45),
+              .init(color: .black.opacity(0.65), location: 1),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+          )
+
+          VStack(alignment: .leading, spacing: 0) {
+            if let label = item.label, !label.isEmpty {
+              HStack {
+                labelChip(label, icon: item.labelIcon)
+                Spacer()
+              }
+            }
+            Spacer(minLength: 0)
+            infoPanel
+          }
+          .padding(12)
+        }
+        .frame(width: geo.size.width, height: geo.size.height)
+        .clipShape(shape)
+        .overlay(shape.strokeBorder(Color.white.opacity(0.12), lineWidth: 1))
+        .contentShape(shape)
+      }
+      .buttonStyle(HeroCardPressStyle())
+      .shadow(color: .black.opacity(0.35), radius: 16, x: 0, y: 10)
+    }
+  }
+
+  private func labelChip(_ label: String, icon: String?) -> some View {
+    HStack(spacing: 4) {
+      if let icon, !icon.isEmpty {
+        Image(systemName: icon)
+          .font(.system(size: 10, weight: .semibold))
+      }
+      Text(label.uppercased())
+        .font(.system(size: 10, weight: .heavy))
+        .kerning(0.8)
+    }
+    .foregroundStyle(.white.opacity(0.95))
+    .padding(.horizontal, 10)
+    .padding(.vertical, 6)
+    .background(.ultraThinMaterial, in: Capsule())
+    .overlay(Capsule().strokeBorder(Color.white.opacity(0.15), lineWidth: 0.5))
+  }
+
+  private var infoPanel: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(alignment: .center, spacing: 12) {
+        if let posterUrl = item.posterUrl {
+          RemoteHeroImage(urlString: posterUrl, headers: headers)
+            .frame(width: 62, height: 93)
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+              RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.15), lineWidth: 0.5)
+            )
+        }
+
+        VStack(alignment: .leading, spacing: 4) {
+          HeroLogoView(
+            urlString: item.logoUrl,
+            headers: headers,
+            title: item.title
+          )
+
+          if let subtitle = item.subtitle, !subtitle.isEmpty {
+            Text(subtitle)
+              .font(.caption.weight(.semibold))
+              .foregroundStyle(.white.opacity(0.9))
+              .lineLimit(1)
+          }
+
+          if !item.overview.isEmpty {
+            Text(item.overview)
+              .font(.caption)
+              .foregroundStyle(.white.opacity(0.75))
+              .lineLimit(2)
+              .multilineTextAlignment(.leading)
+          }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+      }
+
+      // Full panel width so the chips never get squeezed into ellipses by
+      // the poster column.
+      badgesRow
+
+      if let progress = item.progress, progress > 0.01 {
+        progressBar(progress)
+      }
+    }
+    .padding(12)
+    .background(
+      .ultraThinMaterial,
+      in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 20, style: .continuous)
+        .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
+    )
+  }
+
+  private var badgesRow: some View {
+    HStack(spacing: 6) {
+      if let rating = item.communityRating {
+        HStack(spacing: 3) {
+          Image(systemName: "star.fill")
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(.yellow)
+          Text(String(format: "%.1f", rating))
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.white.opacity(0.9))
+        }
+        .fixedSize()
+        .heroBadgeChip()
+      }
+
+      ForEach(Array(item.badges.enumerated()), id: \.offset) { _, badge in
+        Text(badge)
+          .font(.caption2.weight(.semibold))
+          .foregroundStyle(.white.opacity(0.9))
+          .fixedSize()
+          .heroBadgeChip()
+      }
+    }
+    .lineLimit(1)
+    // Chips render at full size and the rare overflow clips at the panel
+    // edge instead of every chip degrading into "...".
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .clipped()
+  }
+
+  private func progressBar(_ progress: Double) -> some View {
+    GeometryReader { geo in
+      ZStack(alignment: .leading) {
+        Capsule()
+          .fill(Color.white.opacity(0.2))
+        Capsule()
+          .fill(Color.white.opacity(0.9))
+          .frame(width: max(geo.size.width * min(max(progress, 0), 1), 4))
+      }
+    }
+    .frame(height: 3)
+  }
+}
+
+private struct HeroCardPressStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .scaleEffect(configuration.isPressed ? 0.97 : 1)
+      .animation(
+        .spring(response: 0.3, dampingFraction: 0.7),
+        value: configuration.isPressed
+      )
+  }
+}
+
+// MARK: - Page dots
+
+/// Tappable and scrubbable: touching down jumps to the nearest dot's page,
+/// dragging across the strip flies through the carousel.
+private struct HeroPageDots: View {
+  let count: Int
+  let activeIndex: Int
+  let onSelect: (Int) -> Void
+
+  private static let haptics = UISelectionFeedbackGenerator()
+
+  var body: some View {
+    HStack(spacing: 6) {
+      ForEach(0..<count, id: \.self) { index in
+        Capsule()
+          .fill(Color.white.opacity(index == activeIndex ? 0.9 : 0.3))
+          .frame(width: index == activeIndex ? 18 : 6, height: 6)
+      }
+    }
+    .animation(
+      .spring(response: 0.35, dampingFraction: 0.8), value: activeIndex
+    )
+    .padding(.horizontal, 12)
+    .frame(maxHeight: .infinity)
+    .contentShape(Rectangle())
+    .overlay {
+      GeometryReader { geo in
+        Color.clear
+          .contentShape(Rectangle())
+          .gesture(
+            // minimumDistance 0 so a plain tap selects on touch-down. The
+            // surrounding RN scroll view still wins vertical pans (it
+            // cancels content touches), so page scrolling isn't blocked.
+            DragGesture(minimumDistance: 0)
+              .onChanged { value in
+                let step = geo.size.width / CGFloat(count)
+                guard step > 0 else { return }
+                let index = min(
+                  max(Int(value.location.x / step), 0), count - 1)
+                if index != activeIndex {
+                  Self.haptics.selectionChanged()
+                  onSelect(index)
+                }
+              }
+          )
+      }
+    }
+  }
+}
+
+// MARK: - Logo / title
+
+/// Shows the title immediately and swaps in the logo artwork once loaded, so
+/// items without a logo image still get a readable heading.
+private struct HeroLogoView: View {
+  let urlString: String?
+  let headers: [String: String]
+  let title: String
+
+  @State private var logo: UIImage?
+
+  var body: some View {
+    Group {
+      if let logo {
+        Image(uiImage: logo)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(maxWidth: .infinity, maxHeight: 32, alignment: .leading)
+      } else {
+        Text(title)
+          .font(.system(size: 17, weight: .bold))
+          .foregroundStyle(.white)
+          .lineLimit(1)
+      }
+    }
+    .task(id: urlString) {
+      guard let urlString else {
+        logo = nil
+        return
+      }
+      let loaded = await HeroImageLoader.shared.load(urlString, headers: headers)
+      if !Task.isCancelled {
+        logo = loaded
+      }
+    }
+  }
+}
+
+// MARK: - Parallax
+
+extension View {
+  /// Runs `perform` once the scroll has come fully to rest, so a wrap-around
+  /// teleport never interrupts the snap animation.
+  ///
+  /// iOS 18+ has a real signal (`onScrollPhaseChange` → `.idle`). On iOS 17
+  /// there is none, so wait out the snap; `perform` re-checks the live
+  /// position, so a second swipe arriving inside the window is harmless.
+  // Only reachable from the iOS 17+ carousel; the two-parameter `onChange`
+  // below does not exist on the 16.4 deployment target.
+  @available(iOS 17.0, *)
+  @ViewBuilder
+  fileprivate func heroWrapWhenScrollIdle(
+    trigger: String?,
+    perform: @escaping () -> Void
+  ) -> some View {
+    if #available(iOS 18.0, *) {
+      onScrollPhaseChange { _, newPhase in
+        if newPhase == .idle {
+          perform()
+        }
+      }
+    } else {
+      onChange(of: trigger) { _, _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+          perform()
+        }
+      }
+    }
+  }
+
+  /// Pans the view against the scroll direction while its container pages.
+  /// No-op below iOS 17 (the fallback TabView has no scroll phase).
+  @ViewBuilder
+  fileprivate func heroParallax(_ amount: CGFloat) -> some View {
+    if #available(iOS 17.0, *) {
+      scrollTransition(.interactive, axis: .horizontal) { content, phase in
+        content.offset(x: phase.value * amount)
+      }
+    } else {
+      self
+    }
+  }
+
+  fileprivate func heroBadgeChip() -> some View {
+    padding(.horizontal, 8)
+      .padding(.vertical, 4)
+      .background(Color.white.opacity(0.14), in: Capsule())
+  }
+}
+
+// MARK: - Image loading
+
+/// Header-aware image loader with an in-memory cache. The Jellyfin server can
+/// sit behind an auth proxy (Cloudflare Access, Pangolin, ...), so every
+/// request carries the custom headers passed down from JS.
+final class HeroImageLoader {
+  static let shared = HeroImageLoader()
+
+  private let cache = NSCache<NSString, UIImage>()
+
+  private init() {
+    cache.totalCostLimit = 64 * 1024 * 1024
+  }
+
+  func cached(_ urlString: String) -> UIImage? {
+    cache.object(forKey: urlString as NSString)
+  }
+
+  func load(_ urlString: String, headers: [String: String]) async -> UIImage? {
+    if let hit = cached(urlString) {
+      return hit
+    }
+    guard let url = URL(string: urlString) else {
+      return nil
+    }
+    var request = URLRequest(url: url)
+    for (key, value) in headers {
+      request.setValue(value, forHTTPHeaderField: key)
+    }
+    guard
+      let (data, response) = try? await URLSession.shared.data(for: request),
+      let http = response as? HTTPURLResponse,
+      (200..<300).contains(http.statusCode),
+      let image = UIImage(data: data)
+    else {
+      return nil
+    }
+    // Cost is the decoded footprint, not the compressed download: a backdrop
+    // JPEG is an order of magnitude smaller than its bitmap, so charging
+    // `data.count` against the limit means eviction would never trigger.
+    let cost = image.cgImage.map { $0.bytesPerRow * $0.height } ?? data.count
+    cache.setObject(image, forKey: urlString as NSString, cost: cost)
+    return image
+  }
+}
+
+private struct RemoteHeroImage: View {
+  let urlString: String?
+  let headers: [String: String]
+
+  @State private var image: UIImage?
+
+  var body: some View {
+    ZStack {
+      LinearGradient(
+        colors: [Color(white: 0.16), Color(white: 0.10)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+      )
+      if let image {
+        Image(uiImage: image)
+          .resizable()
+          .aspectRatio(contentMode: .fill)
+          .transition(.opacity)
+      }
+    }
+    .task(id: urlString) {
+      guard let urlString else {
+        image = nil
+        return
+      }
+      if let hit = HeroImageLoader.shared.cached(urlString) {
+        image = hit
+        return
+      }
+      let loaded = await HeroImageLoader.shared.load(urlString, headers: headers)
+      if !Task.isCancelled {
+        withAnimation(.easeIn(duration: 0.25)) {
+          image = loaded
+        }
+      }
+    }
+  }
+}
+
+#endif

--- a/modules/hero-carousel/src/HeroCarousel.types.ts
+++ b/modules/hero-carousel/src/HeroCarousel.types.ts
@@ -1,0 +1,72 @@
+import type { StyleProp, ViewStyle } from "react-native";
+
+export type HeroCarouselItem = {
+  id: string;
+  title: string;
+  /** Secondary line under the title, e.g. "S2E5 · Episode name". */
+  subtitle?: string | null;
+  overview: string;
+  /** Pre-localized chip text on the card, e.g. "Continue watching". */
+  label?: string | null;
+  /** SF Symbol name rendered in the chip, e.g. "play.fill". */
+  labelIcon?: string | null;
+  backdropUrl?: string | null;
+  logoUrl?: string | null;
+  posterUrl?: string | null;
+  /** Pre-localized badge strings (year, official rating, runtime, ...). */
+  badges: string[];
+  communityRating?: number | null;
+  /** Watch progress in 0–1; renders a progress bar when > 0. */
+  progress?: number | null;
+};
+
+/** One row in the filter menu. */
+export type HeroCarouselFilterOption = {
+  /** Stable identifier echoed back by `onFilterToggle`. */
+  key: string;
+  /** Pre-localized row title. */
+  label: string;
+  /** Whether the row shows a checkmark. Ignored when `destructive`. */
+  enabled: boolean;
+  /**
+   * Render as a red destructive action instead of a checkmark toggle, for a
+   * row that performs a one-way action rather than flipping a filter.
+   */
+  destructive?: boolean;
+};
+
+/** A group of rows in the filter menu. */
+export type HeroCarouselFilterSection = {
+  /** Stable identity for the group. */
+  key: string;
+  /** Pre-localized header; omit for an untitled group (just a divider). */
+  title?: string | null;
+  options: HeroCarouselFilterOption[];
+};
+
+export type HeroCarouselItemPressEvent = {
+  id: string;
+};
+
+export type HeroCarouselFilterToggleEvent = {
+  key: string;
+};
+
+export type HeroCarouselViewProps = {
+  items: HeroCarouselItem[];
+  /** Custom proxy auth headers attached to every image request. */
+  imageHeaders?: Record<string, string>;
+  /**
+   * Rows for the filter menu behind the button in the card's top-right
+   * corner. Omit (or pass an empty array) to hide the button entirely.
+   */
+  filterSections?: HeroCarouselFilterSection[];
+  /** Pre-localized accessibility label for the filter button. */
+  filterLabel?: string;
+  onItemPress?: (event: { nativeEvent: HeroCarouselItemPressEvent }) => void;
+  /** Fires with the toggled row's `key`; the caller owns the new state. */
+  onFilterToggle?: (event: {
+    nativeEvent: HeroCarouselFilterToggleEvent;
+  }) => void;
+  style?: StyleProp<ViewStyle>;
+};

--- a/modules/hero-carousel/src/HeroCarouselView.tsx
+++ b/modules/hero-carousel/src/HeroCarouselView.tsx
@@ -1,0 +1,77 @@
+import { requireNativeView, requireOptionalNativeModule } from "expo";
+import * as React from "react";
+import { Platform } from "react-native";
+
+import type { HeroCarouselViewProps } from "./HeroCarousel.types";
+
+// The native view takes a single JSON string prop carrying the slides and
+// the image headers. Typed object/array props are applied natively with
+// `try? prop.set(...)`, so a conversion failure is swallowed and the view
+// silently renders empty; a string prop has no such failure mode, and the
+// same payload is what a future Android view would parse.
+type NativeProps = {
+  payload: string;
+  onItemPress?: HeroCarouselViewProps["onItemPress"];
+  onFilterToggle?: HeroCarouselViewProps["onFilterToggle"];
+  style?: HeroCarouselViewProps["style"];
+};
+
+// The native side is a pure presentational view: JS passes prebuilt data
+// (image URLs, localized badge strings) and receives item ids back, so an
+// Android native view can be added under the same "HeroCarousel" name without
+// touching any JS. Phones/tablets only — the TV home has its own hero.
+let NativeHeroCarouselView: React.ComponentType<NativeProps> | null = null;
+
+// requireOptionalNativeModule returns null instead of throwing when the
+// module isn't in this binary (old build, Expo Go, or a platform without a
+// native implementation yet — Android today).
+if (!Platform.isTV && requireOptionalNativeModule("HeroCarousel")) {
+  try {
+    NativeHeroCarouselView = requireNativeView<NativeProps>("HeroCarousel");
+  } catch {
+    // View manager missing despite the module being registered.
+  }
+}
+
+/**
+ * HeroCarouselView — native paged hero carousel.
+ *
+ * iOS 17+: SwiftUI paged ScrollView with interactive parallax and glass
+ * info panels. iOS 15/16: paged TabView fallback with the same card design.
+ * Platforms without a native implementation render nothing.
+ */
+const HeroCarouselView: React.FC<HeroCarouselViewProps> = ({
+  items,
+  imageHeaders,
+  filterSections,
+  filterLabel,
+  onItemPress,
+  onFilterToggle,
+  style,
+}) => {
+  const payload = React.useMemo(
+    () =>
+      JSON.stringify({
+        items,
+        imageHeaders: imageHeaders ?? {},
+        filterSections: filterSections ?? [],
+        filterLabel: filterLabel ?? "",
+      }),
+    [items, imageHeaders, filterSections, filterLabel],
+  );
+  if (!NativeHeroCarouselView) {
+    return null;
+  }
+  return (
+    <NativeHeroCarouselView
+      payload={payload}
+      onItemPress={onItemPress}
+      onFilterToggle={onFilterToggle}
+      style={style}
+    />
+  );
+};
+
+export const isHeroCarouselAvailable = () => NativeHeroCarouselView != null;
+
+export default HeroCarouselView;

--- a/modules/hero-carousel/src/index.ts
+++ b/modules/hero-carousel/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./HeroCarousel.types";
+export {
+  default as HeroCarouselView,
+  isHeroCarouselAvailable,
+} from "./HeroCarouselView";

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -12,6 +12,16 @@ export { ExoPlayerView } from "./exoplayer-player";
 // Glass Poster (tvOS 26+)
 export type { GlassPosterViewProps } from "./glass-poster";
 export { GlassPosterView, isGlassEffectAvailable } from "./glass-poster";
+// Hero Carousel (iOS home tab)
+export type {
+  HeroCarouselFilterOption,
+  HeroCarouselFilterSection,
+  HeroCarouselFilterToggleEvent,
+  HeroCarouselItem,
+  HeroCarouselItemPressEvent,
+  HeroCarouselViewProps,
+} from "./hero-carousel";
+export { HeroCarouselView, isHeroCarouselAvailable } from "./hero-carousel";
 // MPV Player (iOS + Android)
 // Presented native player (iOS + Android phone/tablet)
 export type {

--- a/translations/en.json
+++ b/translations/en.json
@@ -111,9 +111,17 @@
     "continue": "Continue",
     "next_up": "Next up",
     "continue_and_next_up": "Continue & Next up",
+    "recently_added": "Recently added",
     "recently_added_in": "Recently added in {{libraryName}}",
     "suggested_movies": "Suggested movies",
     "suggested_episodes": "Suggested episodes",
+    "hero": {
+      "filter": "Filter",
+      "groups": "Groups",
+      "media": "Media",
+      "tv_shows": "TV shows",
+      "disable": "Disable hero"
+    },
     "intro": {
       "welcome_to_streamyfin": "Welcome to Streamyfin",
       "a_free_and_open_source_client_for_jellyfin": "A free and open-source client for Jellyfin.",
@@ -162,6 +170,7 @@
         "hide_remote_session_button_hint": "Hide the remote-sessions button from the home header.",
         "show_home_backdrop": "Dynamic home backdrop",
         "show_hero_carousel": "Hero carousel",
+        "show_hero_carousel_hint": "Show the large swipeable carousel at the top of the home screen.",
         "show_series_poster_on_episode": "Show series poster on episodes",
         "theme_music": "Theme music",
         "display_size": "Display size",

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -334,6 +334,11 @@ export enum InactivityTimeout {
 export type MpvCacheMode = "auto" | "yes" | "no";
 export type MpvVoDriver = "gpu-next" | "gpu";
 
+/** Content groups that can appear in the home hero carousel. */
+export type HomeHeroSection = "continueWatching" | "nextUp" | "recentlyAdded";
+/** Media kinds that can appear in the home hero carousel. */
+export type HomeHeroMediaType = "movie" | "tv";
+
 export type Settings = {
   home?: Home | null;
   deviceProfile?: "Expo" | "Native" | "Old";
@@ -417,6 +422,14 @@ export type Settings = {
   hideBrightnessSlider: boolean;
   usePopularPlugin: boolean;
   mergeNextUpAndContinueWatching: boolean;
+  /**
+   * Home hero carousel filters. Both are "hidden" lists, so an empty list
+   * (the default) shows everything, and they combine: hiding the
+   * "recentlyAdded" group and the "movie" media type leaves only
+   * continue-watching and next-up episodes.
+   */
+  hiddenHomeHeroSections?: HomeHeroSection[];
+  hiddenHomeHeroMediaTypes?: HomeHeroMediaType[];
   // Use the episode's own image (instead of the series thumb) for the
   // "Next Up" and "Continue Watching" home rows.
   useEpisodeImagesForNextUp: boolean;
@@ -426,7 +439,12 @@ export type Settings = {
   /** Android TV only: use the fully-native Android TV player (opt-in; default off). */
   nativeVideoPlayerAndroidTV?: boolean;
   showHomeBackdrop: boolean;
-  showTVHeroCarousel: boolean;
+  /**
+   * The home hero carousel, on every platform — the TV one and the iOS one
+   * are the same feature and share this single switch. Stored values from
+   * the old TV-only `showTVHeroCarousel` key are migrated in `loadSettings`.
+   */
+  showHeroCarousel: boolean;
   tvTypographyScale: TVTypographyScale;
   showSeriesPosterOnEpisode: boolean;
   tvThemeMusicEnabled: boolean;
@@ -569,12 +587,14 @@ export const defaultValues: Settings = {
   hideBrightnessSlider: false,
   usePopularPlugin: true,
   mergeNextUpAndContinueWatching: false,
+  hiddenHomeHeroSections: [],
+  hiddenHomeHeroMediaTypes: [],
   useEpisodeImagesForNextUp: false,
   // TV-specific settings
   nativeVideoPlayerTV: true,
   nativeVideoPlayerAndroidTV: false,
   showHomeBackdrop: true,
-  showTVHeroCarousel: true,
+  showHeroCarousel: true,
   tvTypographyScale: TVTypographyScale.Default,
   showSeriesPosterOnEpisode: false,
   tvThemeMusicEnabled: true,
@@ -598,8 +618,21 @@ export const defaultValues: Settings = {
   sentryEnabled: true,
 };
 
-const loadSettings = (): Partial<Settings> =>
-  readStoredSettings() as Partial<Settings>;
+const loadSettings = (): Partial<Settings> => {
+  const stored = readStoredSettings() as Partial<Settings> & {
+    showTVHeroCarousel?: boolean;
+  };
+  // `showTVHeroCarousel` became `showHeroCarousel` once the hero shipped on
+  // phones too and the two were merged into one switch. Carry a stored TV
+  // preference across so a hero someone had turned off stays off.
+  if (
+    stored.showHeroCarousel === undefined &&
+    stored.showTVHeroCarousel !== undefined
+  ) {
+    return { ...stored, showHeroCarousel: stored.showTVHeroCarousel };
+  }
+  return stored;
+};
 
 const EXCLUDE_FROM_SAVE = ["home"];
 
@@ -618,9 +651,34 @@ const saveSettings = (settings: Settings) => {
 };
 
 export const settingsAtom = atom<Partial<Settings> | null>(null);
+
+/**
+ * Server-side counterpart to the `showTVHeroCarousel` migration in
+ * `loadSettings`: the Streamyfin plugin config still keys the hero switch
+ * under the old name, so alias it or an admin's existing lock and default
+ * would quietly stop being enforced after the rename.
+ */
+const migratePluginSettings = (
+  settings: PluginLockableSettings | undefined,
+): PluginLockableSettings | undefined => {
+  if (!settings) {
+    return settings;
+  }
+  const legacy = (settings as Record<string, unknown>).showTVHeroCarousel;
+  if (settings.showHeroCarousel !== undefined || legacy === undefined) {
+    return settings;
+  }
+  return {
+    ...settings,
+    showHeroCarousel: legacy as PluginLockableSettings["showHeroCarousel"],
+  };
+};
+
 const loadPluginSettings = () => {
   try {
-    return storage.get<PluginLockableSettings>(STREAMYFIN_PLUGIN_SETTINGS);
+    return migratePluginSettings(
+      storage.get<PluginLockableSettings>(STREAMYFIN_PLUGIN_SETTINGS),
+    );
   } catch (error) {
     console.error("Failed to load plugin settings:", error);
     return undefined;
@@ -672,8 +730,9 @@ export const useSettings = () => {
 
   const setPluginSettings = useCallback(
     (settings: PluginLockableSettings | undefined) => {
-      storage.setAny(STREAMYFIN_PLUGIN_SETTINGS, settings);
-      _setPluginSettings(settings);
+      const migrated = migratePluginSettings(settings);
+      storage.setAny(STREAMYFIN_PLUGIN_SETTINGS, migrated);
+      _setPluginSettings(migrated);
     },
     [_setPluginSettings],
   );


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Adds a hero carousel to the top of the home tab on iOS. It's a native SwiftUI Expo module (`modules/hero-carousel`) with paged scrolling, parallax backdrops and glass info panels, showing 10 slides pulled from continue watching, next up and recently added.

The native view is purely presentational. JS sends prebuilt image URLs and localized strings as one JSON payload and gets item ids back, so an Android view can be added later under the same name without touching any JS. I went with a JSON string prop instead of typed Record props because expo-modules-core applies view props with `try? prop.set(...)`, so a failed conversion gets swallowed and the view just renders empty with no error anywhere. Took me a while to track that down.

The button on the card opens a native menu to filter by group (continue watching, next up, recently added) and by media type (movies, TV), plus a row to turn the hero off. Filtering keeps the carousel at 10 by handing the freed share to whatever is left, so hiding movies pulls in more TV instead of just making it shorter.

`showTVHeroCarousel` is now `showHeroCarousel` and covers both TV and iOS, with stored values migrated on load. I didn't want two settings for the same thing.

Nothing changes on Android. The module is Apple only and the wrapper renders null everywhere else.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

<img width="300" halt="Simulator Screenshot - iPhone 17 - 2026-08-17 at 22 21 35" src="https://github.com/user-attachments/assets/f320d8b8-553b-4b4e-abdb-8837d233dad7" />

android upcoming pr 

<img width="300" alt="Screenshot_1786997884" src="https://github.com/user-attachments/assets/ec959a5f-8f3b-462c-bf41-26a183775497" />


## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. `bun run prebuild` then `bun run ios`. There's a new native module, so a Metro reload isn't enough.
2. Open the Home tab. The carousel sits above Continue watching and opens on the first card.
3. Swipe through it. Past the last card it should wrap to the first (and back the other way) with no visible jump, and one flick should move exactly one card.
4. Tap a card and check it opens the right item page.
5. Tap the filter button top right, turn Movies off. The carousel should stay at 10 slides and fill up with TV instead.
6. In the same menu tap Disable hero. The carousel disappears. Turn it back on under Settings > Appearance > Hero carousel.
7. On TV, check the existing hero still works and still respects the setting (it was renamed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native hero carousel to the mobile home screen with resume, next-up, and recently added media.
  * Added filtering by content section and media type, with progress, ratings, badges, and navigation.
  * Added iOS appearance controls to show or hide the carousel.
  * Added support for authenticated images, dark mode, responsive cards, and smooth paging.

* **Bug Fixes**
  * Unified hero carousel visibility settings across mobile, iOS, and TV.
  * Preserved existing carousel preferences when upgrading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->