### PR TITLE
fix(jellyseerr): don't reject servers whose version isn't a semver

### DIFF
--- a/hooks/useJellyseerr.ts
+++ b/hooks/useJellyseerr.ts
@@ -163,14 +163,19 @@ export class JellyseerrApi {
         const { status, headers, data } = response;
         if (inRange(status, 200, 299)) {
           if (data.version && isVersionBelow(data.version, "2.0.0")) {
-            const error = t(
-              "jellyseerr.toasts.jellyseerr_does_not_meet_requirements",
-            );
             writeErrorLog(
               `Jellyseerr version ${data.version} is below the required 2.0.0`,
             );
-            toast.error(error);
-            throw Error(error);
+            toast.error(
+              t("jellyseerr.toasts.jellyseerr_does_not_meet_requirements"),
+            );
+            // Return rather than throw: the catch below exists for transport
+            // failures and would stack a second, misleading "could not test
+            // the server URL" toast on top of this precise one.
+            return {
+              isValid: false,
+              requiresPass: false,
+            };
           }
 
           storage.setAny(

--- a/utils/serverUrl/semver.test.ts
+++ b/utils/serverUrl/semver.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { isVersionBelow } from "./semver";
+
+describe("isVersionBelow", () => {
+  test("compares numerically, not as strings", () => {
+    expect(isVersionBelow("1.9.9", "2.0.0")).toBe(true);
+    // The reason this helper exists: "2.10.0" < "2.0.0" as a string compare.
+    expect(isVersionBelow("2.10.0", "2.0.0")).toBe(false);
+  });
+
+  test("equal versions are not below", () => {
+    expect(isVersionBelow("2.0.0", "2.0.0")).toBe(false);
+  });
+
+  test("missing segments count as zero", () => {
+    expect(isVersionBelow("2", "2.0.0")).toBe(false);
+    expect(isVersionBelow("2", "2.0.1")).toBe(true);
+    expect(isVersionBelow("2.1", "2.0.0")).toBe(false);
+  });
+
+  test("pre-release suffixes are ignored", () => {
+    expect(isVersionBelow("2.0.0-beta", "2.0.0")).toBe(false);
+    expect(isVersionBelow("1.9.0-rc1", "2.0.0")).toBe(true);
+  });
+
+  test("a leading v is accepted", () => {
+    expect(isVersionBelow("v2.1.0", "2.0.0")).toBe(false);
+    expect(isVersionBelow("v1.9.0", "2.0.0")).toBe(true);
+  });
+
+  test("non-release Jellyseerr builds are unknown, not old", () => {
+    // Jellyseerr's getAppVersion() returns `develop-<commitTag>` for every
+    // build made off a non-release package.json — treating that as version 0
+    // locked every develop/nightly/self-built server out of the integration.
+    expect(isVersionBelow("develop-a1b2c3d", "2.0.0")).toBe(false);
+    expect(isVersionBelow("develop-local", "2.0.0")).toBe(false);
+    expect(isVersionBelow("develop", "2.0.0")).toBe(false);
+  });
+
+  test("empty and junk versions are not treated as below", () => {
+    expect(isVersionBelow("", "2.0.0")).toBe(false);
+    expect(isVersionBelow("unknown", "2.0.0")).toBe(false);
+  });
+
+  test("surrounding whitespace is tolerated", () => {
+    expect(isVersionBelow("  1.0.0  ", "2.0.0")).toBe(true);
+  });
+});

--- a/utils/serverUrl/semver.ts
+++ b/utils/serverUrl/semver.ts
@@ -1,16 +1,40 @@
+/** Strips whitespace and an optional leading `v` (`v2.1.0` → `2.1.0`). */
+const normalize = (version: string): string =>
+  version.trim().replace(/^v/i, "");
+
+/**
+ * Splits a dotted version into numeric segments, or returns null when the
+ * string doesn't start with a number and therefore isn't a version we can
+ * compare at all.
+ */
+const parseSegments = (version: string): number[] | null => {
+  const segments = normalize(version).split(".");
+  if (!Number.isFinite(Number.parseInt(segments[0] ?? "", 10))) return null;
+  // Later segments fall back to 0 so pre-release suffixes are ignored
+  // (`2.0.0-beta` → 2.0.0).
+  return segments.map((segment) => Number.parseInt(segment, 10) || 0);
+};
+
 /**
  * Strict numeric "below" comparison for dotted versions.
  *
  * Avoids the string-comparison bug (`"1.9.9" < "2.0.0"` works by luck but
  * `"2.10.0" < "2.0.0"` is wrongly true). Non-numeric/pre-release suffixes on a
- * segment are ignored (e.g. `2.0.0-beta` → 2.0.0).
+ * segment are ignored (e.g. `2.0.0-beta` → 2.0.0), and a leading `v` is
+ * accepted.
+ *
+ * A version with no leading number is unknown, not old, and is reported as
+ * NOT below the minimum. Jellyseerr's non-release builds report
+ * `develop-<commit>`, which previously parsed to 0 and so failed every
+ * minimum-version check — locking every develop/nightly/self-built server out
+ * of the integration. This matches how the Jellyfin server check treats an
+ * unparseable version (see `isSupportedVersion` in utils/jellyfin/checkServer).
  */
 export function isVersionBelow(version: string, minimum: string): boolean {
-  const parse = (v: string) =>
-    v.split(".").map((segment) => Number.parseInt(segment, 10) || 0);
+  const a = parseSegments(version);
+  const b = parseSegments(minimum);
+  if (!a || !b) return false;
 
-  const a = parse(version);
-  const b = parse(minimum);
   const length = Math.max(a.length, b.length);
 
   for (let i = 0; i < length; i++) {


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Streamyfin refuses to connect to any Jellyseerr that isn't a tagged release, showing *"Seerr server does not meet minimum version requirements! Please update to at least 2.0.0"* — even on an up-to-date `develop` server.

**Root cause.** Jellyseerr's `getAppVersion()` returns `` `develop-${commitTag}` `` for any build made off its non-release `package.json` (whose version is the literal placeholder `0.1.0`), so `/api/v1/status` reports e.g. `develop-a1b2c3d` rather than a semver. `isVersionBelow` parsed the leading segment with `Number.parseInt(segment, 10) || 0`, which turns `"develop-a1b2c3d"` into **0**, so `0 < 2` and the server was judged ancient. Since `JellyseerrApi.test()` then returns `isValid: false`, `login()` never runs and the integration is off entirely — this affects every develop, nightly and self-built Jellyseerr, not just one setup.

**Fix.** A version with no leading number is *unknown*, not old, and is now reported as not below the minimum. That's the same benefit of the doubt the Jellyfin server check already gives an unparseable version (`isSupportedVersion` in `utils/jellyfin/checkServer.ts:36` returns `true` when major/minor aren't finite). A leading `v` and surrounding whitespace are now tolerated too, so `v1.9.0` is still correctly *rejected* instead of being waved through as unparseable.

**Second bug, same screen.** The version failure produced *two* toasts for one problem: it `throw`ew the message it had just shown, and `test()`'s own `.catch` — which exists for transport failures — added a misleading *"Échec du test de l'URL du serveur Seerr"* on top, implying the URL was wrong when it was fine. The version branch now returns an invalid result directly instead of throwing.

`isVersionBelow` had no tests; this adds them, including the `develop-<commit>` regression case.

## 🏷️ Ticket / Issue

N/A — reported from a running develop-channel Jellyseerr (Jellyfin 10.11, unrelated).

### 🖼️ Screenshots / GIFs (if UI)

No new UI. The change is that the two error toasts (screenshot in the linked report: "Échec du test de l'URL du serveur Seerr" + "Seerr ne répond pas aux exigences !") no longer appear for a develop server, and a genuinely-too-old server now shows one toast instead of two.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms *(pending — verified by unit tests and code reading; not yet run against a live develop Seerr on device)*
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. `bun run test:unit` — 8 new `isVersionBelow` cases pass, including `develop-a1b2c3d` → not below 2.0.0.
2. Point Streamyfin at a Jellyseerr running the **develop** branch (its `/api/v1/status` will report `version: "develop-<commit>"`), configured via the Streamyfin plugin's server URL with no API key, then log in.
   - Before: two error toasts on the home screen and no Seerr integration.
   - After: no toasts, Seerr signs in and Discover/requests work.
3. Settings → Jellyseerr → test the same URL: should report success rather than the version error.
4. Regression check that the gate still works: against a real Jellyseerr older than 2.0.0 (e.g. `1.9.x`), you should still get exactly **one** toast — the version requirement message — and no login.

https://claude.ai/code/session_01MV9Z5R1ykEH5Sby5MJ523G


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server version validation for Jellyseerr connections.
  - Displays the correct requirements message for unsupported server versions instead of an additional generic network error.
  - More reliably recognizes version formats, including leading “v” prefixes, whitespace, and prerelease suffixes.
  - Handles invalid or non-release version values safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->