### PR TITLE
feat(cards): draw media rows and grids natively on iOS

### DIFF
--- a/app.json
+++ b/app.json
@@ -89,7 +89,12 @@
           "ios": {
             "deploymentTarget": "16.4",
             "useFrameworks": "static",
-            "forceStaticLinking": ["ExpoUI", "GlassEffectView", "GlassPoster"]
+            "forceStaticLinking": [
+              "ExpoUI",
+              "GlassEffectView",
+              "GlassPoster",
+              "GlassCardRow"
+            ]
           },
           "android": {
             "buildArchs": ["arm64-v8a", "x86_64", "armeabi-v7a"],

--- a/app/(auth)/(tabs)/(favorites)/see-all.tsx
+++ b/app/(auth)/(tabs)/(favorites)/see-all.tsx
@@ -12,11 +12,13 @@ import { useAtom } from "jotai";
 import { useCallback, useMemo } from "react";
 import { useWindowDimensions, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { CardGrid } from "@/components/cards/CardGrid";
 import { Text } from "@/components/common/Text";
 import { TouchableItemRouter } from "@/components/common/TouchableItemRouter";
 import { ItemCardText } from "@/components/ItemCardText";
 import { Loader } from "@/components/Loader";
 import { ItemPoster } from "@/components/posters/ItemPoster";
+import { isGlassCardGridAvailable } from "@/modules/glass-card-row";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 
 type FavoriteTypes =
@@ -167,6 +169,26 @@ export default function FavoritesSeeAllScreen() {
         <View className='justify-center items-center h-full'>
           <Loader />
         </View>
+      ) : isGlassCardGridAvailable() ? (
+        // The whole grid is one native view; nothing scrolls above it here, so
+        // it simply fills the screen under the transparent nav bar.
+        flatData.length === 0 ? (
+          <View className='flex flex-col items-center justify-center h-full py-12'>
+            <Text className='font-bold text-xl text-neutral-500'>
+              {t("home.no_items")}
+            </Text>
+          </View>
+        ) : (
+          <CardGrid
+            items={flatData}
+            columns={nrOfCols}
+            loadingMore={isFetching}
+            onEndReached={handleEndReached}
+            contentInsetTop={insets.top + 50}
+            // Clears the floating tab bar, which overlays the grid.
+            contentInsetBottom={insets.bottom + 100}
+          />
+        )
       ) : (
         <FlashList
           data={flatData}

--- a/app/(auth)/(tabs)/(favorites)/see-all.tsx
+++ b/app/(auth)/(tabs)/(favorites)/see-all.tsx
@@ -13,6 +13,7 @@ import { useCallback, useMemo } from "react";
 import { useWindowDimensions, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CardGrid } from "@/components/cards/CardGrid";
+import { useNativeMediaCards } from "@/components/cards/useNativeMediaCards";
 import { Text } from "@/components/common/Text";
 import { TouchableItemRouter } from "@/components/common/TouchableItemRouter";
 import { ItemCardText } from "@/components/ItemCardText";
@@ -47,6 +48,7 @@ function isFavoriteType(value: unknown): value is FavoriteTypes {
 
 export default function FavoritesSeeAllScreen() {
   const insets = useSafeAreaInsets();
+  const nativeCards = useNativeMediaCards();
   const { width: screenWidth } = useWindowDimensions();
   const [api] = useAtom(apiAtom);
   const [user] = useAtom(userAtom);
@@ -169,7 +171,7 @@ export default function FavoritesSeeAllScreen() {
         <View className='justify-center items-center h-full'>
           <Loader />
         </View>
-      ) : isGlassCardGridAvailable() ? (
+      ) : nativeCards && isGlassCardGridAvailable() ? (
         // The whole grid is one native view; nothing scrolls above it here, so
         // it simply fills the screen under the transparent nav bar.
         flatData.length === 0 ? (

--- a/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
+++ b/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
@@ -28,6 +28,7 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { CardGrid } from "@/components/cards/CardGrid";
 import { Image } from "@/components/common/ServerImage";
 import { Text } from "@/components/common/Text";
 import {
@@ -49,6 +50,7 @@ import { useOrientation } from "@/hooks/useOrientation";
 import { useRefreshLibraryOnFocus } from "@/hooks/useRefreshLibraryOnFocus";
 import { useTVItemActionModal } from "@/hooks/useTVItemActionModal";
 import { useTVOptionModal } from "@/hooks/useTVOptionModal";
+import { isGlassCardGridAvailable } from "@/modules/glass-card-row";
 import * as ScreenOrientation from "@/packages/expo-screen-orientation";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import {
@@ -969,6 +971,11 @@ const Page = () => {
   }, [showOptions, t, tvFilterByOptions, setFilter, _setFilterBy]);
 
   const insets = useSafeAreaInsets();
+  // The nav bar is transparent on iOS, so the pinned filter bar has to clear it
+  // itself — the FlashList path gets this from contentInsetAdjustmentBehavior.
+  // Same safe-area + nav-bar constant the other transparent-header screens use;
+  // @react-navigation/elements can't be imported directly under expo-router.
+  const headerHeight = insets.top + 50;
 
   if (isLoading || isLibraryLoading)
     return (
@@ -979,6 +986,48 @@ const Page = () => {
 
   // Mobile return
   if (!Platform.isTV) {
+    // The whole grid is one native view where that exists. Its own scrolling
+    // means the filter bar can't ride along as a list header, so it is pinned
+    // above instead — below the transparent nav bar, hence the header inset.
+    if (isGlassCardGridAvailable()) {
+      return (
+        <View
+          style={{
+            flex: 1,
+            paddingLeft: insets.left,
+            paddingRight: insets.right,
+          }}
+        >
+          <View style={{ paddingTop: headerHeight }}>
+            <ListHeaderComponent />
+          </View>
+          {flatData.length === 0 ? (
+            <View className='flex flex-col items-center justify-center flex-1'>
+              <Text className='font-bold text-xl text-neutral-500'>
+                {t("library.no_results")}
+              </Text>
+            </View>
+          ) : (
+            <CardGrid
+              items={flatData}
+              columns={nrOfCols}
+              loadingMore={isFetching && !isLoading}
+              onEndReached={() => {
+                if (hasNextPage) {
+                  fetchNextPage();
+                }
+              }}
+              // Clears the floating tab bar, which overlays the grid.
+              contentInsetBottom={insets.bottom + 100}
+              // Filters changed underneath: jump back to the top rather than
+              // staying deep in the previous result set.
+              scrollToTopToken={filterSignature}
+            />
+          )}
+        </View>
+      );
+    }
+
     return (
       <FlashList
         ref={flashListRef}

--- a/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
+++ b/app/(auth)/(tabs)/(libraries)/[libraryId].tsx
@@ -29,6 +29,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CardGrid } from "@/components/cards/CardGrid";
+import { useNativeMediaCards } from "@/components/cards/useNativeMediaCards";
 import { Image } from "@/components/common/ServerImage";
 import { Text } from "@/components/common/Text";
 import {
@@ -971,6 +972,7 @@ const Page = () => {
   }, [showOptions, t, tvFilterByOptions, setFilter, _setFilterBy]);
 
   const insets = useSafeAreaInsets();
+  const nativeCards = useNativeMediaCards();
   // The nav bar is transparent on iOS, so the pinned filter bar has to clear it
   // itself — the FlashList path gets this from contentInsetAdjustmentBehavior.
   // Same safe-area + nav-bar constant the other transparent-header screens use;
@@ -989,7 +991,7 @@ const Page = () => {
     // The whole grid is one native view where that exists. Its own scrolling
     // means the filter bar can't ride along as a list header, so it is pinned
     // above instead — below the transparent nav bar, hence the header inset.
-    if (isGlassCardGridAvailable()) {
+    if (nativeCards && isGlassCardGridAvailable()) {
       return (
         <View
           style={{

--- a/app/(auth)/(tabs)/(search)/index.tsx
+++ b/app/(auth)/(tabs)/(search)/index.tsx
@@ -20,20 +20,17 @@ import {
 import { useTranslation } from "react-i18next";
 import { Platform, ScrollView, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import ContinueWatchingPoster from "@/components/ContinueWatchingPoster";
+import { CardRow } from "@/components/cards/CardRow";
 import { Image } from "@/components/common/ServerImage";
 import { Text } from "@/components/common/Text";
 import {
   getItemNavigation,
   TouchableItemRouter,
 } from "@/components/common/TouchableItemRouter";
-import { ItemCardText } from "@/components/ItemCardText";
 import {
   JellyseerrSearchSort,
   JellyserrIndexPage,
 } from "@/components/jellyseerr/JellyseerrIndexPage";
-import MoviePoster from "@/components/posters/MoviePoster";
-import SeriesPoster from "@/components/posters/SeriesPoster";
 import { DiscoverFilters } from "@/components/search/DiscoverFilters";
 import { LoadingSkeleton } from "@/components/search/LoadingSkeleton";
 import { SearchItemWrapper } from "@/components/search/SearchItemWrapper";
@@ -669,87 +666,35 @@ export default function SearchPage() {
 
         {searchType === "Library" ? (
           <View className={l1 || l2 ? "opacity-0" : "opacity-100"}>
-            <SearchItemWrapper
-              header={t("search.movies")}
-              items={movies}
-              renderItem={(item: BaseItemDto) => (
-                <TouchableItemRouter
-                  key={item.Id}
-                  className='flex flex-col w-28 mr-2'
-                  item={item}
-                >
-                  <MoviePoster item={item} key={item.Id} />
-                  <Text numberOfLines={2} className='mt-2'>
-                    {item.Name}
-                  </Text>
-                  <Text className='opacity-50 text-xs'>
-                    {item.ProductionYear}
-                  </Text>
-                </TouchableItemRouter>
-              )}
+            <CardRow
+              title={t("search.movies")}
+              items={movies ?? []}
+              kind='portrait'
+              hideIfEmpty
             />
-            <SearchItemWrapper
-              items={series}
-              header={t("search.series")}
-              renderItem={(item: BaseItemDto) => (
-                <TouchableItemRouter
-                  key={item.Id}
-                  item={item}
-                  className='flex flex-col w-28 mr-2'
-                >
-                  <SeriesPoster item={item} key={item.Id} />
-                  <Text numberOfLines={2} className='mt-2'>
-                    {item.Name}
-                  </Text>
-                  <Text className='opacity-50 text-xs'>
-                    {item.ProductionYear}
-                  </Text>
-                </TouchableItemRouter>
-              )}
+            <CardRow
+              title={t("search.series")}
+              items={series ?? []}
+              kind='portrait'
+              hideIfEmpty
             />
-            <SearchItemWrapper
-              items={episodes}
-              header={t("search.episodes")}
-              renderItem={(item: BaseItemDto) => (
-                <TouchableItemRouter
-                  item={item}
-                  key={item.Id}
-                  className='flex flex-col w-44 mr-2'
-                >
-                  <ContinueWatchingPoster item={item} />
-                  <ItemCardText item={item} />
-                </TouchableItemRouter>
-              )}
+            <CardRow
+              title={t("search.episodes")}
+              items={episodes ?? []}
+              kind='wide'
+              hideIfEmpty
             />
-            <SearchItemWrapper
-              items={collections}
-              header={t("search.collections")}
-              renderItem={(item: BaseItemDto) => (
-                <TouchableItemRouter
-                  key={item.Id}
-                  item={item}
-                  className='flex flex-col w-28 mr-2'
-                >
-                  <MoviePoster item={item} key={item.Id} />
-                  <Text numberOfLines={2} className='mt-2'>
-                    {item.Name}
-                  </Text>
-                </TouchableItemRouter>
-              )}
+            <CardRow
+              title={t("search.collections")}
+              items={collections ?? []}
+              kind='portrait'
+              hideIfEmpty
             />
-            <SearchItemWrapper
-              items={actors}
-              header={t("search.actors")}
-              renderItem={(item: BaseItemDto) => (
-                <TouchableItemRouter
-                  item={item}
-                  key={item.Id}
-                  className='flex flex-col w-28 mr-2'
-                >
-                  <MoviePoster item={item} />
-                  <ItemCardText item={item} />
-                </TouchableItemRouter>
-              )}
+            <CardRow
+              title={t("search.actors")}
+              items={actors ?? []}
+              kind='portrait'
+              hideIfEmpty
             />
             {/* Music search results */}
             <SearchItemWrapper

--- a/components/ContinueWatchingPoster.tsx
+++ b/components/ContinueWatchingPoster.tsx
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 import { View } from "react-native";
 import { Image } from "@/components/common/ServerImage";
 import { apiAtom } from "@/providers/JellyfinProvider";
+import { getWideImageUrl } from "@/utils/jellyfin/image/getWideImageUrl";
 import { ProgressBar } from "./common/ProgressBar";
 import { WatchedIndicator } from "./WatchedIndicator";
 
@@ -27,44 +28,11 @@ const ContinueWatchingPoster: React.FC<ContinueWatchingPosterProps> = ({
   /**
    * Get horizontal poster for movie and episode, with failover to primary.
    */
-  const url = useMemo(() => {
-    if (!api) {
-      return;
-    }
-    if (item.Type === "Episode" && useEpisodePoster) {
-      return `${api?.basePath}/Items/${item.Id}/Images/Primary?fillHeight=389&quality=80`;
-    }
-    if (item.Type === "Episode") {
-      // Matched pair: the parent that owns the Thumb (ParentThumbItemId), not the
-      // backdrop owner — otherwise the Thumb tag is requested on the wrong item → black.
-      if (item.ParentThumbItemId && item.ParentThumbImageTag) {
-        return `${api?.basePath}/Items/${item.ParentThumbItemId}/Images/Thumb?fillHeight=389&quality=80&tag=${item.ParentThumbImageTag}`;
-      }
-
-      return `${api?.basePath}/Items/${item.Id}/Images/Primary?fillHeight=389&quality=80`;
-    }
-    if (item.Type === "Movie") {
-      if (item.ImageTags?.Thumb) {
-        return `${api?.basePath}/Items/${item.Id}/Images/Thumb?fillHeight=389&quality=80&tag=${item.ImageTags?.Thumb}`;
-      }
-
-      return `${api?.basePath}/Items/${item.Id}/Images/Primary?fillHeight=389&quality=80`;
-    }
-    if (item.Type === "Program") {
-      if (item.ImageTags?.Thumb) {
-        return `${api?.basePath}/Items/${item.Id}/Images/Thumb?fillHeight=389&quality=80&tag=${item.ImageTags?.Thumb}`;
-      }
-
-      return `${api?.basePath}/Items/${item.Id}/Images/Primary?fillHeight=389&quality=80`;
-    }
-
-    if (item.ImageTags?.Thumb) {
-      return `${api?.basePath}/Items/${item.Id}/Images/Thumb?fillHeight=389&quality=80&tag=${item.ImageTags?.Thumb}`;
-    }
-
-    return `${api?.basePath}/Items/${item.Id}/Images/Primary?fillHeight=389&quality=80`;
+  const url = useMemo(
+    () => getWideImageUrl({ api, item, useEpisodePoster }),
     // useEpisodePoster in deps so flipping the prop re-computes the URL live.
-  }, [api, item, useEpisodePoster]);
+    [api, item, useEpisodePoster],
+  );
 
   if (!url)
     return <View className='aspect-video border border-neutral-800 w-44' />;

--- a/components/MoreMoviesWithActor.tsx
+++ b/components/MoreMoviesWithActor.tsx
@@ -3,15 +3,9 @@ import { getItemsApi } from "@jellyfin/sdk/lib/utils/api";
 import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import type React from "react";
-import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { View, type ViewProps } from "react-native";
-import { HorizontalScroll } from "@/components/common/HorizontalScroll";
-import { Text } from "@/components/common/Text";
-import { TouchableItemRouter } from "@/components/common/TouchableItemRouter";
-import { ItemCardText } from "@/components/ItemCardText";
-import MoviePoster from "@/components/posters/MoviePoster";
-import { POSTER_CAROUSEL_HEIGHT } from "@/constants/Values";
+import type { ViewProps } from "react-native";
+import { CardRow } from "@/components/cards/CardRow";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 
 interface Props extends ViewProps {
@@ -62,35 +56,14 @@ export const MoreMoviesWithActor: React.FC<Props> = ({
     enabled: !!api && !!user?.Id && !!actorId,
   });
 
-  const renderItem = useCallback(
-    (item: BaseItemDto, idx: number) => (
-      <TouchableItemRouter
-        key={item.Id ?? idx}
-        item={item}
-        className='flex flex-col w-28'
-      >
-        <View>
-          <MoviePoster item={item} />
-          <ItemCardText item={item} />
-        </View>
-      </TouchableItemRouter>
-    ),
-    [],
-  );
-
-  if (items?.length === 0) return null;
-
   return (
-    <View {...props}>
-      <Text className='text-lg font-bold mb-2 px-4'>
-        {t("item_card.more_with", { name: actorName ?? "" })}
-      </Text>
-      <HorizontalScroll
-        data={items}
-        loading={isLoading}
-        height={POSTER_CAROUSEL_HEIGHT}
-        renderItem={renderItem}
-      />
-    </View>
+    <CardRow
+      {...props}
+      title={t("item_card.more_with", { name: actorName ?? "" })}
+      kind='portrait'
+      items={items ?? []}
+      loading={isLoading}
+      hideIfEmpty
+    />
   );
 };

--- a/components/SimilarItems.tsx
+++ b/components/SimilarItems.tsx
@@ -4,14 +4,9 @@ import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { View, type ViewProps } from "react-native";
-import MoviePoster from "@/components/posters/MoviePoster";
-import { POSTER_CAROUSEL_HEIGHT } from "@/constants/Values";
+import type { ViewProps } from "react-native";
+import { CardRow } from "@/components/cards/CardRow";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
-import { HorizontalScroll } from "./common/HorizontalScroll";
-import { Text } from "./common/Text";
-import { TouchableItemRouter } from "./common/TouchableItemRouter";
-import { ItemCardText } from "./ItemCardText";
 
 interface SimilarItemsProps extends ViewProps {
   itemId?: string | null;
@@ -47,28 +42,13 @@ export const SimilarItems: React.FC<SimilarItemsProps> = ({
   );
 
   return (
-    <View {...props}>
-      <Text className='px-4 text-lg font-bold mb-2'>
-        {t("item_card.similar_items")}
-      </Text>
-      <HorizontalScroll
-        data={movies}
-        loading={isLoading}
-        height={POSTER_CAROUSEL_HEIGHT}
-        noItemsText={t("item_card.no_similar_items_found")}
-        renderItem={(item: BaseItemDto, idx: number) => (
-          <TouchableItemRouter
-            key={idx}
-            item={item}
-            className='flex flex-col w-28'
-          >
-            <View>
-              <MoviePoster item={item} />
-              <ItemCardText item={item} />
-            </View>
-          </TouchableItemRouter>
-        )}
-      />
-    </View>
+    <CardRow
+      {...props}
+      title={t("item_card.similar_items")}
+      kind='portrait'
+      items={movies}
+      loading={isLoading}
+      emptyText={t("item_card.no_similar_items_found")}
+    />
   );
 };

--- a/components/cards/CardData.ts
+++ b/components/cards/CardData.ts
@@ -1,0 +1,136 @@
+import type { Api } from "@jellyfin/sdk";
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+import { getItemProgressPercentage } from "@/components/common/ProgressBar";
+import {
+  GLASS_CARD_ROW_VERTICAL_PADDING,
+  type GlassCardRowItem,
+  glassCardRowHeight,
+} from "@/modules/glass-card-row";
+import { getPortraitImageUrl } from "@/utils/jellyfin/image/getPortraitImageUrl";
+import { getWideImageUrl } from "@/utils/jellyfin/image/getWideImageUrl";
+
+/**
+ * One card, in the shape both renderers take: the native view decodes exactly
+ * this, and the JS fallback renders exactly this. See docs/native-card-row.md.
+ */
+export type CardData = GlassCardRowItem;
+
+export type CardKind = "wide" | "portrait" | "episode";
+
+/**
+ * Card geometry — the single source of truth for every platform. The values
+ * ride along in the payload, so a native view only draws what it is told and
+ * never carries its own constants, and JS reserves the matching height.
+ *
+ * Anything beyond size is a hint: how a card is *styled* is each native
+ * implementation's business.
+ */
+export const CARD_LAYOUTS: Record<
+  CardKind,
+  {
+    cardWidth: number;
+    aspectRatio: number;
+    cornerRadius: number;
+    spacing: number;
+    contentInset: number;
+    frostFraction: number;
+    verticalPadding: number;
+  }
+> = {
+  // Landscape stills.
+  wide: {
+    cardWidth: 220,
+    aspectRatio: 16 / 9,
+    cornerRadius: 14,
+    spacing: 10,
+    contentInset: 16,
+    frostFraction: 0.45,
+    verticalPadding: GLASS_CARD_ROW_VERTICAL_PADDING,
+  },
+  // Portrait posters. The title sits on the card, and a shallower frost covers
+  // less of a tall poster.
+  portrait: {
+    cardWidth: 132,
+    aspectRatio: 10 / 15,
+    cornerRadius: 12,
+    spacing: 10,
+    contentInset: 16,
+    frostFraction: 0.33,
+    verticalPadding: GLASS_CARD_ROW_VERTICAL_PADDING,
+  },
+  // The episode carousel's stills, a little narrower than the home rows.
+  episode: {
+    cardWidth: 200,
+    aspectRatio: 16 / 9,
+    cornerRadius: 14,
+    spacing: 10,
+    contentInset: 16,
+    frostFraction: 0.45,
+    verticalPadding: GLASS_CARD_ROW_VERTICAL_PADDING,
+  },
+};
+
+/** Height a row of this kind occupies, shadow padding included. */
+export const cardRowHeight = (kind: CardKind) =>
+  glassCardRowHeight(
+    CARD_LAYOUTS[kind].cardWidth,
+    CARD_LAYOUTS[kind].aspectRatio,
+  );
+
+const isMovieOrEpisode = (item: BaseItemDto) =>
+  item.Type === "Movie" || item.Type === "Episode";
+const isAggregate = (item: BaseItemDto) =>
+  item.Type === "Series" || item.Type === "BoxSet";
+
+type BuildOptions = {
+  api?: Api | null;
+  kind: CardKind;
+  /** Prefer the episode's own still over the series thumbnail. */
+  useEpisodePoster?: boolean;
+  /** Item to keep at full opacity; every other card is faded back. */
+  selectedId?: string | null;
+};
+
+/**
+ * `BaseItemDto` → card. The one place the labels, image selection and badge
+ * rules live, so every renderer on every platform says the same thing.
+ */
+export function buildItemCards(
+  items: BaseItemDto[],
+  { api, kind, useEpisodePoster = false, selectedId }: BuildOptions,
+): CardData[] {
+  if (!api) return [];
+
+  return items.flatMap((item) => {
+    if (!item.Id) return [];
+
+    // The two lines ItemCardText shows.
+    const subtitle =
+      item.Type === "Episode"
+        ? `S${item.ParentIndexNumber}:E${item.IndexNumber} - ${item.SeriesName ?? ""}`
+        : item.ProductionYear
+          ? String(item.ProductionYear)
+          : null;
+
+    const unplayed = item.UserData?.UnplayedItemCount ?? 0;
+    const imageUrl =
+      kind === "portrait"
+        ? getPortraitImageUrl({ api, item })
+        : getWideImageUrl({ api, item, useEpisodePoster });
+
+    return [
+      {
+        id: item.Id,
+        title: item.Name ?? "",
+        subtitle,
+        imageUrl: imageUrl ?? null,
+        progress: getItemProgressPercentage(item) / 100,
+        // Strict === false: items without UserData (unknown state) get no dot.
+        unwatched: isMovieOrEpisode(item) && item.UserData?.Played === false,
+        unplayedCount:
+          isAggregate(item) && !item.UserData?.Played ? unplayed : 0,
+        dimmed: selectedId != null && item.Id !== selectedId,
+      },
+    ];
+  });
+}

--- a/components/cards/CardData.ts
+++ b/components/cards/CardData.ts
@@ -118,18 +118,26 @@ export function buildItemCards(
         ? getPortraitImageUrl({ api, item })
         : getWideImageUrl({ api, item, useEpisodePoster });
 
+    const progress = getItemProgressPercentage(item) / 100;
+    // Strict === false: items without UserData (unknown state) get no dot.
+    const unwatched = isMovieOrEpisode(item) && item.UserData?.Played === false;
+    const unplayedCount =
+      isAggregate(item) && !item.UserData?.Played ? unplayed : 0;
+    const dimmed = selectedId != null && item.Id !== selectedId;
+
+    // Default fields are left out rather than sent as 0/false/null: the whole
+    // list is serialised on every change, and a library page is mostly
+    // defaults. The native decoder fills them in.
     return [
       {
         id: item.Id,
         title: item.Name ?? "",
-        subtitle,
-        imageUrl: imageUrl ?? null,
-        progress: getItemProgressPercentage(item) / 100,
-        // Strict === false: items without UserData (unknown state) get no dot.
-        unwatched: isMovieOrEpisode(item) && item.UserData?.Played === false,
-        unplayedCount:
-          isAggregate(item) && !item.UserData?.Played ? unplayed : 0,
-        dimmed: selectedId != null && item.Id !== selectedId,
+        ...(subtitle ? { subtitle } : {}),
+        ...(imageUrl ? { imageUrl } : {}),
+        ...(progress > 0 ? { progress } : {}),
+        ...(unwatched ? { unwatched } : {}),
+        ...(unplayedCount > 0 ? { unplayedCount } : {}),
+        ...(dimmed ? { dimmed } : {}),
       },
     ];
   });

--- a/components/cards/CardGrid.tsx
+++ b/components/cards/CardGrid.tsx
@@ -1,0 +1,86 @@
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+import { useMemo } from "react";
+import { useWindowDimensions } from "react-native";
+import { GlassCardGridView } from "@/modules/glass-card-row";
+import { CARD_LAYOUTS, type CardKind } from "./CardData";
+import { useItemCardBehavior } from "./useItemCardBehavior";
+
+type Props = {
+  items: BaseItemDto[];
+  kind?: CardKind;
+  columns: number;
+  loadingMore?: boolean;
+  onEndReached?: () => void;
+  /** Room for anything pinned above the grid, plus the bottom safe area. */
+  contentInsetTop?: number;
+  contentInsetBottom?: number;
+  /** Changing this scrolls back to the top — the filters changed underneath. */
+  scrollToTopToken?: string | null;
+  onPressItem?: (item: BaseItemDto) => void;
+  enableActionSheet?: boolean;
+};
+
+/**
+ * A scrolling grid of media cards, rendered as a single native view.
+ *
+ * The same cards and the same behaviour as `CardRow` — both take them from
+ * `useItemCardBehavior` — arranged in columns instead of a row. The one
+ * difference that matters: card width is derived from the column count, since
+ * a grid has to fill the screen where a row's width is fixed.
+ *
+ * Callers must check `isGlassCardGridAvailable()` and keep their JS list for
+ * platforms without a native implementation.
+ */
+export const CardGrid: React.FC<Props> = ({
+  items,
+  kind = "portrait",
+  columns,
+  loadingMore = false,
+  onEndReached,
+  contentInsetTop = 0,
+  contentInsetBottom = 0,
+  scrollToTopToken,
+  onPressItem,
+  enableActionSheet = true,
+}) => {
+  const { width } = useWindowDimensions();
+  const { cards, imageHeaders, handlePress, handleLongPress, actionSheet } =
+    useItemCardBehavior({
+      items,
+      kind,
+      onPressItem,
+      enableActionSheet,
+    });
+
+  const base = CARD_LAYOUTS[kind];
+  const layout = useMemo(() => {
+    const safeColumns = Math.max(columns, 1);
+    const available =
+      width - base.contentInset * 2 - base.spacing * (safeColumns - 1);
+    return { ...base, cardWidth: Math.floor(available / safeColumns) };
+  }, [base, columns, width]);
+
+  return (
+    <>
+      <GlassCardGridView
+        items={cards}
+        imageHeaders={imageHeaders}
+        layout={layout}
+        columns={columns}
+        loadingMore={loadingMore}
+        contentInsetTop={contentInsetTop}
+        contentInsetBottom={contentInsetBottom}
+        scrollToTopToken={scrollToTopToken}
+        onItemPress={({ nativeEvent }) => handlePress(nativeEvent.id)}
+        onItemLongPress={
+          handleLongPress
+            ? ({ nativeEvent }) => handleLongPress(nativeEvent.id)
+            : undefined
+        }
+        onEndReached={onEndReached}
+        style={{ flex: 1 }}
+      />
+      {actionSheet}
+    </>
+  );
+};

--- a/components/cards/CardRow.tsx
+++ b/components/cards/CardRow.tsx
@@ -1,0 +1,147 @@
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+import { View, type ViewProps } from "react-native";
+import { SectionHeader } from "@/components/common/SectionHeader";
+import { Text } from "@/components/common/Text";
+import {
+  GlassCardRowView,
+  isGlassCardRowAvailable,
+} from "@/modules/glass-card-row";
+import {
+  CARD_LAYOUTS,
+  type CardData,
+  type CardKind,
+  cardRowHeight,
+} from "./CardData";
+import { CardRowSkeleton } from "./CardRowSkeleton";
+import { JsCardRow } from "./JsCardRow";
+import { useItemCardBehavior } from "./useItemCardBehavior";
+
+interface Props extends ViewProps {
+  /** Section heading. Omit for a bare row. */
+  title?: string | null;
+  /** Renders a "See all" action next to the title. */
+  onPressSeeAll?: () => void;
+  seeAllLabel?: string;
+  kind?: CardKind;
+
+  /** Media items — cards, navigation and the action sheet are handled here. */
+  items?: BaseItemDto[];
+  /** Prebuilt cards, for anything that isn't a `BaseItemDto` (cast members). */
+  cards?: CardData[];
+
+  /** Prefer the episode's own still over the series thumbnail. */
+  useEpisodePoster?: boolean;
+  /** Item to keep at full opacity; every other card is faded back. */
+  selectedId?: string | null;
+  /** Card to scroll into view when this value changes. */
+  scrollToId?: string | null;
+
+  loading?: boolean;
+  /** Spinner after the last card while the next page loads. */
+  loadingMore?: boolean;
+  onEndReached?: () => void;
+  /** Shown in place of the row when there is nothing to draw. */
+  emptyText?: string;
+  /** Renders nothing at all when the row is empty. */
+  hideIfEmpty?: boolean;
+
+  /** Replaces the default navigation (items mode). */
+  onPressItem?: (item: BaseItemDto) => void;
+  /** Press handler for `cards` mode. */
+  onPressId?: (id: string) => void;
+  /** Long press opens the played/favorite sheet (items mode). Default: true. */
+  enableActionSheet?: boolean;
+}
+
+/**
+ * A horizontal row of media cards — the one component every section uses.
+ *
+ * It draws the heading, the loading skeleton and the empty state, then renders
+ * the row natively when a native implementation exists and falls back to the
+ * JS cards when it doesn't. Call sites never branch on platform: adding a
+ * native view for another platform (see docs/native-card-row.md) switches all
+ * of them at once.
+ */
+export const CardRow: React.FC<Props> = ({
+  title,
+  onPressSeeAll,
+  seeAllLabel,
+  kind = "wide",
+  items,
+  cards: providedCards,
+  useEpisodePoster = false,
+  selectedId,
+  scrollToId,
+  loading = false,
+  loadingMore = false,
+  onEndReached,
+  emptyText,
+  hideIfEmpty = false,
+  onPressItem,
+  onPressId,
+  enableActionSheet = true,
+  ...props
+}) => {
+  const { cards, imageHeaders, handlePress, handleLongPress, actionSheet } =
+    useItemCardBehavior({
+      items,
+      cards: providedCards,
+      kind,
+      useEpisodePoster,
+      selectedId,
+      onPressItem,
+      onPressId,
+      enableActionSheet,
+    });
+
+  const isEmpty = cards.length === 0;
+  if (hideIfEmpty && isEmpty && !loading) return null;
+
+  return (
+    <View {...props}>
+      {Boolean(title) && (
+        <SectionHeader
+          title={title as string}
+          actionLabel={seeAllLabel}
+          actionDisabled={loading}
+          onPressAction={onPressSeeAll}
+        />
+      )}
+
+      {loading ? (
+        <CardRowSkeleton kind={kind} />
+      ) : isEmpty ? (
+        emptyText ? (
+          <View className='px-4'>
+            <Text className='text-neutral-500'>{emptyText}</Text>
+          </View>
+        ) : null
+      ) : isGlassCardRowAvailable() ? (
+        <GlassCardRowView
+          items={cards}
+          imageHeaders={imageHeaders}
+          layout={CARD_LAYOUTS[kind]}
+          loadingMore={loadingMore}
+          scrollToId={scrollToId}
+          onItemPress={({ nativeEvent }) => handlePress(nativeEvent.id)}
+          onItemLongPress={
+            handleLongPress
+              ? ({ nativeEvent }) => handleLongPress(nativeEvent.id)
+              : undefined
+          }
+          onEndReached={onEndReached}
+          style={{ height: cardRowHeight(kind) }}
+        />
+      ) : (
+        <JsCardRow
+          cards={cards}
+          kind={kind}
+          onPressId={handlePress}
+          onEndReached={onEndReached}
+        />
+      )}
+
+      {actionSheet}
+    </View>
+  );
+};

--- a/components/cards/CardRow.tsx
+++ b/components/cards/CardRow.tsx
@@ -15,6 +15,7 @@ import {
 import { CardRowSkeleton } from "./CardRowSkeleton";
 import { JsCardRow } from "./JsCardRow";
 import { useItemCardBehavior } from "./useItemCardBehavior";
+import { useNativeMediaCards } from "./useNativeMediaCards";
 
 interface Props extends ViewProps {
   /** Section heading. Omit for a bare row. */
@@ -82,6 +83,7 @@ export const CardRow: React.FC<Props> = ({
   enableActionSheet = true,
   ...props
 }) => {
+  const nativeCards = useNativeMediaCards();
   const { cards, imageHeaders, handlePress, handleLongPress, actionSheet } =
     useItemCardBehavior({
       items,
@@ -93,6 +95,10 @@ export const CardRow: React.FC<Props> = ({
       onPressId,
       enableActionSheet,
     });
+
+  // The setting only chooses between two renderers of the same cards; it can't
+  // conjure a native view where none exists.
+  const drawNatively = nativeCards && isGlassCardRowAvailable();
 
   const isEmpty = cards.length === 0;
   if (hideIfEmpty && isEmpty && !loading) return null;
@@ -116,7 +122,7 @@ export const CardRow: React.FC<Props> = ({
             <Text className='text-neutral-500'>{emptyText}</Text>
           </View>
         ) : null
-      ) : isGlassCardRowAvailable() ? (
+      ) : drawNatively ? (
         <GlassCardRowView
           items={cards}
           imageHeaders={imageHeaders}

--- a/components/cards/CardRowSkeleton.tsx
+++ b/components/cards/CardRowSkeleton.tsx
@@ -1,0 +1,33 @@
+import { View } from "react-native";
+import { CARD_LAYOUTS, type CardKind } from "./CardData";
+
+/** Placeholder cards shown while a row loads, sized like the real ones. */
+export const CardRowSkeleton: React.FC<{ kind: CardKind; count?: number }> = ({
+  kind,
+  count = 3,
+}) => {
+  const layout = CARD_LAYOUTS[kind];
+
+  return (
+    <View
+      style={{
+        flexDirection: "row",
+        gap: layout.spacing,
+        paddingHorizontal: layout.contentInset,
+        paddingVertical: layout.verticalPadding,
+      }}
+    >
+      {Array.from({ length: count }, (_, i) => i).map((i) => (
+        <View
+          key={i}
+          style={{
+            width: layout.cardWidth,
+            height: layout.cardWidth / layout.aspectRatio,
+            borderRadius: layout.cornerRadius,
+            backgroundColor: "#171717",
+          }}
+        />
+      ))}
+    </View>
+  );
+};

--- a/components/cards/JsCardRow.tsx
+++ b/components/cards/JsCardRow.tsx
@@ -1,4 +1,5 @@
 import { LinearGradient } from "expo-linear-gradient";
+import { useMemo } from "react";
 import { ScrollView, TouchableOpacity, View } from "react-native";
 import { Image } from "@/components/common/ServerImage";
 import { Text } from "@/components/common/Text";
@@ -155,6 +156,14 @@ export const JsCardRow: React.FC<RowProps> = ({
 }) => {
   const layout = CARD_LAYOUTS[kind];
 
+  // Settle on a card rather than drifting to an arbitrary offset, matching the
+  // native row. The first card starts at contentInset, so the offsets are
+  // measured from there.
+  const snapOffsets = useMemo(
+    () => cards.map((_, index) => index * (layout.cardWidth + layout.spacing)),
+    [cards, layout.cardWidth, layout.spacing],
+  );
+
   const handleScroll = (event: any) => {
     if (!onEndReached) return;
     const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
@@ -169,6 +178,8 @@ export const JsCardRow: React.FC<RowProps> = ({
       showsHorizontalScrollIndicator={false}
       onScroll={handleScroll}
       scrollEventThrottle={16}
+      snapToOffsets={snapOffsets}
+      decelerationRate='fast'
       contentContainerStyle={{
         paddingHorizontal: layout.contentInset,
         paddingVertical: layout.verticalPadding,

--- a/components/cards/JsCardRow.tsx
+++ b/components/cards/JsCardRow.tsx
@@ -1,0 +1,188 @@
+import { LinearGradient } from "expo-linear-gradient";
+import { ScrollView, TouchableOpacity, View } from "react-native";
+import { Image } from "@/components/common/ServerImage";
+import { Text } from "@/components/common/Text";
+import { Colors } from "@/constants/Colors";
+import { CARD_LAYOUTS, type CardData, type CardKind } from "./CardData";
+
+type CardProps = {
+  card: CardData;
+  kind: CardKind;
+  onPress: () => void;
+};
+
+/**
+ * The JS drawing of a card — same data as the native view, same layout rules.
+ * Used wherever no native implementation exists (Android today, or a build
+ * without the module), so a platform never has to look different by accident.
+ */
+export const JsCard: React.FC<CardProps> = ({ card, kind, onPress }) => {
+  const layout = CARD_LAYOUTS[kind];
+  const height = layout.cardWidth / layout.aspectRatio;
+  const progress = Math.min(Math.max(card.progress ?? 0, 0), 1);
+  const unplayed = card.unplayedCount ?? 0;
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={{
+        width: layout.cardWidth,
+        height,
+        borderRadius: layout.cornerRadius,
+        overflow: "hidden",
+        opacity: card.dimmed ? 0.5 : 1,
+        borderWidth: 0.5,
+        borderColor: "rgba(255,255,255,0.12)",
+      }}
+    >
+      {card.imageUrl ? (
+        <Image
+          id={card.id}
+          source={{ uri: card.imageUrl }}
+          cachePolicy='memory-disk'
+          contentFit='cover'
+          style={{ width: "100%", height: "100%" }}
+        />
+      ) : (
+        <View style={{ flex: 1, backgroundColor: "#1a1a1a" }} />
+      )}
+
+      {/* Frosted band, faded in from nothing so the text stays readable. */}
+      <LinearGradient
+        colors={["transparent", "rgba(0,0,0,0.85)"]}
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: height * layout.frostFraction,
+        }}
+      />
+
+      <View
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          paddingHorizontal: 10,
+          paddingBottom: 9,
+        }}
+      >
+        <Text numberOfLines={1} style={{ fontSize: 13, fontWeight: "600" }}>
+          {card.title}
+        </Text>
+        {Boolean(card.subtitle) && (
+          <Text
+            numberOfLines={1}
+            style={{ fontSize: 11, color: "rgba(255,255,255,0.7)" }}
+          >
+            {card.subtitle}
+          </Text>
+        )}
+        {progress > 0 && (
+          <View
+            style={{
+              height: 3,
+              borderRadius: 2,
+              marginTop: 5,
+              backgroundColor: "rgba(255,255,255,0.25)",
+            }}
+          >
+            <View
+              style={{
+                height: 3,
+                borderRadius: 2,
+                width: `${progress * 100}%`,
+                backgroundColor: Colors.primary,
+              }}
+            />
+          </View>
+        )}
+      </View>
+
+      {unplayed > 0 ? (
+        <View
+          style={{
+            position: "absolute",
+            top: 6,
+            right: 6,
+            minWidth: 20,
+            height: 20,
+            paddingHorizontal: 5,
+            borderRadius: 10,
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: Colors.primary,
+          }}
+        >
+          <Text style={{ fontSize: 11, fontWeight: "700" }}>
+            {unplayed >= 1000 ? "1k+" : unplayed}
+          </Text>
+        </View>
+      ) : (
+        card.unwatched && (
+          <View
+            style={{
+              position: "absolute",
+              top: 8,
+              right: 8,
+              width: 10,
+              height: 10,
+              borderRadius: 5,
+              backgroundColor: Colors.primary,
+            }}
+          />
+        )
+      )}
+    </TouchableOpacity>
+  );
+};
+
+type RowProps = {
+  cards: CardData[];
+  kind: CardKind;
+  onPressId: (id: string) => void;
+  onEndReached?: () => void;
+};
+
+/** Horizontal row of `JsCard`s — the fallback for `CardRow`. */
+export const JsCardRow: React.FC<RowProps> = ({
+  cards,
+  kind,
+  onPressId,
+  onEndReached,
+}) => {
+  const layout = CARD_LAYOUTS[kind];
+
+  const handleScroll = (event: any) => {
+    if (!onEndReached) return;
+    const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
+    if (layoutMeasurement.width + contentOffset.x >= contentSize.width - 20) {
+      onEndReached();
+    }
+  };
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      onScroll={handleScroll}
+      scrollEventThrottle={16}
+      contentContainerStyle={{
+        paddingHorizontal: layout.contentInset,
+        paddingVertical: layout.verticalPadding,
+        gap: layout.spacing,
+      }}
+    >
+      {cards.map((card) => (
+        <JsCard
+          key={card.id}
+          card={card}
+          kind={kind}
+          onPress={() => onPressId(card.id)}
+        />
+      ))}
+    </ScrollView>
+  );
+};

--- a/components/cards/useItemCardBehavior.tsx
+++ b/components/cards/useItemCardBehavior.tsx
@@ -1,0 +1,128 @@
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+import { useSegments } from "expo-router";
+import { useAtomValue } from "jotai";
+import { useCallback, useMemo, useState } from "react";
+import { ItemActionSheetHost } from "@/components/common/ItemActionSheetHost";
+import {
+  getItemNavigation,
+  itemRouter,
+} from "@/components/common/TouchableItemRouter";
+import useRouter from "@/hooks/useAppRouter";
+import { useHeadersForUrl } from "@/hooks/useHeadersForUrl";
+import { apiAtom } from "@/providers/JellyfinProvider";
+import { buildItemCards, type CardData, type CardKind } from "./CardData";
+
+type Options = {
+  /** Media items — cards are built here, and presses navigate. */
+  items?: BaseItemDto[];
+  /** Prebuilt cards, for anything that isn't a `BaseItemDto`. */
+  cards?: CardData[];
+  kind: CardKind;
+  useEpisodePoster?: boolean;
+  selectedId?: string | null;
+  /** Replaces the default navigation (items mode). */
+  onPressItem?: (item: BaseItemDto) => void;
+  /** Press handler for `cards` mode. */
+  onPressId?: (id: string) => void;
+  /** Long press opens the played/favorite sheet (items mode). */
+  enableActionSheet?: boolean;
+};
+
+/**
+ * Everything a container of cards needs besides its layout: the cards
+ * themselves, the image auth headers, what a press means, and the long-press
+ * action sheet.
+ *
+ * Shared by `CardRow` and `CardGrid` so the two differ only in how they
+ * arrange cards — a third container gets the same behaviour for free.
+ */
+export function useItemCardBehavior({
+  items,
+  cards: providedCards,
+  kind,
+  useEpisodePoster = false,
+  selectedId,
+  onPressItem,
+  onPressId,
+  enableActionSheet = true,
+}: Options) {
+  const api = useAtomValue(apiAtom);
+  const router = useRouter();
+  const segments = useSegments();
+  const [actionSheetItem, setActionSheetItem] = useState<BaseItemDto | null>(
+    null,
+  );
+
+  const from = (segments as string[])[2] || "(home)";
+
+  const cards = useMemo(
+    () =>
+      providedCards ??
+      buildItemCards(items ?? [], {
+        api,
+        kind,
+        useEpisodePoster,
+        selectedId,
+      }),
+    [providedCards, items, api, kind, useEpisodePoster, selectedId],
+  );
+
+  // Every card is served by the same Jellyfin server, so one resolution covers
+  // the container. Headers only exist when the server sits behind an auth proxy.
+  const imageHeaders = useHeadersForUrl(cards[0]?.imageUrl ?? api?.basePath);
+
+  const handlePress = useCallback(
+    (id: string) => {
+      if (onPressId) {
+        onPressId(id);
+        return;
+      }
+
+      const item = items?.find((i) => i.Id === id);
+      if (!item) return;
+
+      if (onPressItem) {
+        onPressItem(item);
+        return;
+      }
+
+      // Music libraries navigate via the explicit string route so the dynamic
+      // [libraryId] param survives the nested navigator.
+      if ("CollectionType" in item && item.CollectionType === "music") {
+        router.push(itemRouter(item, from) as any);
+        return;
+      }
+
+      router.push(getItemNavigation(item, from) as any);
+    },
+    [from, items, onPressId, onPressItem, router],
+  );
+
+  const handleLongPress = useCallback(
+    (id: string) => {
+      const item = items?.find((i) => i.Id === id);
+      if (item) setActionSheetItem(item);
+    },
+    [items],
+  );
+
+  const closeActionSheet = useCallback(() => setActionSheetItem(null), []);
+
+  // Only media items have a played/favorite state to act on.
+  const allowActionSheet = enableActionSheet && Boolean(items);
+
+  return {
+    cards,
+    imageHeaders,
+    handlePress,
+    handleLongPress: allowActionSheet ? handleLongPress : undefined,
+    /** Mount alongside the cards; renders nothing until a long press. */
+    actionSheet: actionSheetItem ? (
+      <ItemActionSheetHost
+        key={actionSheetItem.Id}
+        item={actionSheetItem}
+        onClose={closeActionSheet}
+      />
+    ) : null,
+  };
+}

--- a/components/cards/useNativeMediaCards.ts
+++ b/components/cards/useNativeMediaCards.ts
@@ -1,0 +1,12 @@
+import { useSettings } from "@/utils/atoms/settings";
+
+/**
+ * Whether cards should be drawn by the native view rather than in React
+ * Native. Both renderers draw the same cards, so this only decides which one
+ * runs — callers still have to check that a native view exists at all
+ * (`isGlassCardRowAvailable` / `isGlassCardGridAvailable`).
+ */
+export function useNativeMediaCards(): boolean {
+  const { settings } = useSettings();
+  return settings?.nativeMediaCards !== false;
+}

--- a/components/common/ItemActionSheetHost.tsx
+++ b/components/common/ItemActionSheetHost.tsx
@@ -1,0 +1,38 @@
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+import { useEffect, useRef } from "react";
+import { useItemActionSheet } from "@/hooks/useItemActionSheet";
+
+type Props = {
+  item: BaseItemDto;
+  onClose: () => void;
+};
+
+/**
+ * Presents the item action sheet for as long as it is mounted, then calls
+ * `onClose`. The sheet's hooks are bound to a single item, so a caller that
+ * only knows which item was long-pressed at runtime — a native list handing
+ * back an id — mounts this with `key={item.Id}` instead of rendering a
+ * TouchableItemRouter per row.
+ */
+export const ItemActionSheetHost: React.FC<Props> = ({ item, onClose }) => {
+  const showActionSheet = useItemActionSheet(item);
+  // Present once per mount: the callback identity changes as the item's
+  // favorite/played state settles, which must not re-open the sheet.
+  const presented = useRef(false);
+
+  useEffect(() => {
+    if (presented.current) return;
+    presented.current = true;
+
+    let cancelled = false;
+    showActionSheet().finally(() => {
+      if (!cancelled) onClose();
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [showActionSheet, onClose]);
+
+  return null;
+};

--- a/components/common/ProgressBar.tsx
+++ b/components/common/ProgressBar.tsx
@@ -6,24 +6,30 @@ interface ProgressBarProps {
   item: BaseItemDto;
 }
 
-export const ProgressBar: React.FC<ProgressBarProps> = ({ item }) => {
-  const progress = useMemo(() => {
-    if (item.Type === "Program") {
-      if (!item.StartDate || !item.EndDate) {
-        return 0;
-      }
-      const startDate = new Date(item.StartDate);
-      const endDate = new Date(item.EndDate);
-      const now = new Date();
-      const total = endDate.getTime() - startDate.getTime();
-      if (total <= 0) {
-        return 0;
-      }
-      const elapsed = now.getTime() - startDate.getTime();
-      return (elapsed / total) * 100;
+/**
+ * How far through an item the user is, 0-100. A live TV program has no watch
+ * state, so it reports how much of its air time has elapsed instead.
+ */
+export const getItemProgressPercentage = (item: BaseItemDto): number => {
+  if (item.Type === "Program") {
+    if (!item.StartDate || !item.EndDate) {
+      return 0;
     }
-    return item.UserData?.PlayedPercentage || 0;
-  }, [item]);
+    const startDate = new Date(item.StartDate);
+    const endDate = new Date(item.EndDate);
+    const now = new Date();
+    const total = endDate.getTime() - startDate.getTime();
+    if (total <= 0) {
+      return 0;
+    }
+    const elapsed = now.getTime() - startDate.getTime();
+    return (elapsed / total) * 100;
+  }
+  return item.UserData?.PlayedPercentage || 0;
+};
+
+export const ProgressBar: React.FC<ProgressBarProps> = ({ item }) => {
+  const progress = useMemo(() => getItemProgressPercentage(item), [item]);
 
   if (progress <= 0) {
     return null;

--- a/components/common/TouchableItemRouter.tsx
+++ b/components/common/TouchableItemRouter.tsx
@@ -1,18 +1,13 @@
-import { useActionSheet } from "@expo/react-native-action-sheet";
 import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
 import { useSegments } from "expo-router";
 import { type PropsWithChildren, useCallback } from "react";
-import { useTranslation } from "react-i18next";
 import {
   Platform,
   TouchableOpacity,
   type TouchableOpacityProps,
 } from "react-native";
 import useRouter from "@/hooks/useAppRouter";
-import { useFavorite } from "@/hooks/useFavorite";
-import { useMarkAsPlayed } from "@/hooks/useMarkAsPlayed";
-import { useDownload } from "@/providers/DownloadProvider";
-import { useOfflineMode } from "@/providers/OfflineModeProvider";
+import { useItemActionSheet } from "@/hooks/useItemActionSheet";
 
 interface Props extends TouchableOpacityProps {
   item: BaseItemDto;
@@ -150,14 +145,9 @@ export const TouchableItemRouter: React.FC<PropsWithChildren<Props>> = ({
   children,
   ...props
 }) => {
-  const { t } = useTranslation();
   const segments = useSegments();
-  const { showActionSheetWithOptions } = useActionSheet();
-  const markAsPlayedStatus = useMarkAsPlayed([item]);
-  const { isFavorite, toggleFavorite } = useFavorite(item);
   const router = useRouter();
-  const isOffline = useOfflineMode();
-  const { deleteFile } = useDownload();
+  const showActionSheet = useItemActionSheet(item);
 
   const from = (segments as string[])[2] || "(home)";
 
@@ -172,59 +162,6 @@ export const TouchableItemRouter: React.FC<PropsWithChildren<Props>> = ({
     const navigation = getItemNavigation(item, from);
     router.push(navigation as any);
   }, [from, item, router]);
-
-  const showActionSheet = useCallback(() => {
-    if (
-      !(
-        item.Type === "Movie" ||
-        item.Type === "Episode" ||
-        item.Type === "Series"
-      )
-    )
-      return;
-
-    const options: string[] = [
-      t("common.mark_as_played"),
-      t("common.mark_as_not_played"),
-      isFavorite
-        ? t("music.track_options.remove_from_favorites")
-        : t("music.track_options.add_to_favorites"),
-      ...(isOffline ? [t("home.downloads.delete_download")] : []),
-      t("common.cancel"),
-    ];
-    const cancelButtonIndex = options.length - 1;
-    const destructiveButtonIndex = isOffline
-      ? cancelButtonIndex - 1
-      : undefined;
-
-    showActionSheetWithOptions(
-      {
-        options,
-        cancelButtonIndex,
-        destructiveButtonIndex,
-      },
-      async (selectedIndex) => {
-        if (selectedIndex === 0) {
-          await markAsPlayedStatus(true);
-        } else if (selectedIndex === 1) {
-          await markAsPlayedStatus(false);
-        } else if (selectedIndex === 2) {
-          toggleFavorite();
-        } else if (isOffline && selectedIndex === 3 && item.Id) {
-          deleteFile(item.Id);
-        }
-      },
-    );
-  }, [
-    showActionSheetWithOptions,
-    isFavorite,
-    markAsPlayedStatus,
-    toggleFavorite,
-    isOffline,
-    deleteFile,
-    item.Id,
-    t,
-  ]);
 
   if (
     from === "(home)" ||

--- a/components/home/InfiniteScrollingCollectionList.tsx
+++ b/components/home/InfiniteScrollingCollectionList.tsx
@@ -6,21 +6,9 @@ import {
 } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  ActivityIndicator,
-  ScrollView,
-  View,
-  type ViewProps,
-} from "react-native";
-import { SectionHeader } from "@/components/common/SectionHeader";
-import { Text } from "@/components/common/Text";
-import MoviePoster from "@/components/posters/MoviePoster";
+import type { ViewProps } from "react-native";
+import { CardRow } from "@/components/cards/CardRow";
 import { useSettings } from "@/utils/atoms/settings";
-import { Colors } from "../../constants/Colors";
-import ContinueWatchingPoster from "../ContinueWatchingPoster";
-import { TouchableItemRouter } from "../common/TouchableItemRouter";
-import { ItemCardText } from "../ItemCardText";
-import SeriesPoster from "../posters/SeriesPoster";
 
 interface Props extends ViewProps {
   title?: string | null;
@@ -105,147 +93,28 @@ export const InfiniteScrollingCollectionList: React.FC<Props> = ({
     return deduped;
   }, [data]);
 
-  const snapOffsets = useMemo(() => {
-    const itemWidth = orientation === "horizontal" ? 184 : 120; // w-44 (176px) + mr-2 (8px) or w-28 (112px) + mr-2 (8px)
-    return allItems.map((_, index) => index * itemWidth);
-  }, [allItems, orientation]);
-
-  if (hideIfEmpty === true && allItems.length === 0 && !isLoading) return null;
   if (disabled || !title) return null;
 
-  const handleScroll = (event: any) => {
-    const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
-    const paddingToBottom = 20;
-
-    // Check if we're near the end of the scroll
-    if (
-      layoutMeasurement.width + contentOffset.x >=
-      contentSize.width - paddingToBottom
-    ) {
-      if (hasNextPage && !isFetchingNextPage) {
-        fetchNextPage();
-      }
+  const loadMore = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
     }
   };
 
   return (
-    <View {...props}>
-      <SectionHeader
-        title={title}
-        actionLabel={t("common.seeAll", { defaultValue: "See all" })}
-        actionDisabled={isLoading}
-        onPressAction={onPressSeeAll}
-      />
-      {isLoading === false && allItems.length === 0 && (
-        <View className='px-4'>
-          <Text className='text-neutral-500'>{t("home.no_items")}</Text>
-        </View>
-      )}
-      {isLoading ? (
-        <View
-          className={`
-            flex flex-row gap-2 px-4
-        `}
-        >
-          {[1, 2, 3].map((i) => (
-            <View className='w-44' key={i}>
-              <View className='bg-neutral-900 h-24 w-full rounded-md mb-1' />
-              <View className='rounded-md overflow-hidden mb-1 self-start'>
-                <Text
-                  className='text-neutral-900 bg-neutral-900 rounded-md'
-                  numberOfLines={1}
-                >
-                  Nisi mollit voluptate amet.
-                </Text>
-              </View>
-              <View className='rounded-md overflow-hidden self-start mb-1'>
-                <Text
-                  className='text-neutral-900 bg-neutral-900 text-xs rounded-md '
-                  numberOfLines={1}
-                >
-                  Lorem ipsum
-                </Text>
-              </View>
-            </View>
-          ))}
-        </View>
-      ) : (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          snapToOffsets={snapOffsets}
-          decelerationRate='fast'
-        >
-          <View className='px-4 flex flex-row'>
-            {allItems.map((item, index) => (
-              <TouchableItemRouter
-                item={item}
-                key={`${item.Id}-${index}`}
-                className={`mr-2
-                  ${orientation === "horizontal" ? "w-44" : "w-28"}
-                `}
-              >
-                {item.Type === "Episode" && orientation === "horizontal" && (
-                  <ContinueWatchingPoster
-                    item={item}
-                    useEpisodePoster={settings?.useEpisodeImagesForNextUp}
-                  />
-                )}
-                {item.Type === "Episode" && orientation === "vertical" && (
-                  <SeriesPoster item={item} />
-                )}
-                {item.Type === "Movie" && orientation === "horizontal" && (
-                  <ContinueWatchingPoster item={item} />
-                )}
-                {item.Type === "Movie" && orientation === "vertical" && (
-                  <MoviePoster item={item} />
-                )}
-                {item.Type === "Series" && orientation === "vertical" && (
-                  <SeriesPoster item={item} />
-                )}
-                {item.Type === "Series" && orientation === "horizontal" && (
-                  <ContinueWatchingPoster item={item} />
-                )}
-                {item.Type === "Program" && (
-                  <ContinueWatchingPoster item={item} />
-                )}
-                {item.Type === "BoxSet" && orientation === "vertical" && (
-                  <MoviePoster item={item} />
-                )}
-                {item.Type === "BoxSet" && orientation === "horizontal" && (
-                  <ContinueWatchingPoster item={item} />
-                )}
-                {item.Type === "Playlist" && orientation === "vertical" && (
-                  <MoviePoster item={item} />
-                )}
-                {item.Type === "Playlist" && orientation === "horizontal" && (
-                  <ContinueWatchingPoster item={item} />
-                )}
-                {item.Type === "Video" && orientation === "vertical" && (
-                  <MoviePoster item={item} />
-                )}
-                {item.Type === "Video" && orientation === "horizontal" && (
-                  <ContinueWatchingPoster item={item} />
-                )}
-                <ItemCardText item={item} />
-              </TouchableItemRouter>
-            ))}
-            {/* Loading indicator for next page */}
-            {isFetchingNextPage && (
-              <View
-                style={{
-                  marginLeft: 8,
-                  marginTop: orientation === "horizontal" ? 37 : 70,
-                }}
-              >
-                <ActivityIndicator size='small' color={Colors.primary} />
-              </View>
-            )}
-          </View>
-        </ScrollView>
-      )}
-    </View>
+    <CardRow
+      {...props}
+      title={title}
+      kind={orientation === "horizontal" ? "wide" : "portrait"}
+      items={allItems}
+      useEpisodePoster={settings?.useEpisodeImagesForNextUp}
+      loading={isLoading}
+      loadingMore={isFetchingNextPage}
+      onEndReached={loadMore}
+      hideIfEmpty={hideIfEmpty}
+      emptyText={t("home.no_items")}
+      onPressSeeAll={onPressSeeAll}
+      seeAllLabel={t("common.seeAll", { defaultValue: "See all" })}
+    />
   );
 };

--- a/components/home/ScrollingCollectionList.tsx
+++ b/components/home/ScrollingCollectionList.tsx
@@ -5,15 +5,10 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { ScrollView, View, type ViewProps } from "react-native";
-import { Text } from "@/components/common/Text";
-import MoviePoster from "@/components/posters/MoviePoster";
+import { View, type ViewProps } from "react-native";
+import { CardRow } from "@/components/cards/CardRow";
 import { useInView } from "@/hooks/useInView";
 import { useSettings } from "@/utils/atoms/settings";
-import ContinueWatchingPoster from "../ContinueWatchingPoster";
-import { TouchableItemRouter } from "../common/TouchableItemRouter";
-import { ItemCardText } from "../ItemCardText";
-import SeriesPoster from "../posters/SeriesPoster";
 
 interface Props extends ViewProps {
   title?: string | null;
@@ -62,83 +57,14 @@ export const ScrollingCollectionList: React.FC<Props> = ({
 
   return (
     <View ref={ref} onLayout={onLayout} {...props}>
-      <Text className='px-4 text-lg font-bold mb-2 text-neutral-100'>
-        {title}
-      </Text>
-      {!shouldShowSkeleton && data?.length === 0 && (
-        <View className='px-4'>
-          <Text className='text-neutral-500'>{t("home.no_items")}</Text>
-        </View>
-      )}
-      {shouldShowSkeleton ? (
-        <View
-          className={`
-            flex flex-row gap-2 px-4
-        `}
-        >
-          {[1, 2, 3].map((i) => (
-            <View className='w-44' key={i}>
-              <View className='bg-neutral-900 h-24 w-full rounded-md mb-1' />
-              <View className='rounded-md overflow-hidden mb-1 self-start'>
-                <Text
-                  className='text-neutral-900 bg-neutral-900 rounded-md'
-                  numberOfLines={1}
-                >
-                  Nisi mollit voluptate amet.
-                </Text>
-              </View>
-              <View className='rounded-md overflow-hidden self-start mb-1'>
-                <Text
-                  className='text-neutral-900 bg-neutral-900 text-xs rounded-md '
-                  numberOfLines={1}
-                >
-                  Lorem ipsum
-                </Text>
-              </View>
-            </View>
-          ))}
-        </View>
-      ) : (
-        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-          <View className='px-4 flex flex-row'>
-            {data?.map((item) => (
-              <TouchableItemRouter
-                item={item}
-                key={item.Id}
-                className={`mr-2 
-                  ${orientation === "horizontal" ? "w-44" : "w-28"}
-                `}
-              >
-                {item.Type === "Episode" && orientation === "horizontal" && (
-                  <ContinueWatchingPoster
-                    item={item}
-                    useEpisodePoster={settings?.useEpisodeImagesForNextUp}
-                  />
-                )}
-                {item.Type === "Episode" && orientation === "vertical" && (
-                  <SeriesPoster item={item} />
-                )}
-                {item.Type === "Movie" && orientation === "horizontal" && (
-                  <ContinueWatchingPoster item={item} />
-                )}
-                {item.Type === "Movie" && orientation === "vertical" && (
-                  <MoviePoster item={item} />
-                )}
-                {item.Type === "Series" && orientation === "vertical" && (
-                  <SeriesPoster item={item} />
-                )}
-                {item.Type === "Series" && orientation === "horizontal" && (
-                  <ContinueWatchingPoster item={item} />
-                )}
-                {item.Type === "Program" && (
-                  <ContinueWatchingPoster item={item} />
-                )}
-                <ItemCardText item={item} />
-              </TouchableItemRouter>
-            ))}
-          </View>
-        </ScrollView>
-      )}
+      <CardRow
+        title={title}
+        kind={orientation === "horizontal" ? "wide" : "portrait"}
+        items={data ?? []}
+        useEpisodePoster={settings?.useEpisodeImagesForNextUp}
+        loading={shouldShowSkeleton}
+        emptyText={t("home.no_items")}
+      />
     </View>
   );
 };

--- a/components/home/StreamystatsPromotedWatchlists.tsx
+++ b/components/home/StreamystatsPromotedWatchlists.tsx
@@ -8,19 +8,13 @@ import { useRouter } from "expo-router";
 import { useAtomValue } from "jotai";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { ScrollView, View, type ViewProps } from "react-native";
-import { SectionHeader } from "@/components/common/SectionHeader";
+import { View, type ViewProps } from "react-native";
+import { CardRow } from "@/components/cards/CardRow";
 import { Text } from "@/components/common/Text";
-import MoviePoster from "@/components/posters/MoviePoster";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { useSettings } from "@/utils/atoms/settings";
 import { createStreamystatsApi } from "@/utils/streamystats/api";
 import type { StreamystatsWatchlist } from "@/utils/streamystats/types";
-import { TouchableItemRouter } from "../common/TouchableItemRouter";
-import { ItemCardText } from "../ItemCardText";
-import SeriesPoster from "../posters/SeriesPoster";
-
-const ITEM_WIDTH = 120; // w-28 (112px) + mr-2 (8px)
 
 interface WatchlistSectionProps extends ViewProps {
   watchlist: StreamystatsWatchlist;
@@ -83,10 +77,6 @@ const WatchlistSection: React.FC<WatchlistSectionProps> = ({
     refetchOnWindowFocus: false,
   });
 
-  const snapOffsets = useMemo(() => {
-    return items?.map((_, index) => index * ITEM_WIDTH) ?? [];
-  }, [items]);
-
   const handleSeeAll = () => {
     router.push({
       pathname: "/(auth)/(tabs)/(watchlists)/[watchlistId]",
@@ -97,52 +87,15 @@ const WatchlistSection: React.FC<WatchlistSectionProps> = ({
   if (!isLoading && (!items || items.length === 0)) return null;
 
   return (
-    <View {...props}>
-      <SectionHeader
-        title={watchlist.name}
-        actionLabel={t("common.seeAll", { defaultValue: "See all" })}
-        actionDisabled={isLoading}
-        onPressAction={handleSeeAll}
-      />
-      {isLoading ? (
-        <View className='flex flex-row gap-2 px-4'>
-          {[1, 2, 3].map((i) => (
-            <View className='w-28' key={i}>
-              <View className='bg-neutral-900 aspect-[2/3] w-full rounded-md mb-1' />
-              <View className='rounded-md overflow-hidden mb-1 self-start'>
-                <Text
-                  className='text-neutral-900 bg-neutral-900 rounded-md'
-                  numberOfLines={1}
-                >
-                  Loading...
-                </Text>
-              </View>
-            </View>
-          ))}
-        </View>
-      ) : (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          snapToOffsets={snapOffsets}
-          decelerationRate='fast'
-        >
-          <View className='px-4 flex flex-row'>
-            {items?.map((item) => (
-              <TouchableItemRouter
-                item={item}
-                key={item.Id}
-                className='mr-2 w-28'
-              >
-                {item.Type === "Movie" && <MoviePoster item={item} />}
-                {item.Type === "Series" && <SeriesPoster item={item} />}
-                <ItemCardText item={item} />
-              </TouchableItemRouter>
-            ))}
-          </View>
-        </ScrollView>
-      )}
-    </View>
+    <CardRow
+      {...props}
+      title={watchlist.name}
+      seeAllLabel={t("common.seeAll", { defaultValue: "See all" })}
+      onPressSeeAll={handleSeeAll}
+      kind='portrait'
+      items={items ?? []}
+      loading={isLoading}
+    />
   );
 };
 

--- a/components/home/StreamystatsRecommendations.tsx
+++ b/components/home/StreamystatsRecommendations.tsx
@@ -6,20 +6,13 @@ import { getItemsApi, getSystemApi } from "@jellyfin/sdk/lib/utils/api";
 import { useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 import { useMemo } from "react";
-import { ScrollView, View, type ViewProps } from "react-native";
+import type { ViewProps } from "react-native";
 
-import { SectionHeader } from "@/components/common/SectionHeader";
-import { Text } from "@/components/common/Text";
-import MoviePoster from "@/components/posters/MoviePoster";
+import { CardRow } from "@/components/cards/CardRow";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { useSettings } from "@/utils/atoms/settings";
 import { createStreamystatsApi } from "@/utils/streamystats/api";
 import type { StreamystatsRecommendationsIdsResponse } from "@/utils/streamystats/types";
-import { TouchableItemRouter } from "../common/TouchableItemRouter";
-import { ItemCardText } from "../ItemCardText";
-import SeriesPoster from "../posters/SeriesPoster";
-
-const ITEM_WIDTH = 120; // w-28 (112px) + mr-2 (8px)
 
 interface Props extends ViewProps {
   title: string;
@@ -141,55 +134,16 @@ export const StreamystatsRecommendations: React.FC<Props> = ({
   const isLoading = isLoadingRecommendations || isLoadingItems;
   const isError = isRecommendationsError || isItemsError;
 
-  const snapOffsets = useMemo(() => {
-    return items?.map((_, index) => index * ITEM_WIDTH) ?? [];
-  }, [items]);
-
   if (!streamyStatsEnabled) return null;
   if (isError) return null;
-  if (!isLoading && (!items || items.length === 0)) return null;
-
   return (
-    <View {...props}>
-      <SectionHeader title={title} />
-      {isLoading ? (
-        <View className='flex flex-row gap-2 px-4'>
-          {[1, 2, 3].map((i) => (
-            <View className='w-28' key={i}>
-              <View className='bg-neutral-900 aspect-[2/3] w-full rounded-md mb-1' />
-              <View className='rounded-md overflow-hidden mb-1 self-start'>
-                <Text
-                  className='text-neutral-900 bg-neutral-900 rounded-md'
-                  numberOfLines={1}
-                >
-                  Loading title...
-                </Text>
-              </View>
-            </View>
-          ))}
-        </View>
-      ) : (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          snapToOffsets={snapOffsets}
-          decelerationRate='fast'
-        >
-          <View className='px-4 flex flex-row'>
-            {items?.map((item) => (
-              <TouchableItemRouter
-                item={item}
-                key={item.Id}
-                className='mr-2 w-28'
-              >
-                {item.Type === "Movie" && <MoviePoster item={item} />}
-                {item.Type === "Series" && <SeriesPoster item={item} />}
-                <ItemCardText item={item} />
-              </TouchableItemRouter>
-            ))}
-          </View>
-        </ScrollView>
-      )}
-    </View>
+    <CardRow
+      {...props}
+      title={title}
+      kind='portrait'
+      items={items ?? []}
+      loading={isLoading}
+      hideIfEmpty
+    />
   );
 };

--- a/components/posters/SeriesPoster.tsx
+++ b/components/posters/SeriesPoster.tsx
@@ -5,7 +5,7 @@ import { View } from "react-native";
 import { Image } from "@/components/common/ServerImage";
 import { WatchedIndicator } from "@/components/WatchedIndicator";
 import { apiAtom } from "@/providers/JellyfinProvider";
-import { getPrimaryImageUrl } from "@/utils/jellyfin/image/getPrimaryImageUrl";
+import { getPortraitImageUrl } from "@/utils/jellyfin/image/getPortraitImageUrl";
 
 type MoviePosterProps = {
   item: BaseItemDto;
@@ -15,16 +15,10 @@ type MoviePosterProps = {
 const SeriesPoster: React.FC<MoviePosterProps> = ({ item }) => {
   const [api] = useAtom(apiAtom);
 
-  const url = useMemo(() => {
-    if (item.Type === "Episode") {
-      return `${api?.basePath}/Items/${item.SeriesId}/Images/Primary?fillHeight=389&quality=80&tag=${item.SeriesPrimaryImageTag}`;
-    }
-    return getPrimaryImageUrl({
-      api,
-      item,
-      width: 300,
-    });
-  }, [item]);
+  const url = useMemo(
+    () => getPortraitImageUrl({ api, item, width: 300 }),
+    [api, item],
+  );
 
   const blurhash = useMemo(() => {
     const key = item.ImageTags?.Primary as string;

--- a/components/series/CastAndCrew.tsx
+++ b/components/series/CastAndCrew.tsx
@@ -5,16 +5,13 @@ import type {
 import { useSegments } from "expo-router";
 import { useAtom } from "jotai";
 import type React from "react";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { TouchableOpacity, View, type ViewProps } from "react-native";
-import { POSTER_CAROUSEL_HEIGHT } from "@/constants/Values";
+import type { ViewProps } from "react-native";
+import { CardRow } from "@/components/cards/CardRow";
 import useRouter from "@/hooks/useAppRouter";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { getPrimaryImageUrl } from "@/utils/jellyfin/image/getPrimaryImageUrl";
-import { HorizontalScroll } from "../common/HorizontalScroll";
-import { Text } from "../common/Text";
-import Poster from "../posters/Poster";
 
 interface Props extends ViewProps {
   item?: BaseItemDto | null;
@@ -43,40 +40,45 @@ export const CastAndCrew: React.FC<Props> = ({ item, loading, ...props }) => {
     return Object.values(people);
   }, [item?.People]);
 
+  // People aren't BaseItemDto, so the cards are built here rather than by
+  // CardRow's item mapping.
+  const cards = useMemo(
+    () =>
+      destinctPeople.flatMap((person) =>
+        person.Id
+          ? [
+              {
+                id: person.Id,
+                title: person.Name ?? "",
+                subtitle: person.Role ?? null,
+                imageUrl: getPrimaryImageUrl({ api, item: person }),
+              },
+            ]
+          : [],
+      ),
+    [api, destinctPeople],
+  );
+
+  const openPerson = useCallback(
+    (personId: string) => {
+      router.push({
+        pathname: "/persons/[personId]",
+        params: { personId },
+      });
+    },
+    [router],
+  );
+
   if (!from) return null;
 
   return (
-    <View {...props} className='flex flex-col'>
-      <Text className='text-lg font-bold mb-2 px-4'>
-        {t("item_card.cast_and_crew")}
-      </Text>
-      <HorizontalScroll
-        loading={loading}
-        keyExtractor={(i, _idx) => i.Id?.toString() || ""}
-        height={POSTER_CAROUSEL_HEIGHT}
-        data={destinctPeople}
-        renderItem={(i) => (
-          <TouchableOpacity
-            onPress={() => {
-              if (i.Id) {
-                router.push({
-                  pathname: "/persons/[personId]",
-                  params: { personId: i.Id },
-                });
-              }
-            }}
-            className='flex flex-col w-28'
-          >
-            <Poster id={i.Id} url={getPrimaryImageUrl({ api, item: i })} />
-            <Text className='mt-2' numberOfLines={1}>
-              {i.Name}
-            </Text>
-            <Text className='text-xs opacity-50' numberOfLines={1}>
-              {i.Role}
-            </Text>
-          </TouchableOpacity>
-        )}
-      />
-    </View>
+    <CardRow
+      {...props}
+      title={t("item_card.cast_and_crew")}
+      kind='portrait'
+      cards={cards}
+      loading={loading}
+      onPressId={openPerson}
+    />
   );
 };

--- a/components/series/CurrentSeries.tsx
+++ b/components/series/CurrentSeries.tsx
@@ -1,15 +1,13 @@
 import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
 import { useAtom } from "jotai";
 import type React from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { TouchableOpacity, View, type ViewProps } from "react-native";
-import { POSTER_CAROUSEL_HEIGHT } from "@/constants/Values";
+import type { ViewProps } from "react-native";
+import { CardRow } from "@/components/cards/CardRow";
 import useRouter from "@/hooks/useAppRouter";
 import { apiAtom } from "@/providers/JellyfinProvider";
 import { getPrimaryImageUrlById } from "@/utils/jellyfin/image/getPrimaryImageUrlById";
-import { HorizontalScroll } from "../common/HorizontalScroll";
-import { Text } from "../common/Text";
-import Poster from "../posters/Poster";
 
 interface Props extends ViewProps {
   item?: BaseItemDto | null;
@@ -20,30 +18,31 @@ export const CurrentSeries: React.FC<Props> = ({ item, ...props }) => {
   const { t } = useTranslation();
   const router = useRouter();
 
+  // The card shows the series this episode belongs to, so it is built by hand
+  // rather than from the episode item.
+  const cards = useMemo(
+    () =>
+      item
+        ? [
+            {
+              id: item.Id ?? "series",
+              title: item.SeriesName ?? "",
+              imageUrl: getPrimaryImageUrlById({ api, id: item.ParentId }),
+            },
+          ]
+        : [],
+    [api, item],
+  );
+
   return (
-    <View {...props}>
-      <Text className='text-lg font-bold mb-2 px-4'>
-        {t("item_card.series")}
-      </Text>
-      <HorizontalScroll
-        data={[item]}
-        height={POSTER_CAROUSEL_HEIGHT}
-        renderItem={(item, _index) => (
-          <TouchableOpacity
-            key={item?.Id}
-            onPress={() =>
-              item?.SeriesId && router.push(`/series/${item.SeriesId}`)
-            }
-            className='flex flex-col space-y-2 w-28'
-          >
-            <Poster
-              id={item?.Id}
-              url={getPrimaryImageUrlById({ api, id: item?.ParentId })}
-            />
-            <Text numberOfLines={1}>{item?.SeriesName}</Text>
-          </TouchableOpacity>
-        )}
-      />
-    </View>
+    <CardRow
+      {...props}
+      title={t("item_card.series")}
+      kind='portrait'
+      cards={cards}
+      onPressId={() =>
+        item?.SeriesId && router.push(`/series/${item.SeriesId}` as any)
+      }
+    />
   );
 };

--- a/components/series/NextUp.tsx
+++ b/components/series/NextUp.tsx
@@ -1,22 +1,17 @@
 import { getTvShowsApi } from "@jellyfin/sdk/lib/utils/api";
-import { FlashList } from "@shopify/flash-list";
 import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import type React from "react";
 import { useTranslation } from "react-i18next";
-import { View } from "react-native";
+import { CardRow } from "@/components/cards/CardRow";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
-import ContinueWatchingPoster from "../ContinueWatchingPoster";
-import { Text } from "../common/Text";
-import { TouchableItemRouter } from "../common/TouchableItemRouter";
-import { ItemCardText } from "../ItemCardText";
 
 export const NextUp: React.FC<{ seriesId: string }> = ({ seriesId }) => {
   const [user] = useAtom(userAtom);
   const [api] = useAtom(apiAtom);
   const { t } = useTranslation();
 
-  const { data: items } = useQuery({
+  const { data: items, isLoading } = useQuery({
     queryKey: ["nextUp", seriesId],
     queryFn: async () => {
       if (!api) return null;
@@ -33,35 +28,14 @@ export const NextUp: React.FC<{ seriesId: string }> = ({ seriesId }) => {
     staleTime: 0,
   });
 
-  if (!items?.length)
-    return (
-      <View className='px-4'>
-        <Text className='text-lg font-bold mb-2'>{t("item_card.next_up")}</Text>
-        <Text className='opacity-50'>{t("item_card.no_items_to_display")}</Text>
-      </View>
-    );
-
   return (
-    <View>
-      <Text className='text-lg font-bold px-4 mb-2'>
-        {t("item_card.next_up")}
-      </Text>
-      <FlashList
-        contentContainerStyle={{ paddingLeft: 16 }}
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        data={items}
-        renderItem={({ item, index }) => (
-          <TouchableItemRouter
-            item={item}
-            key={index}
-            className='flex flex-col w-44'
-          >
-            <ContinueWatchingPoster item={item} useEpisodePoster />
-            <ItemCardText item={item} />
-          </TouchableItemRouter>
-        )}
-      />
-    </View>
+    <CardRow
+      title={t("item_card.next_up")}
+      kind='wide'
+      items={items ?? []}
+      useEpisodePoster
+      loading={isLoading}
+      emptyText={t("item_card.no_items_to_display")}
+    />
   );
 };

--- a/components/series/SeasonEpisodesCarousel.tsx
+++ b/components/series/SeasonEpisodesCarousel.tsx
@@ -2,19 +2,14 @@ import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
 import { getTvShowsApi } from "@jellyfin/sdk/lib/utils/api";
 import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
-import { useEffect, useMemo, useRef } from "react";
-import { TouchableOpacity, type ViewStyle } from "react-native";
+import { useMemo } from "react";
+import { View, type ViewStyle } from "react-native";
+import { CardRow } from "@/components/cards/CardRow";
 import useRouter from "@/hooks/useAppRouter";
 import { useDownload } from "@/providers/DownloadProvider";
 import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
 import { useOfflineMode } from "@/providers/OfflineModeProvider";
 import { getDownloadedEpisodesBySeasonId } from "@/utils/downloads/offline-series";
-import ContinueWatchingPoster from "../ContinueWatchingPoster";
-import {
-  HorizontalScroll,
-  type HorizontalScrollRef,
-} from "../common/HorizontalScroll";
-import { ItemCardText } from "../ItemCardText";
 
 interface Props {
   item?: BaseItemDto | null;
@@ -38,12 +33,6 @@ export const SeasonEpisodesCarousel: React.FC<Props> = ({
   // updateDownloadedItem() reflect the latest state instead of a stale
   // refreshKey-gated snapshot. getAllDownloadedItems() is cached, so this stays cheap.
   const { getDownloadedItems } = useDownload();
-
-  const scrollRef = useRef<HorizontalScrollRef>(null);
-
-  const scrollToIndex = (index: number) => {
-    scrollRef.current?.scrollToIndex(index, -16);
-  };
 
   const seasonId = useMemo(() => {
     return item?.SeasonId;
@@ -74,46 +63,19 @@ export const SeasonEpisodesCarousel: React.FC<Props> = ({
     enabled: !!seasonId && (isOffline || (!!api && !!user?.Id)),
   });
 
-  useEffect(() => {
-    if (item?.Type === "Episode" && item.Id) {
-      const index = episodes?.findIndex((ep) => ep.Id === item.Id);
-      if (index !== undefined && index !== -1) {
-        setTimeout(() => {
-          scrollToIndex(index);
-        }, 400);
-      }
-    }
-  }, [episodes, item]);
-
-  const snapOffsets = useMemo(() => {
-    const itemWidth = 184; // w-44 (176px) + mr-2 (8px)
-    return episodes?.map((_, index) => index * itemWidth) || [];
-  }, [episodes]);
-
   return (
-    <HorizontalScroll
-      ref={scrollRef}
-      data={episodes}
-      extraData={item}
-      loading={loading || isPending}
-      style={style}
-      containerStyle={containerStyle}
-      renderItem={(_item, _idx) => (
-        <TouchableOpacity
-          key={_item.Id}
-          onPress={() => {
-            router.setParams({ id: _item.Id });
-          }}
-          className={`flex flex-col w-44
-                  ${item?.Id === _item.Id ? "" : "opacity-50"}
-                `}
-        >
-          <ContinueWatchingPoster item={_item} useEpisodePoster />
-          <ItemCardText item={_item} />
-        </TouchableOpacity>
-      )}
-      snapToOffsets={snapOffsets}
-      decelerationRate='fast'
-    />
+    <View style={[containerStyle, style]}>
+      <CardRow
+        kind='episode'
+        items={episodes ?? []}
+        useEpisodePoster
+        loading={loading || isPending}
+        // Everything but the episode being viewed is faded back.
+        selectedId={item?.Id}
+        scrollToId={item?.Type === "Episode" ? item?.Id : null}
+        // Swaps the item shown by the page rather than navigating.
+        onPressItem={(episode) => router.setParams({ id: episode.Id })}
+      />
+    </View>
   );
 };

--- a/components/settings/AppearanceSettings.tsx
+++ b/components/settings/AppearanceSettings.tsx
@@ -70,6 +70,19 @@ export const AppearanceSettings: React.FC = () => {
             }
           />
         </ListItem>
+        {Platform.OS === "ios" && !Platform.isTV && (
+          <ListItem
+            title={t("home.settings.appearance.native_media_cards")}
+            subtitle={t("home.settings.appearance.native_media_cards_hint")}
+          >
+            <SettingSwitch
+              value={settings.nativeMediaCards}
+              onValueChange={(value) =>
+                updateSettings({ nativeMediaCards: value })
+              }
+            />
+          </ListItem>
+        )}
         <ListItem
           title={t("home.settings.appearance.hide_remote_session_button")}
           subtitle={t(

--- a/hooks/useItemActionSheet.ts
+++ b/hooks/useItemActionSheet.ts
@@ -1,0 +1,83 @@
+import { useActionSheet } from "@expo/react-native-action-sheet";
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useFavorite } from "@/hooks/useFavorite";
+import { useMarkAsPlayed } from "@/hooks/useMarkAsPlayed";
+import { useDownload } from "@/providers/DownloadProvider";
+import { useOfflineMode } from "@/providers/OfflineModeProvider";
+
+/**
+ * The long-press action sheet for a media item: played state, favorite, and —
+ * offline — deleting the download.
+ *
+ * Returns a function that presents the sheet and resolves once it closes, so a
+ * caller that mounts it on demand knows when to unmount again. Unsupported item
+ * types present nothing and resolve immediately.
+ */
+export function useItemActionSheet(item: BaseItemDto) {
+  const { t } = useTranslation();
+  const { showActionSheetWithOptions } = useActionSheet();
+  const markAsPlayedStatus = useMarkAsPlayed([item]);
+  const { isFavorite, toggleFavorite } = useFavorite(item);
+  const isOffline = useOfflineMode();
+  const { deleteFile } = useDownload();
+
+  return useCallback((): Promise<void> => {
+    if (
+      !(
+        item.Type === "Movie" ||
+        item.Type === "Episode" ||
+        item.Type === "Series"
+      )
+    ) {
+      return Promise.resolve();
+    }
+
+    const options: string[] = [
+      t("common.mark_as_played"),
+      t("common.mark_as_not_played"),
+      isFavorite
+        ? t("music.track_options.remove_from_favorites")
+        : t("music.track_options.add_to_favorites"),
+      ...(isOffline ? [t("home.downloads.delete_download")] : []),
+      t("common.cancel"),
+    ];
+    const cancelButtonIndex = options.length - 1;
+    const destructiveButtonIndex = isOffline
+      ? cancelButtonIndex - 1
+      : undefined;
+
+    return new Promise<void>((resolve) => {
+      showActionSheetWithOptions(
+        {
+          options,
+          cancelButtonIndex,
+          destructiveButtonIndex,
+        },
+        async (selectedIndex) => {
+          if (selectedIndex === 0) {
+            await markAsPlayedStatus(true);
+          } else if (selectedIndex === 1) {
+            await markAsPlayedStatus(false);
+          } else if (selectedIndex === 2) {
+            toggleFavorite();
+          } else if (isOffline && selectedIndex === 3 && item.Id) {
+            deleteFile(item.Id);
+          }
+          resolve();
+        },
+      );
+    });
+  }, [
+    showActionSheetWithOptions,
+    isFavorite,
+    markAsPlayedStatus,
+    toggleFavorite,
+    isOffline,
+    deleteFile,
+    item.Id,
+    item.Type,
+    t,
+  ]);
+}

--- a/modules/glass-card-row/expo-module.config.json
+++ b/modules/glass-card-row/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["GlassCardRowModule", "GlassCardGridModule"]
+  }
+}

--- a/modules/glass-card-row/index.ts
+++ b/modules/glass-card-row/index.ts
@@ -1,0 +1,1 @@
+export * from "./src";

--- a/modules/glass-card-row/ios/GlassCardGridExpoView.swift
+++ b/modules/glass-card-row/ios/GlassCardGridExpoView.swift
@@ -39,6 +39,9 @@ class GlassCardGridExpoView: ExpoView {
   let onItemLongPress = EventDispatcher()
   let onEndReached = EventDispatcher()
 
+  /// Only touched on the main thread; identifies the newest payload.
+  private var payloadSequence = 0
+
   required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
     setupHostingController()
@@ -75,12 +78,26 @@ class GlassCardGridExpoView: ExpoView {
 
   // MARK: - Props
 
+  /// Off-main for the same reason as the row, and it matters more here: paging
+  /// a library appends to a list that keeps growing, so every page would
+  /// otherwise re-decode everything before it, mid-scroll.
   func setPayload(_ payload: String) {
-    guard let data = payload.data(using: .utf8),
-      let decoded = try? JSONDecoder().decode(GlassCardGridPayload.self, from: data)
-    else {
-      return
+    payloadSequence &+= 1
+    let sequence = payloadSequence
+    guard let data = payload.data(using: .utf8) else { return }
+
+    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+      guard
+        let decoded = try? JSONDecoder().decode(GlassCardGridPayload.self, from: data)
+      else { return }
+      DispatchQueue.main.async {
+        guard let self, sequence == self.payloadSequence else { return }
+        self.apply(decoded)
+      }
     }
+  }
+
+  private func apply(_ decoded: GlassCardGridPayload) {
     if decoded.items != state.items {
       state.items = decoded.items
     }

--- a/modules/glass-card-row/ios/GlassCardGridExpoView.swift
+++ b/modules/glass-card-row/ios/GlassCardGridExpoView.swift
@@ -1,0 +1,115 @@
+import Combine
+import ExpoModulesCore
+import SwiftUI
+import UIKit
+
+/// Wire format of the grid's `payload` prop. The cards and the card geometry
+/// are the same types the row uses — a grid is the same cards in a different
+/// container, so it shares the model rather than defining a second one.
+private struct GlassCardGridPayload: Decodable {
+  let items: [GlassCardItem]
+  let imageHeaders: [String: String]?
+  let layout: GlassCardLayout?
+  let columns: Int?
+  let loadingMore: Bool?
+  /// Extra room at the top and bottom of the scroll content, for safe areas
+  /// and anything JS pins over the grid.
+  let contentInsetTop: Double?
+  let contentInsetBottom: Double?
+  /// Changing this scrolls back to the top — filters changed underneath.
+  let scrollToTopToken: String?
+}
+
+final class GlassCardGridState: ObservableObject {
+  @Published var items: [GlassCardItem] = []
+  @Published var imageHeaders: [String: String] = [:]
+  @Published var layout = GlassCardLayout()
+  @Published var columns = 3
+  @Published var loadingMore = false
+  @Published var contentInsetTop: Double = 0
+  @Published var contentInsetBottom: Double = 0
+  @Published var scrollToTopToken: String?
+}
+
+class GlassCardGridExpoView: ExpoView {
+  private var hostingController: UIHostingController<GlassCardGridRootView>?
+  private let state = GlassCardGridState()
+
+  let onItemPress = EventDispatcher()
+  let onItemLongPress = EventDispatcher()
+  let onEndReached = EventDispatcher()
+
+  required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+    setupHostingController()
+  }
+
+  private func setupHostingController() {
+    let root = GlassCardGridRootView(
+      state: state,
+      onItemPress: { [weak self] id, index in
+        self?.onItemPress(["id": id, "index": index])
+      },
+      onItemLongPress: { [weak self] id, index in
+        self?.onItemLongPress(["id": id, "index": index])
+      },
+      onEndReached: { [weak self] in
+        self?.onEndReached([:])
+      }
+    )
+    let hostingController = UIHostingController(rootView: root)
+    hostingController.view.backgroundColor = .clear
+    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+
+    addSubview(hostingController.view)
+
+    NSLayoutConstraint.activate([
+      hostingController.view.topAnchor.constraint(equalTo: topAnchor),
+      hostingController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+      hostingController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
+      hostingController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
+    ])
+
+    self.hostingController = hostingController
+  }
+
+  // MARK: - Props
+
+  func setPayload(_ payload: String) {
+    guard let data = payload.data(using: .utf8),
+      let decoded = try? JSONDecoder().decode(GlassCardGridPayload.self, from: data)
+    else {
+      return
+    }
+    if decoded.items != state.items {
+      state.items = decoded.items
+    }
+    let headers = decoded.imageHeaders ?? [:]
+    if headers != state.imageHeaders {
+      state.imageHeaders = headers
+    }
+    let layout = decoded.layout ?? GlassCardLayout()
+    if layout != state.layout {
+      state.layout = layout
+    }
+    let columns = max(decoded.columns ?? 3, 1)
+    if columns != state.columns {
+      state.columns = columns
+    }
+    let loadingMore = decoded.loadingMore ?? false
+    if loadingMore != state.loadingMore {
+      state.loadingMore = loadingMore
+    }
+    let top = decoded.contentInsetTop ?? 0
+    if top != state.contentInsetTop {
+      state.contentInsetTop = top
+    }
+    let bottom = decoded.contentInsetBottom ?? 0
+    if bottom != state.contentInsetBottom {
+      state.contentInsetBottom = bottom
+    }
+    if decoded.scrollToTopToken != state.scrollToTopToken {
+      state.scrollToTopToken = decoded.scrollToTopToken
+    }
+  }
+}

--- a/modules/glass-card-row/ios/GlassCardGridModule.swift
+++ b/modules/glass-card-row/ios/GlassCardGridModule.swift
@@ -1,0 +1,18 @@
+import ExpoModulesCore
+
+public class GlassCardGridModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("GlassCardGrid")
+
+    View(GlassCardGridExpoView.self) {
+      Events("onItemPress", "onItemLongPress", "onEndReached")
+
+      // One JSON string, for the same reason the row uses one: a typed view
+      // prop that fails to convert is swallowed by `try? prop.set(...)` and the
+      // view renders empty with no error. See docs/native-card-row.md.
+      Prop("payload") { (view: GlassCardGridExpoView, payload: String) in
+        view.setPayload(payload)
+      }
+    }
+  }
+}

--- a/modules/glass-card-row/ios/GlassCardGridView.swift
+++ b/modules/glass-card-row/ios/GlassCardGridView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import UIKit
+
+/// Entry point hosted by the grid's ExpoView. The whole scrollable grid is one
+/// native view; whatever JS pins above it stays in JS.
+struct GlassCardGridRootView: View {
+  @ObservedObject var state: GlassCardGridState
+  let onItemPress: (String, Int) -> Void
+  let onItemLongPress: (String, Int) -> Void
+  let onEndReached: () -> Void
+
+  var body: some View {
+    #if os(iOS)
+    GlassCardGrid(
+      items: state.items,
+      headers: state.imageHeaders,
+      layout: state.layout,
+      columns: state.columns,
+      loadingMore: state.loadingMore,
+      contentInsetTop: state.contentInsetTop,
+      contentInsetBottom: state.contentInsetBottom,
+      scrollToTopToken: state.scrollToTopToken,
+      onItemPress: onItemPress,
+      onItemLongPress: onItemLongPress,
+      onEndReached: onEndReached
+    )
+    .environment(\.colorScheme, .dark)
+    #else
+    EmptyView()
+    #endif
+  }
+}
+
+#if os(iOS)
+
+private struct GlassCardGrid: View {
+  let items: [GlassCardItem]
+  let headers: [String: String]
+  let layout: GlassCardLayout
+  let columns: Int
+  let loadingMore: Bool
+  let contentInsetTop: Double
+  let contentInsetBottom: Double
+  let scrollToTopToken: String?
+  let onItemPress: (String, Int) -> Void
+  let onItemLongPress: (String, Int) -> Void
+  let onEndReached: () -> Void
+
+  /// Anchor for scroll-to-top; the first card's id would disappear with it
+  /// when the filtered list changes.
+  private let topAnchorId = "glass-card-grid-top"
+
+  private var gridColumns: [GridItem] {
+    Array(
+      repeating: GridItem(.fixed(layout.cardWidth), spacing: layout.spacing),
+      count: max(columns, 1)
+    )
+  }
+
+  var body: some View {
+    ScrollViewReader { proxy in
+      ScrollView(.vertical, showsIndicators: true) {
+        // The anchor sits outside the grid: inside, it would be laid out as a
+        // grid item and eat the first cell.
+        Color.clear
+          .frame(height: 0)
+          .id(topAnchorId)
+
+        LazyVGrid(columns: gridColumns, spacing: layout.spacing) {
+          ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+            GlassCardView(
+              item: item,
+              headers: headers,
+              layout: layout,
+              onPress: { onItemPress(item.id, index) },
+              onLongPress: { onItemLongPress(item.id, index) }
+            )
+            // Same tail-driven paging as the row: the cells are lazy, so the
+            // last few appearing is exactly "scrolled to the end". JS ignores
+            // the event while a page is in flight.
+            .onAppear {
+              if index >= items.count - columns * 2 {
+                onEndReached()
+              }
+            }
+          }
+        }
+        .padding(.horizontal, layout.contentInset)
+        .padding(.top, contentInsetTop)
+        .padding(.bottom, contentInsetBottom)
+
+        if loadingMore {
+          ProgressView()
+            .padding(.bottom, contentInsetBottom + 16)
+        }
+      }
+      .onChange(of: scrollToTopToken) { _ in
+        DispatchQueue.main.async {
+          proxy.scrollTo(topAnchorId, anchor: .top)
+        }
+      }
+    }
+  }
+}
+
+#endif

--- a/modules/glass-card-row/ios/GlassCardRow.podspec
+++ b/modules/glass-card-row/ios/GlassCardRow.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name           = 'GlassCardRow'
+  s.version        = '1.0.0'
+  s.summary        = 'Native SwiftUI horizontal card row for iOS'
+  s.description    = 'Horizontally scrolling row of glass media cards, rendered as one native view instead of a native view per card'
+  s.author         = 'Streamyfin'
+  s.homepage       = 'https://github.com/streamyfin/streamyfin'
+  s.platforms      = {
+    :ios => '15.1',
+    :tvos => '15.1'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_VERSION' => '5.9'
+  }
+
+  s.source_files = "*.{h,m,mm,swift}"
+end

--- a/modules/glass-card-row/ios/GlassCardRowExpoView.swift
+++ b/modules/glass-card-row/ios/GlassCardRowExpoView.swift
@@ -111,6 +111,9 @@ class GlassCardRowExpoView: ExpoView {
   let onItemLongPress = EventDispatcher()
   let onEndReached = EventDispatcher()
 
+  /// Only touched on the main thread; identifies the newest payload.
+  private var payloadSequence = 0
+
   required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
     setupHostingController()
@@ -156,12 +159,26 @@ class GlassCardRowExpoView: ExpoView {
 
   // MARK: - Props
 
+  /// Decoding is O(list length), and a new page arrives mid-scroll — exactly
+  /// when a main-thread stall shows. Decode off-main and publish the result,
+  /// dropping it if a newer payload has landed meanwhile.
   func setPayload(_ payload: String) {
-    guard let data = payload.data(using: .utf8),
-      let decoded = try? JSONDecoder().decode(GlassCardRowPayload.self, from: data)
-    else {
-      return
+    payloadSequence &+= 1
+    let sequence = payloadSequence
+    guard let data = payload.data(using: .utf8) else { return }
+
+    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+      guard
+        let decoded = try? JSONDecoder().decode(GlassCardRowPayload.self, from: data)
+      else { return }
+      DispatchQueue.main.async {
+        guard let self, sequence == self.payloadSequence else { return }
+        self.apply(decoded)
+      }
     }
+  }
+
+  private func apply(_ decoded: GlassCardRowPayload) {
     if decoded.items != state.items {
       state.items = decoded.items
     }

--- a/modules/glass-card-row/ios/GlassCardRowExpoView.swift
+++ b/modules/glass-card-row/ios/GlassCardRowExpoView.swift
@@ -1,0 +1,185 @@
+import Combine
+import ExpoModulesCore
+import SwiftUI
+import UIKit
+
+/// One card in the row. A plain value so the SwiftUI layer has no
+/// ExpoModulesCore dependency, and an Android view can parse the same JSON.
+struct GlassCardItem: Identifiable, Equatable, Decodable {
+  let id: String
+  let title: String
+  let subtitle: String?
+  let imageUrl: String?
+  /// Watch progress in 0...1; draws the progress bar when > 0.
+  let progress: Double
+  /// Unwatched movie/episode — draws the corner accent.
+  let unwatched: Bool
+  /// Remaining episodes on a Series/BoxSet; draws the count badge when > 0.
+  let unplayedCount: Int
+  /// Faded back because another card in the row is the current one.
+  let dimmed: Bool
+
+  private enum CodingKeys: String, CodingKey {
+    case id, title, subtitle, imageUrl, progress, unwatched, unplayedCount
+    case dimmed
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+    subtitle = try container.decodeIfPresent(String.self, forKey: .subtitle)
+    imageUrl = try container.decodeIfPresent(String.self, forKey: .imageUrl)
+    progress =
+      try container.decodeIfPresent(Double.self, forKey: .progress)
+      .map { min(max($0, 0), 1) } ?? 0
+    unwatched = try container.decodeIfPresent(Bool.self, forKey: .unwatched) ?? false
+    unplayedCount = try container.decodeIfPresent(Int.self, forKey: .unplayedCount) ?? 0
+    dimmed = try container.decodeIfPresent(Bool.self, forKey: .dimmed) ?? false
+  }
+}
+
+/// Card geometry. JS owns it because it also has to reserve the row's height
+/// in the React Native layout before the native view measures anything.
+struct GlassCardLayout: Equatable, Decodable {
+  var cardWidth: Double = 220
+  var aspectRatio: Double = 16.0 / 9.0
+  var cornerRadius: Double = 14
+  var spacing: Double = 10
+  /// Leading/trailing inset of the row's content.
+  var contentInset: Double = 16
+  /// Share of the card the frosted band covers, bottom up. A tall portrait
+  /// poster needs a smaller share than a landscape still for the same text.
+  var frostFraction: Double = 0.45
+  /// Breathing room above/below the cards so the drop shadow isn't clipped.
+  /// Sent by JS, which has to reserve the same height in its own layout.
+  var verticalPadding: Double = 6
+
+  var cardHeight: Double { cardWidth / aspectRatio }
+
+  init() {}
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    cardWidth = try container.decodeIfPresent(Double.self, forKey: .cardWidth) ?? 220
+    aspectRatio =
+      try container.decodeIfPresent(Double.self, forKey: .aspectRatio) ?? 16.0 / 9.0
+    cornerRadius = try container.decodeIfPresent(Double.self, forKey: .cornerRadius) ?? 14
+    spacing = try container.decodeIfPresent(Double.self, forKey: .spacing) ?? 10
+    contentInset = try container.decodeIfPresent(Double.self, forKey: .contentInset) ?? 16
+    frostFraction =
+      try container.decodeIfPresent(Double.self, forKey: .frostFraction) ?? 0.45
+    verticalPadding =
+      try container.decodeIfPresent(Double.self, forKey: .verticalPadding) ?? 6
+    if aspectRatio <= 0 { aspectRatio = 16.0 / 9.0 }
+    if cardWidth <= 0 { cardWidth = 220 }
+    frostFraction = min(max(frostFraction, 0), 1)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case cardWidth, aspectRatio, cornerRadius, spacing, contentInset
+    case frostFraction, verticalPadding
+  }
+}
+
+/// Wire format of the `payload` prop.
+private struct GlassCardRowPayload: Decodable {
+  let items: [GlassCardItem]
+  let imageHeaders: [String: String]?
+  let layout: GlassCardLayout?
+  let loadingMore: Bool?
+  /// Card to bring into view. Applied when the value changes, so it can't
+  /// fight the user's own scrolling on unrelated payload updates.
+  let scrollToId: String?
+}
+
+/// Observable state so SwiftUI updates in place instead of rebuilding the
+/// hosting controller on every prop change.
+final class GlassCardRowState: ObservableObject {
+  @Published var items: [GlassCardItem] = []
+  @Published var imageHeaders: [String: String] = [:]
+  @Published var layout = GlassCardLayout()
+  @Published var loadingMore = false
+  @Published var scrollToId: String?
+}
+
+class GlassCardRowExpoView: ExpoView {
+  private var hostingController: UIHostingController<GlassCardRowRootView>?
+  private let state = GlassCardRowState()
+
+  let onItemPress = EventDispatcher()
+  let onItemLongPress = EventDispatcher()
+  let onEndReached = EventDispatcher()
+
+  required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+    setupHostingController()
+  }
+
+  private func setupHostingController() {
+    let root = GlassCardRowRootView(
+      state: state,
+      onItemPress: { [weak self] id, index in
+        self?.onItemPress(["id": id, "index": index])
+      },
+      onItemLongPress: { [weak self] id, index in
+        self?.onItemLongPress(["id": id, "index": index])
+      },
+      onEndReached: { [weak self] in
+        self?.onEndReached([:])
+      }
+    )
+    let hostingController = UIHostingController(rootView: root)
+    hostingController.view.backgroundColor = .clear
+    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+
+    addSubview(hostingController.view)
+
+    NSLayoutConstraint.activate([
+      hostingController.view.topAnchor.constraint(equalTo: topAnchor),
+      hostingController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+      hostingController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
+      hostingController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
+    ])
+
+    self.hostingController = hostingController
+  }
+
+  /// Reported so the row still occupies the right height if a caller ever
+  /// leaves it out of the style; JS normally sets an explicit height.
+  override var intrinsicContentSize: CGSize {
+    CGSize(
+      width: UIView.noIntrinsicMetric,
+      height: state.layout.cardHeight + state.layout.verticalPadding * 2
+    )
+  }
+
+  // MARK: - Props
+
+  func setPayload(_ payload: String) {
+    guard let data = payload.data(using: .utf8),
+      let decoded = try? JSONDecoder().decode(GlassCardRowPayload.self, from: data)
+    else {
+      return
+    }
+    if decoded.items != state.items {
+      state.items = decoded.items
+    }
+    let headers = decoded.imageHeaders ?? [:]
+    if headers != state.imageHeaders {
+      state.imageHeaders = headers
+    }
+    let layout = decoded.layout ?? GlassCardLayout()
+    if layout != state.layout {
+      state.layout = layout
+      invalidateIntrinsicContentSize()
+    }
+    let loadingMore = decoded.loadingMore ?? false
+    if loadingMore != state.loadingMore {
+      state.loadingMore = loadingMore
+    }
+    if decoded.scrollToId != state.scrollToId {
+      state.scrollToId = decoded.scrollToId
+    }
+  }
+}

--- a/modules/glass-card-row/ios/GlassCardRowModule.swift
+++ b/modules/glass-card-row/ios/GlassCardRowModule.swift
@@ -1,0 +1,21 @@
+import ExpoModulesCore
+
+public class GlassCardRowModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("GlassCardRow")
+
+    View(GlassCardRowExpoView.self) {
+      Events("onItemPress", "onItemLongPress", "onEndReached")
+
+      // Everything the row renders arrives as one JSON string: the cards, the
+      // image auth headers and the card geometry. Typed Record/Array props are
+      // applied natively with `try? prop.set(...)` (ExpoFabricView.updateProps),
+      // so a conversion that fails is swallowed silently and the view just
+      // renders empty with no error anywhere. A String prop has no such failure
+      // mode, and the payload stays portable for a future Android view.
+      Prop("payload") { (view: GlassCardRowExpoView, payload: String) in
+        view.setPayload(payload)
+      }
+    }
+  }
+}

--- a/modules/glass-card-row/ios/GlassCardRowView.swift
+++ b/modules/glass-card-row/ios/GlassCardRowView.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import SwiftUI
 import UIKit
 
@@ -305,16 +306,42 @@ extension Color {
 
 // MARK: - Image loading
 
-/// Header-aware image loader with an in-memory cache. The Jellyfin server can
-/// sit behind an auth proxy (Cloudflare Access, Pangolin, ...), so every
-/// request carries the custom headers passed down from JS.
+/// Header-aware image loader. The Jellyfin server can sit behind an auth proxy
+/// (Cloudflare Access, Pangolin, ...), so every request carries the custom
+/// headers passed down from JS.
+///
+/// Three layers, in order: decoded images in memory, encoded bytes on disk, then
+/// the network. The disk layer is what stops a cold launch re-downloading every
+/// poster — the JS path gets that from expo-image's own disk cache, so without
+/// it the native cards would be the slower of the two on first paint.
 final class GlassCardImageLoader {
   static let shared = GlassCardImageLoader()
 
+  /// Decoded images, so scrolling back to a card doesn't decode it again.
   private let cache = NSCache<NSString, UIImage>()
+  /// One request per URL: the same poster shows up in several rows at once, and
+  /// a card that re-renders mid-flight must not start a second download.
+  private var inFlight: [String: Task<UIImage?, Never>] = [:]
+  private let lock = NSLock()
+
+  private let directory: URL?
+  private let diskQueue = DispatchQueue(label: "glass-card-image-disk", qos: .utility)
+  /// Bytes on disk are cheap; this only bounds unbounded growth.
+  private let diskBudget = 256 * 1024 * 1024
 
   private init() {
     cache.totalCostLimit = 64 * 1024 * 1024
+
+    directory = FileManager.default
+      .urls(for: .cachesDirectory, in: .userDomainMask)
+      .first?
+      .appendingPathComponent("GlassCardImages", isDirectory: true)
+
+    if let directory {
+      try? FileManager.default.createDirectory(
+        at: directory, withIntermediateDirectories: true)
+      diskQueue.async { [weak self] in self?.pruneDisk() }
+    }
   }
 
   func cached(_ urlString: String) -> UIImage? {
@@ -325,6 +352,33 @@ final class GlassCardImageLoader {
     if let hit = cached(urlString) {
       return hit
     }
+
+    lock.lock()
+    if let existing = inFlight[urlString] {
+      lock.unlock()
+      return await existing.value
+    }
+    let task = Task<UIImage?, Never> { [weak self] in
+      await self?.fetch(urlString, headers: headers) ?? nil
+    }
+    inFlight[urlString] = task
+    lock.unlock()
+
+    let image = await task.value
+
+    lock.lock()
+    inFlight[urlString] = nil
+    lock.unlock()
+
+    return image
+  }
+
+  private func fetch(_ urlString: String, headers: [String: String]) async -> UIImage? {
+    if let data = readFromDisk(urlString), let image = UIImage(data: data) {
+      store(image, data: data, for: urlString, writeToDisk: false)
+      return image
+    }
+
     guard let url = URL(string: urlString) else {
       return nil
     }
@@ -340,8 +394,62 @@ final class GlassCardImageLoader {
     else {
       return nil
     }
-    cache.setObject(image, forKey: urlString as NSString, cost: data.count)
+
+    store(image, data: data, for: urlString, writeToDisk: true)
     return image
+  }
+
+  private func store(
+    _ image: UIImage, data: Data, for urlString: String, writeToDisk: Bool
+  ) {
+    cache.setObject(image, forKey: urlString as NSString, cost: data.count)
+    guard writeToDisk, let url = fileURL(for: urlString) else { return }
+    diskQueue.async {
+      try? data.write(to: url, options: .atomic)
+    }
+  }
+
+  // MARK: - Disk
+
+  /// The URL carries the image tag, so the same URL always means the same
+  /// bytes and a plain hash of it is a safe key.
+  private func fileURL(for urlString: String) -> URL? {
+    guard let directory else { return nil }
+    let digest = SHA256.hash(data: Data(urlString.utf8))
+    let name = digest.map { String(format: "%02x", $0) }.joined()
+    return directory.appendingPathComponent(name)
+  }
+
+  private func readFromDisk(_ urlString: String) -> Data? {
+    guard let url = fileURL(for: urlString) else { return nil }
+    return try? Data(contentsOf: url)
+  }
+
+  /// Oldest files go first once the folder passes its budget. Runs once at
+  /// startup, off the main thread.
+  private func pruneDisk() {
+    guard let directory else { return }
+    let keys: [URLResourceKey] = [.contentAccessDateKey, .fileSizeKey]
+    guard
+      let files = try? FileManager.default.contentsOfDirectory(
+        at: directory, includingPropertiesForKeys: keys)
+    else { return }
+
+    let entries = files.compactMap { url -> (URL, Date, Int)? in
+      guard let values = try? url.resourceValues(forKeys: Set(keys)),
+        let size = values.fileSize
+      else { return nil }
+      return (url, values.contentAccessDate ?? .distantPast, size)
+    }
+
+    var total = entries.reduce(0) { $0 + $1.2 }
+    guard total > diskBudget else { return }
+
+    for entry in entries.sorted(by: { $0.1 < $1.1 }) {
+      try? FileManager.default.removeItem(at: entry.0)
+      total -= entry.2
+      if total <= diskBudget { break }
+    }
   }
 }
 

--- a/modules/glass-card-row/ios/GlassCardRowView.swift
+++ b/modules/glass-card-row/ios/GlassCardRowView.swift
@@ -84,7 +84,9 @@ private struct GlassCardScroller: View {
           }
         }
         .padding(.vertical, layout.verticalPadding)
+        .modifier(SnapTargetLayout())
       }
+      .modifier(SnapToCards())
       .onAppear { scroll(proxy, to: scrollToId, animated: false) }
       .onChange(of: scrollToId) { newValue in
         scroll(proxy, to: newValue, animated: true)
@@ -104,6 +106,35 @@ private struct GlassCardScroller: View {
       } else {
         proxy.scrollTo(id, anchor: .leading)
       }
+    }
+  }
+}
+
+// MARK: - Snapping
+
+/// The row settles on a card rather than drifting to an arbitrary offset, the
+/// way the JS list did with `snapToOffsets`. Each card's leading gap is part of
+/// its identified view, so the alignment keeps the row's inset.
+///
+/// iOS 17 introduced the scroll-target API; below that the row scrolls freely,
+/// which is the graceful degradation — the alternative is reimplementing the
+/// deceleration maths by hand.
+private struct SnapTargetLayout: ViewModifier {
+  func body(content: Content) -> some View {
+    if #available(iOS 17.0, *) {
+      content.scrollTargetLayout()
+    } else {
+      content
+    }
+  }
+}
+
+private struct SnapToCards: ViewModifier {
+  func body(content: Content) -> some View {
+    if #available(iOS 17.0, *) {
+      content.scrollTargetBehavior(.viewAligned)
+    } else {
+      content
     }
   }
 }

--- a/modules/glass-card-row/ios/GlassCardRowView.swift
+++ b/modules/glass-card-row/ios/GlassCardRowView.swift
@@ -1,0 +1,356 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Root
+
+/// Entry point hosted by the ExpoView. iPhone/iPad only: the TV home has its
+/// own focus-driven rows, and Android falls back to the JS list.
+struct GlassCardRowRootView: View {
+  @ObservedObject var state: GlassCardRowState
+  let onItemPress: (String, Int) -> Void
+  let onItemLongPress: (String, Int) -> Void
+  let onEndReached: () -> Void
+
+  var body: some View {
+    #if os(iOS)
+    GlassCardScroller(
+      items: state.items,
+      headers: state.imageHeaders,
+      layout: state.layout,
+      loadingMore: state.loadingMore,
+      scrollToId: state.scrollToId,
+      onItemPress: onItemPress,
+      onItemLongPress: onItemLongPress,
+      onEndReached: onEndReached
+    )
+    // The app is dark themed; force dark so the frost renders dark regardless
+    // of the system appearance.
+    .environment(\.colorScheme, .dark)
+    #else
+    EmptyView()
+    #endif
+  }
+}
+
+#if os(iOS)
+
+// MARK: - Row
+
+private struct GlassCardScroller: View {
+  let items: [GlassCardItem]
+  let headers: [String: String]
+  let layout: GlassCardLayout
+  let loadingMore: Bool
+  let scrollToId: String?
+  let onItemPress: (String, Int) -> Void
+  let onItemLongPress: (String, Int) -> Void
+  let onEndReached: () -> Void
+
+  var body: some View {
+    ScrollViewReader { proxy in
+      ScrollView(.horizontal, showsIndicators: false) {
+        // Spacing lives on the cards rather than on the stack so that the gap
+        // is part of the identified view: `scrollTo` aligns the *identified*
+        // view's leading edge with the viewport, so a bare card would park
+        // flush against the screen edge and swallow the row's inset.
+        LazyHStack(spacing: 0) {
+          ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+            GlassCardView(
+              item: item,
+              headers: headers,
+              layout: layout,
+              onPress: { onItemPress(item.id, index) },
+              onLongPress: { onItemLongPress(item.id, index) }
+            )
+            .padding(.leading, index == 0 ? layout.contentInset : layout.spacing)
+            .padding(.trailing, index == items.count - 1 ? layout.contentInset : 0)
+            .id(item.id)
+            // Paging is driven from the tail of the row rather than from a
+            // scroll offset: the cells are lazy, so "the last few appeared" is
+            // exactly "the user scrolled to the end". Re-entrancy is handled in
+            // JS, which ignores the event while a page is in flight or the list
+            // is exhausted.
+            .onAppear {
+              if index >= items.count - 3 {
+                onEndReached()
+              }
+            }
+          }
+
+          if loadingMore {
+            ProgressView()
+              .frame(width: 44, height: layout.cardHeight)
+              .padding(.horizontal, layout.spacing)
+          }
+        }
+        .padding(.vertical, layout.verticalPadding)
+      }
+      .onAppear { scroll(proxy, to: scrollToId, animated: false) }
+      .onChange(of: scrollToId) { newValue in
+        scroll(proxy, to: newValue, animated: true)
+      }
+    }
+  }
+
+  /// Deferred a runloop tick: the target cell may not exist yet in the lazy
+  /// stack on the pass that sets the id.
+  private func scroll(_ proxy: ScrollViewProxy, to id: String?, animated: Bool) {
+    guard let id, items.contains(where: { $0.id == id }) else { return }
+    DispatchQueue.main.async {
+      if animated {
+        withAnimation(.easeInOut(duration: 0.3)) {
+          proxy.scrollTo(id, anchor: .leading)
+        }
+      } else {
+        proxy.scrollTo(id, anchor: .leading)
+      }
+    }
+  }
+}
+
+// MARK: - Card
+
+/// One card. Shared by the row and the grid.
+struct GlassCardView: View {
+  let item: GlassCardItem
+  let headers: [String: String]
+  let layout: GlassCardLayout
+  let onPress: () -> Void
+  let onLongPress: () -> Void
+
+  /// Set when the long press fires so the touch-up doesn't also open the item.
+  @State private var longPressFired = false
+
+  private var shape: RoundedRectangle {
+    RoundedRectangle(cornerRadius: layout.cornerRadius, style: .continuous)
+  }
+
+  var body: some View {
+    // A Button rather than a tap gesture: `onTapGesture` next to a long press
+    // loses the gesture arena to it and never fires, and the button style is
+    // what gives the press-down feedback.
+    Button {
+      if longPressFired {
+        longPressFired = false
+        return
+      }
+      onPress()
+    } label: {
+      card
+    }
+    .buttonStyle(GlassCardPressStyle())
+    .simultaneousGesture(
+      LongPressGesture(minimumDuration: 0.4).onEnded { _ in
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        longPressFired = true
+        onLongPress()
+        // Self-clearing: if the touch-up never reaches the button (the action
+        // sheet takes over), the flag must not swallow the next tap.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+          longPressFired = false
+        }
+      }
+    )
+  }
+
+  private var card: some View {
+    ZStack(alignment: .bottomLeading) {
+      RemoteCardImage(urlString: item.imageUrl, headers: headers)
+        .frame(width: layout.cardWidth, height: layout.cardHeight)
+
+      frost
+
+      VStack(alignment: .leading, spacing: 1) {
+        Text(item.title)
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundColor(.white)
+          .lineLimit(1)
+
+        if let subtitle = item.subtitle, !subtitle.isEmpty {
+          Text(subtitle)
+            .font(.system(size: 11))
+            .foregroundColor(.white.opacity(0.7))
+            .lineLimit(1)
+        }
+
+        if item.progress > 0 {
+          progressBar
+            .padding(.top, 5)
+        }
+      }
+      .padding(.horizontal, 10)
+      .padding(.bottom, 9)
+      .frame(width: layout.cardWidth, alignment: .leading)
+
+      badge
+    }
+    .frame(width: layout.cardWidth, height: layout.cardHeight)
+    .clipShape(shape)
+    .overlay(shape.strokeBorder(Color.white.opacity(0.12), lineWidth: 0.5))
+    .shadow(color: .black.opacity(0.35), radius: 5, x: 0, y: 3)
+    .contentShape(Rectangle())
+    .opacity(item.dimmed ? 0.5 : 1)
+  }
+
+  /// Frosted band fading in over the bottom of the card so the text stays
+  /// readable on any artwork: a blur that ramps up from nothing, plus a dark
+  /// wash underneath it for contrast against bright frames.
+  private var frost: some View {
+    VStack(spacing: 0) {
+      Spacer(minLength: 0)
+      Rectangle()
+        .fill(.ultraThinMaterial)
+        .frame(height: layout.cardHeight * layout.frostFraction)
+        .mask(
+          LinearGradient(
+            colors: [.clear, .black.opacity(0.6), .black],
+            startPoint: .top,
+            endPoint: .bottom
+          )
+        )
+        .overlay(
+          LinearGradient(
+            colors: [.clear, .black.opacity(0.45)],
+            startPoint: .top,
+            endPoint: .bottom
+          )
+        )
+    }
+    .allowsHitTesting(false)
+  }
+
+  private var progressBar: some View {
+    GeometryReader { geometry in
+      ZStack(alignment: .leading) {
+        Capsule()
+          .fill(Color.white.opacity(0.25))
+        Capsule()
+          .fill(Color.glassCardAccent)
+          .frame(width: max(2, geometry.size.width * item.progress))
+      }
+    }
+    .frame(height: 3)
+  }
+
+  /// Mirrors the JS poster's indicators: a count for a series with episodes
+  /// left, otherwise a dot for an unwatched movie or episode.
+  @ViewBuilder
+  private var badge: some View {
+    if item.unplayedCount > 0 {
+      Text(item.unplayedCount >= 1000 ? "1k+" : String(item.unplayedCount))
+        .font(.system(size: 11, weight: .bold))
+        .foregroundColor(.white)
+        .padding(.horizontal, 5)
+        .frame(minWidth: 20, minHeight: 20)
+        .background(Color.glassCardAccent, in: Capsule())
+        .padding(6)
+        .frame(width: layout.cardWidth, height: layout.cardHeight, alignment: .topTrailing)
+        .allowsHitTesting(false)
+    } else if item.unwatched {
+      Circle()
+        .fill(Color.glassCardAccent)
+        .frame(width: 10, height: 10)
+        .overlay(Circle().strokeBorder(Color.white.opacity(0.5), lineWidth: 0.5))
+        .padding(8)
+        .frame(width: layout.cardWidth, height: layout.cardHeight, alignment: .topTrailing)
+        .allowsHitTesting(false)
+    }
+  }
+}
+
+struct GlassCardPressStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .scaleEffect(configuration.isPressed ? 0.96 : 1)
+      .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+  }
+}
+
+extension Color {
+  /// Matches the app's purple accent (`bg-purple-600`).
+  fileprivate static let glassCardAccent = Color(
+    red: 147 / 255, green: 51 / 255, blue: 234 / 255)
+}
+
+// MARK: - Image loading
+
+/// Header-aware image loader with an in-memory cache. The Jellyfin server can
+/// sit behind an auth proxy (Cloudflare Access, Pangolin, ...), so every
+/// request carries the custom headers passed down from JS.
+final class GlassCardImageLoader {
+  static let shared = GlassCardImageLoader()
+
+  private let cache = NSCache<NSString, UIImage>()
+
+  private init() {
+    cache.totalCostLimit = 64 * 1024 * 1024
+  }
+
+  func cached(_ urlString: String) -> UIImage? {
+    cache.object(forKey: urlString as NSString)
+  }
+
+  func load(_ urlString: String, headers: [String: String]) async -> UIImage? {
+    if let hit = cached(urlString) {
+      return hit
+    }
+    guard let url = URL(string: urlString) else {
+      return nil
+    }
+    var request = URLRequest(url: url)
+    for (key, value) in headers {
+      request.setValue(value, forHTTPHeaderField: key)
+    }
+    guard
+      let (data, response) = try? await URLSession.shared.data(for: request),
+      let http = response as? HTTPURLResponse,
+      (200..<300).contains(http.statusCode),
+      let image = UIImage(data: data)
+    else {
+      return nil
+    }
+    cache.setObject(image, forKey: urlString as NSString, cost: data.count)
+    return image
+  }
+}
+
+struct RemoteCardImage: View {
+  let urlString: String?
+  let headers: [String: String]
+
+  @State private var image: UIImage?
+
+  var body: some View {
+    ZStack {
+      LinearGradient(
+        colors: [Color(white: 0.16), Color(white: 0.10)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+      )
+      if let image {
+        Image(uiImage: image)
+          .resizable()
+          .aspectRatio(contentMode: .fill)
+          .transition(.opacity)
+      }
+    }
+    .task(id: urlString) {
+      guard let urlString else {
+        image = nil
+        return
+      }
+      if let hit = GlassCardImageLoader.shared.cached(urlString) {
+        image = hit
+        return
+      }
+      let loaded = await GlassCardImageLoader.shared.load(urlString, headers: headers)
+      if !Task.isCancelled {
+        withAnimation(.easeIn(duration: 0.2)) {
+          image = loaded
+        }
+      }
+    }
+  }
+}
+
+#endif

--- a/modules/glass-card-row/src/GlassCardGridView.tsx
+++ b/modules/glass-card-row/src/GlassCardGridView.tsx
@@ -1,0 +1,89 @@
+import { requireNativeView, requireOptionalNativeModule } from "expo";
+import * as React from "react";
+import { Platform } from "react-native";
+
+import type { GlassCardGridViewProps } from "./GlassCardRow.types";
+
+type NativeProps = {
+  payload: string;
+  onItemPress?: GlassCardGridViewProps["onItemPress"];
+  onItemLongPress?: GlassCardGridViewProps["onItemLongPress"];
+  onEndReached?: GlassCardGridViewProps["onEndReached"];
+  style?: GlassCardGridViewProps["style"];
+};
+
+// Same availability rules as the row: phones and tablets only, and null when
+// the module isn't in this binary.
+let NativeGlassCardGridView: React.ComponentType<NativeProps> | null = null;
+
+if (!Platform.isTV && requireOptionalNativeModule("GlassCardGrid")) {
+  try {
+    NativeGlassCardGridView = requireNativeView<NativeProps>("GlassCardGrid");
+  } catch {
+    // View manager missing despite the module being registered.
+  }
+}
+
+/**
+ * GlassCardGridView — the whole scrollable grid as a single native view.
+ *
+ * The cards are the same model the row uses; only the container differs. The
+ * grid owns its vertical scrolling, so anything above it (a filter bar) stays
+ * pinned in JS rather than scrolling away with the content.
+ */
+const GlassCardGridView: React.FC<GlassCardGridViewProps> = ({
+  items,
+  imageHeaders,
+  layout,
+  columns,
+  loadingMore,
+  contentInsetTop,
+  contentInsetBottom,
+  scrollToTopToken,
+  onItemPress,
+  onItemLongPress,
+  onEndReached,
+  style,
+}) => {
+  const payload = React.useMemo(
+    () =>
+      JSON.stringify({
+        items,
+        imageHeaders: imageHeaders ?? {},
+        layout: layout ?? {},
+        columns: columns ?? 3,
+        loadingMore: loadingMore ?? false,
+        contentInsetTop: contentInsetTop ?? 0,
+        contentInsetBottom: contentInsetBottom ?? 0,
+        scrollToTopToken: scrollToTopToken ?? null,
+      }),
+    [
+      items,
+      imageHeaders,
+      layout,
+      columns,
+      loadingMore,
+      contentInsetTop,
+      contentInsetBottom,
+      scrollToTopToken,
+    ],
+  );
+
+  if (!NativeGlassCardGridView) {
+    return null;
+  }
+
+  return (
+    <NativeGlassCardGridView
+      payload={payload}
+      onItemPress={onItemPress}
+      onItemLongPress={onItemLongPress}
+      onEndReached={onEndReached}
+      style={style}
+    />
+  );
+};
+
+export const isGlassCardGridAvailable = () => NativeGlassCardGridView != null;
+
+export default GlassCardGridView;

--- a/modules/glass-card-row/src/GlassCardRow.types.ts
+++ b/modules/glass-card-row/src/GlassCardRow.types.ts
@@ -1,0 +1,100 @@
+import type { StyleProp, ViewStyle } from "react-native";
+
+/** One card. Everything is prebuilt in JS — the native view is presentational. */
+export interface GlassCardRowItem {
+  /** Item id, handed back by `onItemPress` / `onItemLongPress`. */
+  id: string;
+  title: string;
+  subtitle?: string | null;
+  imageUrl?: string | null;
+  /** Watch progress in 0...1. Draws the progress bar when > 0. */
+  progress?: number;
+  /** Unwatched movie or episode — draws the accent dot. */
+  unwatched?: boolean;
+  /** Episodes left on a series/box set — draws the count badge when > 0. */
+  unplayedCount?: number;
+  /** Faded back because another card in the row is the current one. */
+  dimmed?: boolean;
+}
+
+/** Card geometry. JS owns it because it also reserves the row height in RN. */
+export interface GlassCardRowLayout {
+  /** Card width in points. Default: 220. */
+  cardWidth?: number;
+  /** width / height of the artwork. Default: 16 / 9. */
+  aspectRatio?: number;
+  /** Default: 14. */
+  cornerRadius?: number;
+  /** Gap between cards. Default: 10. */
+  spacing?: number;
+  /** Leading/trailing inset of the row content. Default: 16. */
+  contentInset?: number;
+  /**
+   * Share of the card the frosted band covers, bottom up. Default: 0.45 — a
+   * tall portrait poster wants less than a landscape still for the same text.
+   */
+  frostFraction?: number;
+  /**
+   * Breathing room above/below the cards so the drop shadow isn't clipped.
+   * Default: `GLASS_CARD_ROW_VERTICAL_PADDING`. Sent rather than hardcoded
+   * natively so JS stays the single source of the row's height.
+   */
+  verticalPadding?: number;
+}
+
+/** The grid takes the same cards and geometry; only the container differs. */
+export interface GlassCardGridViewProps {
+  items: GlassCardRowItem[];
+  imageHeaders?: Record<string, string>;
+  layout?: GlassCardRowLayout;
+  /** Cards per row. Default: 3. */
+  columns?: number;
+  loadingMore?: boolean;
+  /** Room at the top of the scroll content, for safe areas and pinned UI. */
+  contentInsetTop?: number;
+  contentInsetBottom?: number;
+  /** Changing this scrolls back to the top — the list changed underneath. */
+  scrollToTopToken?: string | null;
+  onItemPress?: (event: { nativeEvent: { id: string; index: number } }) => void;
+  onItemLongPress?: (event: {
+    nativeEvent: { id: string; index: number };
+  }) => void;
+  onEndReached?: () => void;
+  style?: StyleProp<ViewStyle>;
+}
+
+export interface GlassCardRowViewProps {
+  items: GlassCardRowItem[];
+  /** Custom proxy auth headers for the image host, if any are configured. */
+  imageHeaders?: Record<string, string>;
+  layout?: GlassCardRowLayout;
+  /** Shows a spinner after the last card while the next page loads. */
+  loadingMore?: boolean;
+  /**
+   * Card to bring into view. Applied when the value changes, so it never
+   * fights the user's own scrolling on unrelated re-renders.
+   */
+  scrollToId?: string | null;
+  onItemPress?: (event: { nativeEvent: { id: string; index: number } }) => void;
+  onItemLongPress?: (event: {
+    nativeEvent: { id: string; index: number };
+  }) => void;
+  /** Fired when the tail of the row scrolls into view. */
+  onEndReached?: () => void;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Vertical padding the native row adds around the cards so their drop shadow
+ * isn't clipped. Mirrors `GlassCardRowMetrics.verticalPadding` in Swift; add it
+ * to the card height when sizing the row.
+ */
+export const GLASS_CARD_ROW_VERTICAL_PADDING = 6;
+
+/** Height the row needs for a given card width and aspect ratio. */
+export function glassCardRowHeight(
+  cardWidth: number,
+  aspectRatio: number,
+): number {
+  return cardWidth / aspectRatio + GLASS_CARD_ROW_VERTICAL_PADDING * 2;
+}

--- a/modules/glass-card-row/src/GlassCardRowView.tsx
+++ b/modules/glass-card-row/src/GlassCardRowView.tsx
@@ -1,0 +1,83 @@
+import { requireNativeView, requireOptionalNativeModule } from "expo";
+import * as React from "react";
+import { Platform } from "react-native";
+
+import type { GlassCardRowViewProps } from "./GlassCardRow.types";
+
+// The native view takes a single JSON string prop carrying the cards, the
+// image headers and the card geometry. Typed object/array props are applied
+// natively with `try? prop.set(...)`, so a conversion failure is swallowed and
+// the view silently renders empty; a string prop has no such failure mode, and
+// the same payload is what a future Android view would parse.
+type NativeProps = {
+  payload: string;
+  onItemPress?: GlassCardRowViewProps["onItemPress"];
+  onItemLongPress?: GlassCardRowViewProps["onItemLongPress"];
+  onEndReached?: GlassCardRowViewProps["onEndReached"];
+  style?: GlassCardRowViewProps["style"];
+};
+
+// Phones and tablets only: the TV home has its own focus-driven rows, and
+// Android has no native implementation, so both keep the JS list.
+//
+// requireOptionalNativeModule returns null instead of throwing when the module
+// isn't in this binary (an older build, or a platform without a native view).
+let NativeGlassCardRowView: React.ComponentType<NativeProps> | null = null;
+
+if (!Platform.isTV && requireOptionalNativeModule("GlassCardRow")) {
+  try {
+    NativeGlassCardRowView = requireNativeView<NativeProps>("GlassCardRow");
+  } catch {
+    // View manager missing despite the module being registered.
+  }
+}
+
+/**
+ * GlassCardRowView — one native horizontally scrolling row of media cards.
+ *
+ * The whole row is a single native view rather than a native card per cell, so
+ * a JS list never has to host dozens of native children. Renders nothing on
+ * platforms without a native implementation; check `isGlassCardRowAvailable()`
+ * and fall back to the JS list there.
+ */
+const GlassCardRowView: React.FC<GlassCardRowViewProps> = ({
+  items,
+  imageHeaders,
+  layout,
+  loadingMore,
+  scrollToId,
+  onItemPress,
+  onItemLongPress,
+  onEndReached,
+  style,
+}) => {
+  const payload = React.useMemo(
+    () =>
+      JSON.stringify({
+        items,
+        imageHeaders: imageHeaders ?? {},
+        layout: layout ?? {},
+        loadingMore: loadingMore ?? false,
+        scrollToId: scrollToId ?? null,
+      }),
+    [items, imageHeaders, layout, loadingMore, scrollToId],
+  );
+
+  if (!NativeGlassCardRowView) {
+    return null;
+  }
+
+  return (
+    <NativeGlassCardRowView
+      payload={payload}
+      onItemPress={onItemPress}
+      onItemLongPress={onItemLongPress}
+      onEndReached={onEndReached}
+      style={style}
+    />
+  );
+};
+
+export const isGlassCardRowAvailable = () => NativeGlassCardRowView != null;
+
+export default GlassCardRowView;

--- a/modules/glass-card-row/src/index.ts
+++ b/modules/glass-card-row/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  default as GlassCardGridView,
+  isGlassCardGridAvailable,
+} from "./GlassCardGridView";
+export * from "./GlassCardRow.types";
+export {
+  default as GlassCardRowView,
+  isGlassCardRowAvailable,
+} from "./GlassCardRowView";

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -9,6 +9,17 @@ export type {
 export { default as BackgroundDownloader } from "./background-downloader";
 // ExoPlayer (Android TV)
 export { ExoPlayerView } from "./exoplayer-player";
+// Glass Card Row (iOS phone/tablet)
+export type {
+  GlassCardRowItem,
+  GlassCardRowLayout,
+  GlassCardRowViewProps,
+} from "./glass-card-row";
+export {
+  GlassCardRowView,
+  glassCardRowHeight,
+  isGlassCardRowAvailable,
+} from "./glass-card-row";
 // Glass Poster (tvOS 26+)
 export type { GlassPosterViewProps } from "./glass-poster";
 export { GlassPosterView, isGlassEffectAvailable } from "./glass-poster";

--- a/translations/en.json
+++ b/translations/en.json
@@ -158,6 +158,8 @@
         "merge_next_up_continue_watching_hint": "Combine Continue Watching and Next Up into a single home row.",
         "use_episode_images_next_up": "Use episode images for Next Up & Continue Watching",
         "use_episode_images_next_up_hint": "Show each episode's own thumbnail in the Next Up and Continue Watching rows instead of the series image.",
+        "native_media_cards": "Native media cards",
+        "native_media_cards_hint": "Draw poster rows and grids with a native view. Turn off to render the same cards in JavaScript.",
         "hide_remote_session_button": "Hide remote session button",
         "hide_remote_session_button_hint": "Hide the remote-sessions button from the home header.",
         "show_home_backdrop": "Dynamic home backdrop",

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -420,6 +420,12 @@ export type Settings = {
   // Use the episode's own image (instead of the series thumb) for the
   // "Next Up" and "Continue Watching" home rows.
   useEpisodeImagesForNextUp: boolean;
+  /**
+   * Draw media card rows and grids with the native view where one exists
+   * (iPhone/iPad today). Off renders the same cards in React Native instead —
+   * the two are meant to look alike, so this is for comparing them.
+   */
+  nativeMediaCards: boolean;
   // TV-specific settings
   /** Apple TV only: use the fully-native tvOS player (default on; needs tvOS 26+). */
   nativeVideoPlayerTV: boolean;
@@ -570,6 +576,7 @@ export const defaultValues: Settings = {
   usePopularPlugin: true,
   mergeNextUpAndContinueWatching: false,
   useEpisodeImagesForNextUp: false,
+  nativeMediaCards: true,
   // TV-specific settings
   nativeVideoPlayerTV: true,
   nativeVideoPlayerAndroidTV: false,

--- a/utils/jellyfin/image/getPortraitImageUrl.ts
+++ b/utils/jellyfin/image/getPortraitImageUrl.ts
@@ -1,0 +1,27 @@
+import type { Api } from "@jellyfin/sdk";
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+import { getPrimaryImageUrl } from "./getPrimaryImageUrl";
+
+/**
+ * Portrait (10:15) poster image for an item, as used by the poster cards.
+ *
+ * An episode has no poster of its own, so it borrows its series' primary
+ * image — that is what a vertical row of episodes is expected to show.
+ */
+export const getPortraitImageUrl = ({
+  api,
+  item,
+  width = 300,
+}: {
+  api?: Api | null;
+  item?: BaseItemDto | null;
+  width?: number;
+}): string | undefined => {
+  if (!api || !item) return undefined;
+
+  if (item.Type === "Episode" && item.SeriesId) {
+    return `${api.basePath}/Items/${item.SeriesId}/Images/Primary?fillHeight=389&quality=80&tag=${item.SeriesPrimaryImageTag}`;
+  }
+
+  return getPrimaryImageUrl({ api, item, width }) ?? undefined;
+};

--- a/utils/jellyfin/image/getWideImageUrl.ts
+++ b/utils/jellyfin/image/getWideImageUrl.ts
@@ -1,0 +1,47 @@
+import type { Api } from "@jellyfin/sdk";
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
+
+/**
+ * Landscape (16:9-ish) image for an item, as used by the continue-watching
+ * cards: the Thumb when the item has one, with a failover to Primary.
+ *
+ * @param useEpisodePoster - Prefer the episode's own still over the series
+ *   Thumb for episodes (the `useEpisodeImagesForNextUp` setting).
+ */
+export const getWideImageUrl = ({
+  api,
+  item,
+  useEpisodePoster = false,
+  fillHeight = 389,
+  quality = 80,
+}: {
+  api?: Api | null;
+  item?: BaseItemDto | null;
+  useEpisodePoster?: boolean;
+  fillHeight?: number;
+  quality?: number;
+}): string | undefined => {
+  if (!api || !item?.Id) return undefined;
+
+  const primary = `${api.basePath}/Items/${item.Id}/Images/Primary?fillHeight=${fillHeight}&quality=${quality}`;
+  const thumb = (itemId: string, tag: string) =>
+    `${api.basePath}/Items/${itemId}/Images/Thumb?fillHeight=${fillHeight}&quality=${quality}&tag=${tag}`;
+
+  if (item.Type === "Episode") {
+    if (useEpisodePoster) return primary;
+
+    // Matched pair: the parent that owns the Thumb (ParentThumbItemId), not the
+    // backdrop owner — otherwise the Thumb tag is requested on the wrong item → black.
+    if (item.ParentThumbItemId && item.ParentThumbImageTag) {
+      return thumb(item.ParentThumbItemId, item.ParentThumbImageTag);
+    }
+
+    return primary;
+  }
+
+  if (item.ImageTags?.Thumb) {
+    return thumb(item.Id, item.ImageTags.Thumb);
+  }
+
+  return primary;
+};


### PR DESCRIPTION
Media card rows and grids are drawn by a native view on iOS phone/tablet, one view per row or grid rather than a poster component per cell. Everywhere else — Android, tvOS, older builds — keeps rendering in JS, from the same card model.

## The card

The artwork fills the card, with the title, subtitle and progress bar over a frosted band that fades in over the bottom. Unwatched items get an accent dot; a series with episodes left gets its count.

## How it is split

The native side is purely presentational. JS builds the image URLs, labels, progress and badges, hands them over as **one JSON string payload**, and gets item ids back for navigation and the long-press sheet. Fetching, paging, auth headers, translations and every routing decision stay in JS.

Two consequences worth calling out:

- A Compose view registered under the same module name (`GlassCardRow` / `GlassCardGrid`) would light up with **no JS changes** — call sites branch on `isGlassCardRowAvailable()`, never on `Platform.OS`. Styling is each implementation's business; only the geometry fields need honouring, because JS reserves the matching height.
- One JSON string rather than typed props is deliberate: expo-modules-core applies view props with `try? prop.set(...)`, so a failed conversion is swallowed and the view renders empty with no error anywhere.

## Consolidation

Each section used to repeat a heading, a skeleton, an empty state and a switch over item types choosing between `ContinueWatchingPoster` / `MoviePoster` / `SeriesPoster` / `Poster` plus `ItemCardText`. All of that is now one component:

```tsx
<CardRow title={t("home.continue_watching")} items={items} kind="wide" />
<CardRow title={t("item_card.cast_and_crew")} cards={personCards} kind="portrait" onPressId={openPerson} />
```

`components/cards/` holds the card model and geometry table (`CardData.ts`), the two containers (`CardRow`, `CardGrid`), the behaviour they share (`useItemCardBehavior`), and the JS fallback cards (`JsCardRow`).

Three helpers were extracted so both renderers can't drift: `getWideImageUrl`, `getPortraitImageUrl`, and `getItemProgressPercentage`. The long-press action sheet moved out of `TouchableItemRouter` into `useItemActionSheet`, which that component now uses too.

## Converted

Home rows, Live TV rows, search results (movies, series, episodes, collections, actors), the item page (series, cast & crew, similar items, episode carousel), series next-up, Streamystats recommendations and promoted watchlists, the library grid and the favourites see-all grid.

## Left on the JS path, deliberately

- **Collections and watchlist grids** — the native grid owns its scrolling, so their content headers (collection artwork, watchlist description) would become permanently pinned. That's fine for the library's filter bar, not for these.
- **`MediaListSection`** — paginates through `InfiniteHorizontalScroll`; converting means lifting that query into the component first.
- **`SeasonPicker`, the player's episode list, music rows** — thumbnail-beside-text and round-artist shapes, neither a row nor a grid.

## Testing

Verified on an iPhone 17 simulator (iOS 26.5): taps navigate, long press opens the played/favourite sheet, rows scroll independently inside the page scroll, paging fires at the tail of both rows and grids, the episode carousel dims the non-current episodes and auto-scrolls to the current one, and the library grid keeps its filter bar pinned while paging deep into the library.

Not verified: Live TV rows (needs a tuner), and the JS fallback on a real Android device — though it was exercised accidentally and behaved correctly when the app ran without the native module present.

typecheck, lint and format are clean.

https://claude.ai/code/session_01Rx1AbBTseLM5E8HPmv6aJD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native glass-card rows and grids with loading states, pagination, scrolling, badges, progress indicators, and item actions.
  - Favorites and library views now support responsive, safe-area-aware card grids.
  - Standardized search, media, recommendations, cast, episodes, and watchlists with reusable card layouts.
  - Added platform-compatible fallbacks when native cards are unavailable.
  - Added an iOS appearance setting to enable or disable native media cards.
  - Improved portrait, wide, and episode artwork handling.

- **Bug Fixes**
  - Improved action-sheet behavior and watched-content progress calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->