### PR TITLE
feat(home): Jetpack Compose hero carousel on Android

### DIFF
--- a/components/settings/AppearanceSettings.tsx
+++ b/components/settings/AppearanceSettings.tsx
@@ -5,6 +5,7 @@ import { Linking, Platform } from "react-native";
 import { SettingSwitch } from "@/components/common/SettingSwitch";
 import DisabledSetting from "@/components/settings/DisabledSetting";
 import useRouter from "@/hooks/useAppRouter";
+import { isHeroCarouselAvailable } from "@/modules";
 import { useSettings } from "@/utils/atoms/settings";
 import { ListGroup } from "../list/ListGroup";
 import { ListItem } from "../list/ListItem";
@@ -44,7 +45,10 @@ export const AppearanceSettings: React.FC = () => {
             }
           />
         </ListItem>
-        {Platform.OS === "ios" && (
+        {/* The switch tracks the native view rather than a platform: it is
+            the only way back once the carousel's own menu turns it off, so it
+            has to be offered wherever the carousel can render. */}
+        {isHeroCarouselAvailable() && (
           <ListItem
             title={t("home.settings.appearance.show_hero_carousel")}
             subtitle={t("home.settings.appearance.show_hero_carousel_hint")}

--- a/modules/hero-carousel/android/build.gradle
+++ b/modules/hero-carousel/android/build.gradle
@@ -1,0 +1,67 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:${rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : '2.1.20'}")
+  }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+
+group = 'expo.modules.herocarousel'
+version = '1.0.0'
+
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+apply from: expoModulesCorePlugin
+applyKotlinExpoModulesCorePlugin()
+useCoreDependencies()
+useExpoPublishing()
+
+// If you want to use the managed Android SDK versions from expo-modules-core, set this to true.
+def useManagedAndroidSdkVersions = false
+if (useManagedAndroidSdkVersions) {
+  useDefaultAndroidSdkVersions()
+} else {
+  buildscript {
+    ext.safeExtGet = { prop, fallback ->
+      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+  }
+  project.android {
+    compileSdkVersion safeExtGet("compileSdkVersion", 36)
+    defaultConfig {
+      minSdkVersion safeExtGet("minSdkVersion", 26)
+      targetSdkVersion safeExtGet("targetSdkVersion", 36)
+    }
+  }
+}
+
+android {
+  namespace "expo.modules.herocarousel"
+  defaultConfig {
+    versionCode 1
+    versionName "1.0.0"
+  }
+  buildFeatures {
+    compose true
+  }
+  lintOptions {
+    abortOnError false
+  }
+}
+
+dependencies {
+  // Jetpack Compose, pinned to the versions @expo/ui resolves so the app
+  // ends up with one Compose runtime rather than two.
+  implementation 'androidx.compose.foundation:foundation-android:1.10.6'
+  implementation 'androidx.compose.ui:ui-android:1.10.6'
+  implementation 'androidx.compose.material3:material3:1.5.0-alpha17'
+  implementation 'androidx.compose.material3:material3-android:1.5.0-alpha17'
+  implementation 'androidx.compose.material:material-icons-core:1.7.8'
+  // Only for the three glyphs core doesn't ship (fast-forward, sparkles,
+  // filter). Already on the app's classpath via modules/mpv-player.
+  implementation 'androidx.compose.material:material-icons-extended:1.7.8'
+  implementation 'androidx.core:core-ktx:1.18.0'
+}

--- a/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselContent.kt
+++ b/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselContent.kt
@@ -1,0 +1,873 @@
+package expo.modules.herocarousel
+
+import android.graphics.Bitmap
+import android.os.Build
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.lerp
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.util.Locale
+import kotlin.math.abs
+
+/**
+ * Jetpack Compose twin of `HeroCarouselView.swift`. Same payload, same
+ * geometry, same card design; the paging mechanics differ where the platform
+ * offers something better (see [HeroPager]).
+ */
+
+private object HeroLayout {
+  /** Horizontal inset of the snapped card. Neighbors peek through it. */
+  val PageMargin = 36.dp
+  val CardSpacing = 12.dp
+  val CardCorner = 28.dp
+  val PanelCorner = 20.dp
+  val CardPadding = 12.dp
+  /** Extra backdrop width on each side, consumed by the parallax pan. */
+  val Parallax = 36.dp
+  /** Vertical space reserved under the cards for the page dots. */
+  val DotsArea = 24.dp
+  val CardElevation = 12.dp
+  val PanelBlur = 24.dp
+}
+
+/**
+ * `Modifier.blur` is a no-op below Android 12, so the glass panel falls back
+ * to a heavier flat tint there instead of drawing an unblurred copy of the
+ * backdrop behind its own text.
+ */
+private val BlurSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+private val PlaceholderBrush = Brush.linearGradient(
+  listOf(Color(0xFF292929), Color(0xFF1A1A1A))
+)
+
+/** Scrim so the glass panel and label stay legible on bright art. */
+private val CardScrimBrush = Brush.verticalGradient(
+  0f to Color.Black.copy(alpha = 0.25f),
+  0.3f to Color.Transparent,
+  0.45f to Color.Transparent,
+  1f to Color.Black.copy(alpha = 0.65f)
+)
+
+private val PanelSheenBrush = Brush.verticalGradient(
+  listOf(Color.White.copy(alpha = 0.10f), Color.White.copy(alpha = 0.04f))
+)
+
+/** iOS `.destructive` red, so both platforms flag the same row the same way. */
+private val DestructiveColor = Color(0xFFFF453A)
+
+private val TextPrimary = Color.White
+private val TextSecondary = Color.White.copy(alpha = 0.9f)
+private val TextTertiary = Color.White.copy(alpha = 0.75f)
+private val HairlineColor = Color.White.copy(alpha = 0.15f)
+
+// MARK: - Root
+
+@Composable
+internal fun HeroCarouselRoot(
+  payload: HeroPayload,
+  onItemPress: (String) -> Unit,
+  onFilterToggle: (String) -> Unit
+) {
+  // The app is dark themed; force a dark scheme so the filter menu renders
+  // dark regardless of the system setting (iOS forces `colorScheme` too).
+  MaterialTheme(colorScheme = HeroColorScheme) {
+    Box(Modifier.fillMaxSize()) {
+      if (payload.items.isEmpty()) {
+        // Loading / no-data placeholder: a faint card skeleton where the
+        // hero will appear.
+        HeroSkeleton()
+      } else {
+        HeroPager(
+          items = payload.items,
+          headers = payload.imageHeaders,
+          onItemPress = onItemPress
+        )
+      }
+
+      // Overlaid here rather than inside a card for two reasons: neighbour
+      // cards peek in at the edges, so a per-card button would show a second
+      // half-clipped copy in the slivers; and filtering down to zero items
+      // must not strand the user without a way to undo it, so the button has
+      // to outlive the carousel and sit over the empty-state skeleton too.
+      if (payload.filterSections.isNotEmpty()) {
+        HeroFilterMenu(
+          sections = payload.filterSections,
+          label = payload.filterLabel,
+          onToggle = onFilterToggle,
+          modifier = Modifier
+            .align(Alignment.TopEnd)
+            .padding(top = 12.dp, end = HeroLayout.PageMargin + 12.dp)
+        )
+      }
+    }
+  }
+}
+
+private val HeroColorScheme = darkColorScheme(
+  surface = Color(0xFF1C1C1E),
+  surfaceContainer = Color(0xFF1C1C1E),
+  onSurface = Color.White,
+  onSurfaceVariant = Color.White.copy(alpha = 0.7f)
+)
+
+// MARK: - Pager
+
+/**
+ * Wrap-around paging without the sentinel-clone dance the SwiftUI side needs:
+ * a pager over `Int.MAX_VALUE` pages that indexes items modulo their count
+ * starts in the middle and can be swiped either way forever, so there is no
+ * teleport to hide and no scroll-idle phase to wait for.
+ */
+@Composable
+private fun HeroPager(
+  items: List<HeroItem>,
+  headers: Map<String, String>,
+  onItemPress: (String) -> Unit
+) {
+  val count = items.size
+  val pagerState = rememberPagerState(initialPage = infiniteStartPage(count)) {
+    if (count > 1) Int.MAX_VALUE else count
+  }
+  // Data changed under us (e.g. pull-to-refresh dropped a slide): the page
+  // index means a different item now, so go back to the start. Same count is
+  // left alone — a refresh that returns the same slides keeps the position.
+  LaunchedEffect(count) { pagerState.scrollToPage(infiniteStartPage(count)) }
+
+  val scope = rememberCoroutineScope()
+  var scrollJob by remember { mutableStateOf<Job?>(null) }
+
+  Column(Modifier.fillMaxSize()) {
+    HorizontalPager(
+      state = pagerState,
+      modifier = Modifier
+        .fillMaxWidth()
+        .weight(1f),
+      // Insets the pages so the snapped card sits centered with a neighbor
+      // sliver on each side, matching iOS `contentMargins`.
+      contentPadding = PaddingValues(horizontal = HeroLayout.PageMargin),
+      pageSpacing = HeroLayout.CardSpacing,
+      beyondViewportPageCount = 1,
+      key = { page -> page }
+    ) { page ->
+      val item = items[Math.floorMod(page, count)]
+      BoxWithConstraints(Modifier.fillMaxSize()) {
+        HeroCard(
+          item = item,
+          headers = headers,
+          cardWidth = maxWidth,
+          cardHeight = maxHeight,
+          // A lambda, not a value: read inside the draw phase so a swipe
+          // re-runs the layer instead of recomposing three cards per frame.
+          pageOffset = { pagerState.offsetForPage(page) },
+          onPress = { onItemPress(item.id) }
+        )
+      }
+    }
+
+    if (count > 1) {
+      val activeIndex = Math.floorMod(pagerState.currentPage, count)
+      HeroPageDots(
+        count = count,
+        activeIndex = activeIndex,
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(HeroLayout.DotsArea)
+      ) { index ->
+        // Scrubbing fires selections faster than a page animation settles;
+        // the previous fly-through is dropped rather than queued.
+        scrollJob?.cancel()
+        scrollJob = scope.launch {
+          pagerState.animateScrollToPage(nearestPage(pagerState.currentPage, index, count))
+        }
+      }
+    }
+  }
+}
+
+private fun infiniteStartPage(count: Int): Int =
+  if (count > 1) (Int.MAX_VALUE / 2) - (Int.MAX_VALUE / 2) % count else 0
+
+/** The page carrying [index] that is fewest swipes away in either direction. */
+private fun nearestPage(currentPage: Int, index: Int, count: Int): Int {
+  val forward = Math.floorMod(index - Math.floorMod(currentPage, count), count)
+  val delta = if (forward > count / 2) forward - count else forward
+  return currentPage + delta
+}
+
+/**
+ * How far [page] sits from the settled position, in pages: 0 when snapped,
+ * +1 one page to the right, -1 one page to the left. Matches the sign of
+ * SwiftUI's `ScrollTransitionPhase.value` so both platforms pan the backdrop
+ * the same way.
+ */
+private fun PagerState.offsetForPage(page: Int): Float =
+  ((currentPage - page) + currentPageOffsetFraction) * -1f
+
+// MARK: - Card
+
+@Composable
+private fun HeroCard(
+  item: HeroItem,
+  headers: Map<String, String>,
+  cardWidth: Dp,
+  cardHeight: Dp,
+  pageOffset: () -> Float,
+  onPress: () -> Unit
+) {
+  val shape = RoundedCornerShape(HeroLayout.CardCorner)
+  val interactionSource = remember { MutableInteractionSource() }
+  val pressed by interactionSource.collectIsPressedAsState()
+  val pressScale = animateFloatAsState(
+    targetValue = if (pressed) 0.97f else 1f,
+    animationSpec = spring(dampingRatio = 0.7f, stiffness = 400f),
+    label = "heroCardPress"
+  )
+  val parallaxPx = with(LocalDensity.current) { HeroLayout.Parallax.toPx() }
+  val backdrop = rememberHeroImage(item.backdropUrl, headers)
+
+  Box(
+    Modifier
+      .fillMaxSize()
+      .graphicsLayer {
+        val offset = pageOffset().coerceIn(-1f, 1f)
+        val scale = lerp(0.95f, 1f, 1f - abs(offset)) * pressScale.value
+        scaleX = scale
+        scaleY = scale
+      }
+      .shadow(HeroLayout.CardElevation, shape, clip = false)
+      .clip(shape)
+      .border(1.dp, Color.White.copy(alpha = 0.12f), shape)
+      .clickable(
+        interactionSource = interactionSource,
+        indication = null,
+        onClick = onPress
+      )
+  ) {
+    HeroBackdrop(
+      image = backdrop,
+      cardWidth = cardWidth,
+      cardHeight = cardHeight,
+      parallaxPx = parallaxPx,
+      pageOffset = pageOffset
+    )
+    Box(Modifier.matchParentSize().background(CardScrimBrush))
+
+    Column(Modifier.fillMaxSize().padding(HeroLayout.CardPadding)) {
+      val label = item.label
+      if (!label.isNullOrEmpty()) {
+        HeroLabelChip(label, item.labelIcon)
+      }
+      Spacer(Modifier.weight(1f))
+      HeroInfoPanel(
+        item = item,
+        headers = headers,
+        backdrop = backdrop,
+        cardWidth = cardWidth,
+        cardHeight = cardHeight,
+        parallaxPx = parallaxPx,
+        pageOffset = pageOffset
+      )
+    }
+  }
+}
+
+/**
+ * The card art, drawn wider than the card so the parallax pan never exposes
+ * an edge. Also used — offset and blurred — as the material behind the info
+ * panel, which is why it takes the card's geometry rather than filling its
+ * parent.
+ */
+@Composable
+private fun HeroBackdrop(
+  image: ImageBitmap?,
+  cardWidth: Dp,
+  cardHeight: Dp,
+  parallaxPx: Float,
+  pageOffset: () -> Float,
+  modifier: Modifier = Modifier
+) {
+  val fade = animateFloatAsState(
+    targetValue = if (image != null) 1f else 0f,
+    animationSpec = tween(durationMillis = 250),
+    label = "heroBackdropFade"
+  )
+  Box(
+    modifier
+      .requiredSize(cardWidth, cardHeight)
+      .clipToBounds()
+      .background(PlaceholderBrush),
+    contentAlignment = Alignment.Center
+  ) {
+    if (image != null) {
+      Image(
+        bitmap = image,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = Modifier
+          // `requiredWidth`, not `width`: the overflow is the point, and a
+          // plain width would be coerced back to the card's bounds.
+          .requiredWidth(cardWidth + HeroLayout.Parallax * 2)
+          .fillMaxHeight()
+          .graphicsLayer {
+            translationX = pageOffset().coerceIn(-1f, 1f) * parallaxPx
+            alpha = fade.value
+          }
+      )
+    }
+  }
+}
+
+@Composable
+private fun HeroLabelChip(label: String, iconName: String?) {
+  val icon = sfSymbolIcon(iconName)
+  Row(
+    modifier = Modifier
+      .clip(CircleShape)
+      .background(Color.Black.copy(alpha = 0.42f))
+      .border(0.5.dp, HairlineColor, CircleShape)
+      .padding(horizontal = 10.dp, vertical = 6.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(4.dp)
+  ) {
+    if (icon != null) {
+      Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = Color.White.copy(alpha = 0.95f),
+        modifier = Modifier.size(11.dp)
+      )
+    }
+    Text(
+      text = label.uppercase(),
+      color = Color.White.copy(alpha = 0.95f),
+      fontSize = 10.sp,
+      fontWeight = FontWeight.Black,
+      letterSpacing = 0.8.sp,
+      maxLines = 1
+    )
+  }
+}
+
+/**
+ * The SF Symbol names JS sends are the payload's one iOS-shaped field. Rather
+ * than teach JS about two icon sets, the mapping to Material icons lives here.
+ */
+private fun sfSymbolIcon(name: String?): ImageVector? = when (name) {
+  "play.fill" -> Icons.Filled.PlayArrow
+  "forward.fill" -> Icons.Filled.FastForward
+  "sparkles" -> Icons.Filled.AutoAwesome
+  else -> null
+}
+
+// MARK: - Info panel
+
+@Composable
+private fun HeroInfoPanel(
+  item: HeroItem,
+  headers: Map<String, String>,
+  backdrop: ImageBitmap?,
+  cardWidth: Dp,
+  cardHeight: Dp,
+  parallaxPx: Float,
+  pageOffset: () -> Float
+) {
+  val shape = RoundedCornerShape(HeroLayout.PanelCorner)
+  Box(
+    Modifier
+      .fillMaxWidth()
+      .clip(shape)
+      .border(1.dp, Color.White.copy(alpha = 0.1f), shape)
+  ) {
+    if (BlurSupported) {
+      // SwiftUI's `.ultraThinMaterial` samples whatever is behind it; Compose
+      // has no such material, so the panel re-draws the card art blurred.
+      // The wrapper takes the panel's size (`matchParentSize` keeps it out of
+      // the measure pass) and the copy is pinned by the card's bottom-left
+      // corner — 12dp out and 12dp down from the panel's — so the blur lines
+      // up with the art it is standing on, parallax included.
+      Box(Modifier.matchParentSize()) {
+        HeroBackdrop(
+          image = backdrop,
+          cardWidth = cardWidth,
+          cardHeight = cardHeight,
+          parallaxPx = parallaxPx,
+          pageOffset = pageOffset,
+          modifier = Modifier
+            .align(Alignment.BottomStart)
+            .offset(x = -HeroLayout.CardPadding, y = HeroLayout.CardPadding)
+            .blur(HeroLayout.PanelBlur, BlurredEdgeTreatment.Unbounded)
+        )
+      }
+    }
+    Box(
+      Modifier
+        .matchParentSize()
+        .background(Color.Black.copy(alpha = if (BlurSupported) 0.38f else 0.62f))
+    )
+    Box(Modifier.matchParentSize().background(PanelSheenBrush))
+
+    Column(
+      modifier = Modifier.padding(HeroLayout.CardPadding),
+      verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+      ) {
+        if (!item.posterUrl.isNullOrEmpty()) {
+          val poster = rememberHeroImage(item.posterUrl, headers)
+          val posterShape = RoundedCornerShape(10.dp)
+          Box(
+            Modifier
+              .size(62.dp, 93.dp)
+              .clip(posterShape)
+              .background(PlaceholderBrush)
+              .border(0.5.dp, HairlineColor, posterShape)
+          ) {
+            if (poster != null) {
+              Image(
+                bitmap = poster,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+              )
+            }
+          }
+        }
+
+        Column(
+          modifier = Modifier.weight(1f),
+          verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+          HeroLogo(item.logoUrl, headers, item.title)
+
+          val subtitle = item.subtitle
+          if (!subtitle.isNullOrEmpty()) {
+            Text(
+              text = subtitle,
+              color = TextSecondary,
+              fontSize = 12.sp,
+              fontWeight = FontWeight.SemiBold,
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis
+            )
+          }
+
+          if (item.overview.isNotEmpty()) {
+            Text(
+              text = item.overview,
+              color = TextTertiary,
+              fontSize = 12.sp,
+              lineHeight = 16.sp,
+              maxLines = 2,
+              overflow = TextOverflow.Ellipsis
+            )
+          }
+        }
+      }
+
+      // Full panel width so the chips never get squeezed by the poster column.
+      HeroBadges(item)
+
+      val progress = item.progress
+      if (progress != null && progress > 0.01f) {
+        HeroProgressBar(progress)
+      }
+    }
+  }
+}
+
+/**
+ * Shows the title immediately and swaps in the logo artwork once loaded, so
+ * items without a logo image still get a readable heading.
+ */
+@Composable
+private fun HeroLogo(url: String?, headers: Map<String, String>, title: String) {
+  val logo = rememberHeroImage(url, headers)
+  if (logo != null) {
+    Image(
+      bitmap = logo,
+      contentDescription = title,
+      contentScale = ContentScale.Fit,
+      alignment = Alignment.CenterStart,
+      modifier = Modifier
+        .fillMaxWidth()
+        .height(32.dp)
+    )
+  } else {
+    Text(
+      text = title,
+      color = TextPrimary,
+      fontSize = 17.sp,
+      fontWeight = FontWeight.Bold,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis
+    )
+  }
+}
+
+@Composable
+private fun HeroBadges(item: HeroItem) {
+  if (item.communityRating == null && item.badges.isEmpty()) return
+  Row(
+    // Chips render at full size and the rare overflow clips at the panel edge
+    // instead of every chip degrading into "...".
+    modifier = Modifier
+      .fillMaxWidth()
+      .clipToBounds()
+      .wrapContentWidth(Alignment.Start, unbounded = true),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(6.dp)
+  ) {
+    item.communityRating?.let { rating ->
+      HeroBadgeChip {
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(3.dp)
+        ) {
+          Icon(
+            imageVector = Icons.Filled.Star,
+            contentDescription = null,
+            tint = Color(0xFFFFD60A),
+            modifier = Modifier.size(10.dp)
+          )
+          Text(
+            text = String.format(Locale.getDefault(), "%.1f", rating),
+            color = TextSecondary,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1
+          )
+        }
+      }
+    }
+    for (badge in item.badges) {
+      HeroBadgeChip {
+        Text(
+          text = badge,
+          color = TextSecondary,
+          fontSize = 11.sp,
+          fontWeight = FontWeight.SemiBold,
+          maxLines = 1,
+          softWrap = false
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun HeroBadgeChip(content: @Composable () -> Unit) {
+  Box(
+    modifier = Modifier
+      .clip(CircleShape)
+      .background(Color.White.copy(alpha = 0.14f))
+      .padding(horizontal = 8.dp, vertical = 4.dp)
+  ) {
+    content()
+  }
+}
+
+@Composable
+private fun HeroProgressBar(progress: Float) {
+  Box(
+    Modifier
+      .fillMaxWidth()
+      .height(3.dp)
+      .clip(CircleShape)
+      .background(Color.White.copy(alpha = 0.2f))
+  ) {
+    Box(
+      Modifier
+        .fillMaxWidth(progress.coerceIn(0f, 1f))
+        .widthIn(min = 4.dp)
+        .fillMaxHeight()
+        .clip(CircleShape)
+        .background(Color.White.copy(alpha = 0.9f))
+    )
+  }
+}
+
+// MARK: - Page dots
+
+/**
+ * Tappable and scrubbable: touching down jumps to the nearest dot's page,
+ * dragging across the strip flies through the carousel.
+ */
+@Composable
+private fun HeroPageDots(
+  count: Int,
+  activeIndex: Int,
+  modifier: Modifier = Modifier,
+  onSelect: (Int) -> Unit
+) {
+  val haptics = LocalHapticFeedback.current
+  // Read through a holder rather than capturing: keying the gesture detector
+  // on the active index would tear down a scrub in progress every time the
+  // page it selects lands.
+  val currentActiveIndex = rememberUpdatedState(activeIndex)
+
+  Box(modifier, contentAlignment = Alignment.Center) {
+    Row(
+      modifier = Modifier
+        .fillMaxHeight()
+        .padding(horizontal = 12.dp)
+        .pointerInput(count) {
+          awaitEachGesture {
+            var lastIndex = currentActiveIndex.value
+            val step = size.width / count.toFloat()
+
+            fun selectAt(x: Float) {
+              if (step <= 0f) return
+              val index = (x / step).toInt().coerceIn(0, count - 1)
+              if (index != lastIndex) {
+                lastIndex = index
+                haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                onSelect(index)
+              }
+            }
+
+            // Not consumed: the RN scroll view wrapping the hero still wins
+            // vertical pans that start on the dots.
+            val down = awaitFirstDown(requireUnconsumed = false)
+            selectAt(down.position.x)
+            do {
+              val event = awaitPointerEvent()
+              for (change in event.changes) {
+                if (change.pressed) {
+                  selectAt(change.position.x)
+                }
+              }
+            } while (event.changes.any { it.pressed })
+          }
+        },
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterHorizontally)
+    ) {
+      repeat(count) { index ->
+        val active = index == activeIndex
+        val width by animateDpAsState(
+          targetValue = if (active) 18.dp else 6.dp,
+          animationSpec = spring(dampingRatio = 0.8f, stiffness = 350f),
+          label = "heroDotWidth"
+        )
+        val alpha by animateFloatAsState(
+          targetValue = if (active) 0.9f else 0.3f,
+          animationSpec = spring(dampingRatio = 0.8f, stiffness = 350f),
+          label = "heroDotAlpha"
+        )
+        Box(
+          Modifier
+            .width(width)
+            .height(6.dp)
+            .clip(CircleShape)
+            .background(Color.White.copy(alpha = alpha))
+        )
+      }
+    }
+  }
+}
+
+// MARK: - Filter menu
+
+/**
+ * Glass button in the card's top-right corner, mirroring the label chip on
+ * the left. Opens a dropdown whose rows carry a checkmark when enabled, which
+ * is how the SwiftUI `Toggle` rows read on iOS.
+ */
+@Composable
+private fun HeroFilterMenu(
+  sections: List<HeroFilterSection>,
+  label: String,
+  onToggle: (String) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  var expanded by remember { mutableStateOf(false) }
+
+  Box(modifier) {
+    Box(
+      modifier = Modifier
+        .size(32.dp)
+        .clip(CircleShape)
+        .background(Color.Black.copy(alpha = 0.45f))
+        .border(0.5.dp, HairlineColor, CircleShape)
+        .clickable { expanded = true },
+      contentAlignment = Alignment.Center
+    ) {
+      Icon(
+        imageVector = Icons.Filled.FilterList,
+        contentDescription = label.takeIf { it.isNotEmpty() },
+        tint = Color.White.copy(alpha = 0.95f),
+        modifier = Modifier.size(17.dp)
+      )
+    }
+
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+      sections.forEachIndexed { sectionIndex, section ->
+        if (sectionIndex > 0) {
+          HorizontalDivider(color = Color.White.copy(alpha = 0.12f))
+        }
+        val title = section.title
+        if (!title.isNullOrEmpty()) {
+          Text(
+            text = title,
+            color = Color.White.copy(alpha = 0.6f),
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+          )
+        }
+        for (option in section.options) {
+          DropdownMenuItem(
+            text = {
+              Text(
+                text = option.label,
+                color = if (option.destructive) DestructiveColor else Color.White
+              )
+            },
+            trailingIcon = {
+              // A destructive row is a one-way action, not a filter: it is
+              // only ever reachable while the thing it turns off is on, so a
+              // checkmark would say nothing.
+              if (!option.destructive && option.enabled) {
+                Icon(
+                  imageVector = Icons.Filled.Check,
+                  contentDescription = null,
+                  tint = Color.White
+                )
+              }
+            },
+            onClick = {
+              expanded = false
+              // The caller owns the state; this only reports the intent.
+              onToggle(option.key)
+            }
+          )
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Skeleton
+
+@Composable
+private fun HeroSkeleton() {
+  val shape = RoundedCornerShape(HeroLayout.CardCorner)
+  Column(Modifier.fillMaxSize()) {
+    Box(
+      Modifier
+        .fillMaxWidth()
+        .weight(1f)
+        .padding(horizontal = HeroLayout.PageMargin)
+        .clip(shape)
+        .background(Color.White.copy(alpha = 0.06f))
+        .border(1.dp, Color.White.copy(alpha = 0.08f), shape)
+    )
+    Spacer(Modifier.height(HeroLayout.DotsArea))
+  }
+}
+
+// MARK: - Images
+
+/**
+ * Resolves [url] to a bitmap, serving the cache synchronously so a card that
+ * pages back into view doesn't fade in again.
+ */
+@Composable
+private fun rememberHeroImage(url: String?, headers: Map<String, String>): ImageBitmap? {
+  var bitmap by remember(url) {
+    mutableStateOf(url?.takeIf { it.isNotEmpty() }?.let(HeroImageLoader::cached))
+  }
+  LaunchedEffect(url, headers) {
+    if (bitmap == null && !url.isNullOrEmpty()) {
+      bitmap = HeroImageLoader.load(url, headers)
+    }
+  }
+  return rememberImageBitmap(bitmap)
+}
+
+@Composable
+private fun rememberImageBitmap(bitmap: Bitmap?): ImageBitmap? =
+  remember(bitmap) { bitmap?.asImageBitmap() }

--- a/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselModule.kt
+++ b/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselModule.kt
@@ -18,6 +18,12 @@ class HeroCarouselModule : Module() {
       Prop("payload") { view: HeroCarouselExpoView, payload: String ->
         view.setPayload(payload)
       }
+
+      // The composition is pinned to the Activity so a tab switch can't kill
+      // it, which means nothing else would ever tear it down.
+      OnViewDestroys { view: HeroCarouselExpoView ->
+        view.dispose()
+      }
     }
   }
 }

--- a/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselModule.kt
+++ b/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselModule.kt
@@ -1,0 +1,23 @@
+package expo.modules.herocarousel
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class HeroCarouselModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("HeroCarousel")
+
+    View(HeroCarouselExpoView::class) {
+      Events("onItemPress", "onFilterToggle")
+
+      // Everything the view renders arrives as one JSON string: the slides,
+      // the image auth headers and the filter menu. The string prop exists
+      // for iOS's sake (typed props are applied there with `try? prop.set`,
+      // which swallows a failed conversion), and it is the reason this view
+      // could be added under the same name with no JS changes at all.
+      Prop("payload") { view: HeroCarouselExpoView, payload: String ->
+        view.setPayload(payload)
+      }
+    }
+  }
+}

--- a/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselView.kt
+++ b/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselView.kt
@@ -4,35 +4,39 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.view.MotionEvent
 import android.view.ViewConfiguration
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
-import expo.modules.kotlin.views.ComposableScope
-import expo.modules.kotlin.views.ComposeProps
-import expo.modules.kotlin.views.ExpoComposeView
+import expo.modules.kotlin.views.ExpoView
 import kotlin.math.abs
-
-class HeroCarouselProps(
-  val payload: MutableState<HeroPayload> = mutableStateOf(HeroPayload.EMPTY)
-) : ComposeProps
 
 /**
  * Android half of the `HeroCarousel` view, hosting the Compose carousel in
  * the React Native view tree.
  *
- * `withHostingView = true` is what makes this a Compose root rather than a
- * child of an `@expo/ui` `<Host>`: expo-modules-core then adds the
- * `ComposeView` itself and pins its composition to the Activity lifecycle,
- * which is what keeps the carousel from going blank when react-native-screens
- * detaches the home tab on a tab switch.
+ * Deliberately a plain [ExpoView] with its own [ComposeView] rather than
+ * expo-modules-core's `ExpoComposeView`: registering one of those goes
+ * through `toPropsParsingStrategy`, whose `isIntrospectable` /
+ * `introspectionOf` calls are Pika compiler-plugin intrinsics. That plugin is
+ * not applied to modules built inside this app — `@expo/ui` gets away with it
+ * because it ships as a prebuilt AAR — so the reified marker survives into the
+ * bytecode and the module throws `UnsupportedOperationException: This function
+ * has a reified type parameter...` the moment it is registered, taking the
+ * whole app down at startup. Hosting Compose by hand costs the lifecycle
+ * wiring below and nothing else; the props machinery was unused anyway, since
+ * everything arrives as one JSON string.
  */
 @SuppressLint("ViewConstructor")
 class HeroCarouselExpoView(context: Context, appContext: AppContext) :
-  ExpoComposeView<HeroCarouselProps>(context, appContext, withHostingView = true) {
+  ExpoView(context, appContext) {
 
-  override val props = HeroCarouselProps()
+  private val payload = mutableStateOf(HeroPayload.EMPTY)
 
   private val onItemPress by EventDispatcher()
   private val onFilterToggle by EventDispatcher()
@@ -41,24 +45,68 @@ class HeroCarouselExpoView(context: Context, appContext: AppContext) :
   private var downX = 0f
   private var downY = 0f
 
-  @Composable
-  override fun ComposableScope.Content() {
-    HeroCarouselRoot(
-      payload = props.payload.value,
-      onItemPress = { id -> onItemPress(mapOf("id" to id)) },
-      onFilterToggle = { key -> onFilterToggle(mapOf("key" to key)) }
-    )
+  private val composeView = ComposeView(context).also { view ->
+    view.id = generateViewId()
+    view.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+    // Pin the composition to the Activity, not to this view's tree owner.
+    // react-native-screens destroys the screen fragment's lifecycle on every
+    // tab switch, and Compose self-disposes on its ON_DESTROY — leaving a
+    // dead composition that never recreates, i.e. a blank hero after the
+    // first switch away from Home. Overriding the owners on the ComposeView
+    // (nearest tag wins) points both at the Activity instead.
+    val activity = appContext.currentActivity
+    if (activity is LifecycleOwner && activity is SavedStateRegistryOwner) {
+      view.setViewTreeLifecycleOwner(activity)
+      view.setViewTreeSavedStateRegistryOwner(activity)
+      view.setViewCompositionStrategy(
+        ViewCompositionStrategy.DisposeOnLifecycleDestroyed(activity.lifecycle)
+      )
+    } else {
+      view.setViewCompositionStrategy(
+        ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+      )
+    }
+    view.setContent {
+      HeroCarouselRoot(
+        payload = payload.value,
+        onItemPress = { id -> onItemPress(mapOf("id" to id)) },
+        onFilterToggle = { key -> onFilterToggle(mapOf("key" to key)) }
+      )
+    }
+  }
+
+  // React Native does not re-layout a native view when it calls
+  // `requestLayout` itself, which Compose does whenever its content resizes.
+  override val shouldUseAndroidLayout = true
+
+  init {
+    // Card shadows and the scaled neighbour cards draw outside our bounds.
+    clipChildren = false
+    clipToPadding = false
+    addView(composeView)
   }
 
   /**
    * A failed parse leaves the previous payload in place rather than blanking
    * the carousel, matching `setPayload` on iOS.
    */
-  fun setPayload(payload: String) {
-    val parsed = HeroPayload.parse(payload) ?: return
-    if (parsed != props.payload.value) {
-      props.payload.value = parsed
+  fun setPayload(json: String) {
+    val parsed = HeroPayload.parse(json) ?: return
+    if (parsed != payload.value) {
+      payload.value = parsed
     }
+  }
+
+  /**
+   * The composition outlives window detachment on purpose (see above), so it
+   * has to be torn down explicitly when React Native drops the view —
+   * otherwise the Activity's lifecycle observer keeps this view alive.
+   */
+  fun dispose() {
+    composeView.setViewCompositionStrategy(
+      ViewCompositionStrategy.DisposeOnDetachedFromWindow
+    )
+    composeView.disposeComposition()
   }
 
   /**

--- a/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselView.kt
+++ b/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselView.kt
@@ -1,0 +1,91 @@
+package expo.modules.herocarousel
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.MotionEvent
+import android.view.ViewConfiguration
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeProps
+import expo.modules.kotlin.views.ExpoComposeView
+import kotlin.math.abs
+
+class HeroCarouselProps(
+  val payload: MutableState<HeroPayload> = mutableStateOf(HeroPayload.EMPTY)
+) : ComposeProps
+
+/**
+ * Android half of the `HeroCarousel` view, hosting the Compose carousel in
+ * the React Native view tree.
+ *
+ * `withHostingView = true` is what makes this a Compose root rather than a
+ * child of an `@expo/ui` `<Host>`: expo-modules-core then adds the
+ * `ComposeView` itself and pins its composition to the Activity lifecycle,
+ * which is what keeps the carousel from going blank when react-native-screens
+ * detaches the home tab on a tab switch.
+ */
+@SuppressLint("ViewConstructor")
+class HeroCarouselExpoView(context: Context, appContext: AppContext) :
+  ExpoComposeView<HeroCarouselProps>(context, appContext, withHostingView = true) {
+
+  override val props = HeroCarouselProps()
+
+  private val onItemPress by EventDispatcher()
+  private val onFilterToggle by EventDispatcher()
+
+  private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
+  private var downX = 0f
+  private var downY = 0f
+
+  @Composable
+  override fun ComposableScope.Content() {
+    HeroCarouselRoot(
+      payload = props.payload.value,
+      onItemPress = { id -> onItemPress(mapOf("id" to id)) },
+      onFilterToggle = { key -> onFilterToggle(mapOf("key" to key)) }
+    )
+  }
+
+  /**
+   * A failed parse leaves the previous payload in place rather than blanking
+   * the carousel, matching `setPayload` on iOS.
+   */
+  fun setPayload(payload: String) {
+    val parsed = HeroPayload.parse(payload) ?: return
+    if (parsed != props.payload.value) {
+      props.payload.value = parsed
+    }
+  }
+
+  /**
+   * The hero lives inside React Native's vertical ScrollView, which claims a
+   * gesture as soon as it crosses the slop vertically — a diagonal swipe can
+   * therefore be stolen mid-page. Claiming the gesture the moment it reads as
+   * horizontal keeps paging intact while leaving vertical scrolling alone.
+   * Same idea as ViewPager2's `NestedScrollableHost`.
+   *
+   * The disallow flag is cleared by the framework on the next ACTION_DOWN, so
+   * there is nothing to undo here.
+   */
+  override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+    when (ev.actionMasked) {
+      MotionEvent.ACTION_DOWN -> {
+        downX = ev.x
+        downY = ev.y
+      }
+
+      MotionEvent.ACTION_MOVE -> {
+        val dx = abs(ev.x - downX)
+        val dy = abs(ev.y - downY)
+        if (dx > touchSlop && dx > dy) {
+          parent?.requestDisallowInterceptTouchEvent(true)
+        }
+      }
+    }
+    return super.onInterceptTouchEvent(ev)
+  }
+}

--- a/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroImageLoader.kt
+++ b/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroImageLoader.kt
@@ -1,0 +1,85 @@
+package expo.modules.herocarousel
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.LruCache
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Header-aware image loader with an in-memory cache, mirroring
+ * `HeroImageLoader` on iOS. The Jellyfin server can sit behind an auth proxy
+ * (Cloudflare Access, Pangolin, ...), so every request carries the custom
+ * headers passed down from JS.
+ *
+ * Fetches run on a process-wide scope with a per-URL inflight latch rather
+ * than in the caller's coroutine: paging swaps cards in and out constantly,
+ * and a card that scrolls away mid-download should hand its work to the next
+ * one that asks instead of cancelling it and starting over.
+ */
+internal object HeroImageLoader {
+  // Backdrops decode to a few MB each and ten of them stay reachable while
+  // the carousel is on screen.
+  private const val MAX_CACHE_BYTES = 48 * 1024 * 1024
+
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+  private val cache = object : LruCache<String, Bitmap>(MAX_CACHE_BYTES) {
+    override fun sizeOf(key: String, value: Bitmap): Int = value.byteCount
+  }
+
+  private val inflight = ConcurrentHashMap<String, Deferred<Bitmap?>>()
+
+  fun cached(url: String): Bitmap? = cache.get(url)
+
+  suspend fun load(url: String, headers: Map<String, String>): Bitmap? {
+    cache.get(url)?.let { return it }
+
+    val deferred = inflight[url] ?: run {
+      val fetch = scope.async(start = CoroutineStart.LAZY) { fetch(url, headers) }
+      // Another caller may have registered between the read and the write;
+      // whoever lands first owns the fetch and the loser is never started.
+      val existing = inflight.putIfAbsent(url, fetch)
+      if (existing != null) {
+        fetch.cancel()
+        existing
+      } else {
+        fetch.start()
+        fetch
+      }
+    }
+    return deferred.await()
+  }
+
+  private fun fetch(url: String, headers: Map<String, String>): Bitmap? {
+    return try {
+      val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+        connectTimeout = 10_000
+        readTimeout = 20_000
+        for ((name, value) in headers) {
+          setRequestProperty(name, value)
+        }
+      }
+      try {
+        if (connection.responseCode !in 200..299) {
+          return null
+        }
+        connection.inputStream.use { BitmapFactory.decodeStream(it) }
+          ?.also { cache.put(url, it) }
+      } finally {
+        connection.disconnect()
+      }
+    } catch (_: Exception) {
+      null
+    } finally {
+      inflight.remove(url)
+    }
+  }
+}

--- a/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroPayload.kt
+++ b/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroPayload.kt
@@ -1,0 +1,145 @@
+package expo.modules.herocarousel
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Plain values the Compose layer renders, decoded from the `payload` prop.
+ * Mirrors `HeroCarouselExpoView.swift` on iOS — both sides parse the same
+ * JSON the JS view builds, so neither platform needs its own JS path.
+ */
+data class HeroItem(
+  val id: String,
+  val title: String,
+  val subtitle: String?,
+  val overview: String,
+  val label: String?,
+  /** SF Symbol name; resolved to a Material icon in `HeroCarouselContent`. */
+  val labelIcon: String?,
+  val backdropUrl: String?,
+  val logoUrl: String?,
+  val posterUrl: String?,
+  val badges: List<String>,
+  val communityRating: Double?,
+  /** Watch progress in 0..1; renders a progress bar when > 0. */
+  val progress: Float?
+)
+
+/** One row of the filter menu. Labels arrive pre-localized. */
+data class HeroFilterOption(
+  val key: String,
+  val label: String,
+  val enabled: Boolean,
+  /** Red one-way action rather than a checkmark toggle. */
+  val destructive: Boolean
+)
+
+/** A group of filter rows. An absent title renders as a plain divider. */
+data class HeroFilterSection(
+  val key: String,
+  val title: String?,
+  val options: List<HeroFilterOption>
+)
+
+/** Wire format of the `payload` prop. */
+data class HeroPayload(
+  val items: List<HeroItem> = emptyList(),
+  val imageHeaders: Map<String, String> = emptyMap(),
+  val filterSections: List<HeroFilterSection> = emptyList(),
+  val filterLabel: String = ""
+) {
+  companion object {
+    val EMPTY = HeroPayload()
+
+    /** Returns null when the payload can't be read, so the view keeps what it has. */
+    fun parse(json: String): HeroPayload? {
+      return try {
+        val root = JSONObject(json)
+        HeroPayload(
+          items = root.optJSONArray("items").mapObjects { it.toHeroItem() }.filterNotNull(),
+          imageHeaders = root.optJSONObject("imageHeaders").toStringMap(),
+          filterSections = root.optJSONArray("filterSections")
+            .mapObjects { it.toFilterSection() }
+            .filterNotNull(),
+          filterLabel = root.stringOrNull("filterLabel").orEmpty()
+        )
+      } catch (_: Exception) {
+        null
+      }
+    }
+  }
+}
+
+private fun JSONObject.toHeroItem(): HeroItem? {
+  val id = stringOrNull("id") ?: return null
+  return HeroItem(
+    id = id,
+    title = stringOrNull("title").orEmpty(),
+    subtitle = stringOrNull("subtitle"),
+    overview = stringOrNull("overview").orEmpty(),
+    label = stringOrNull("label"),
+    labelIcon = stringOrNull("labelIcon"),
+    backdropUrl = stringOrNull("backdropUrl"),
+    logoUrl = stringOrNull("logoUrl"),
+    posterUrl = stringOrNull("posterUrl"),
+    badges = optJSONArray("badges").mapStrings(),
+    communityRating = doubleOrNull("communityRating"),
+    progress = doubleOrNull("progress")?.toFloat()?.coerceIn(0f, 1f)
+  )
+}
+
+private fun JSONObject.toFilterSection(): HeroFilterSection? {
+  val key = stringOrNull("key") ?: return null
+  return HeroFilterSection(
+    key = key,
+    title = stringOrNull("title"),
+    options = optJSONArray("options").mapObjects { it.toFilterOption() }.filterNotNull()
+  )
+}
+
+private fun JSONObject.toFilterOption(): HeroFilterOption? {
+  val key = stringOrNull("key") ?: return null
+  return HeroFilterOption(
+    key = key,
+    label = stringOrNull("label").orEmpty(),
+    enabled = optBoolean("enabled", false),
+    destructive = optBoolean("destructive", false)
+  )
+}
+
+/**
+ * `optString` resolves an explicit JSON null to the literal string "null", so
+ * every read goes through `isNull` first — the payload leans on nullable
+ * fields (`subtitle`, `logoUrl`, ...) and a "null" title would render as one.
+ */
+private fun JSONObject.stringOrNull(key: String): String? =
+  if (isNull(key)) null else optString(key).takeIf { it.isNotEmpty() }
+
+private fun JSONObject.doubleOrNull(key: String): Double? =
+  if (isNull(key)) null else optDouble(key).takeIf { !it.isNaN() }
+
+private fun <T> JSONArray?.mapObjects(transform: (JSONObject) -> T?): List<T?> {
+  val array = this ?: return emptyList()
+  return (0 until array.length()).mapNotNull { index ->
+    array.optJSONObject(index)?.let(transform)
+  }
+}
+
+private fun JSONArray?.mapStrings(): List<String> {
+  val array = this ?: return emptyList()
+  return (0 until array.length()).mapNotNull { index ->
+    if (array.isNull(index)) null else array.optString(index).takeIf { it.isNotEmpty() }
+  }
+}
+
+private fun JSONObject?.toStringMap(): Map<String, String> {
+  val json = this ?: return emptyMap()
+  val result = mutableMapOf<String, String>()
+  val keys = json.keys()
+  while (keys.hasNext()) {
+    val key = keys.next()
+    if (json.isNull(key)) continue
+    result[key] = json.optString(key)
+  }
+  return result
+}

--- a/modules/hero-carousel/expo-module.config.json
+++ b/modules/hero-carousel/expo-module.config.json
@@ -1,6 +1,10 @@
 {
-  "platforms": ["apple"],
+  "platforms": ["apple", "android"],
+  "coreFeatures": ["compose"],
   "apple": {
     "modules": ["HeroCarouselModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.herocarousel.HeroCarouselModule"]
   }
 }

--- a/modules/hero-carousel/expo-module.config.json
+++ b/modules/hero-carousel/expo-module.config.json
@@ -1,6 +1,5 @@
 {
   "platforms": ["apple", "android"],
-  "coreFeatures": ["compose"],
   "apple": {
     "modules": ["HeroCarouselModule"]
   },

--- a/modules/hero-carousel/index.ts
+++ b/modules/hero-carousel/index.ts
@@ -1,4 +1,4 @@
-// Hero Carousel - Native SwiftUI paged hero for the iOS home tab
+// Hero Carousel - Native paged hero for the home tab (SwiftUI + Compose)
 
 export * from "./src/HeroCarousel.types";
 export {

--- a/modules/hero-carousel/src/HeroCarouselView.tsx
+++ b/modules/hero-carousel/src/HeroCarouselView.tsx
@@ -8,7 +8,7 @@ import type { HeroCarouselViewProps } from "./HeroCarousel.types";
 // the image headers. Typed object/array props are applied natively with
 // `try? prop.set(...)`, so a conversion failure is swallowed and the view
 // silently renders empty; a string prop has no such failure mode, and the
-// same payload is what a future Android view would parse.
+// same payload is what both native views parse.
 type NativeProps = {
   payload: string;
   onItemPress?: HeroCarouselViewProps["onItemPress"];
@@ -17,14 +17,13 @@ type NativeProps = {
 };
 
 // The native side is a pure presentational view: JS passes prebuilt data
-// (image URLs, localized badge strings) and receives item ids back, so an
-// Android native view can be added under the same "HeroCarousel" name without
-// touching any JS. Phones/tablets only — the TV home has its own hero.
+// (image URLs, localized badge strings) and receives item ids back, which is
+// how SwiftUI and Jetpack Compose can both render it under the same
+// "HeroCarousel" name. Phones/tablets only — the TV home has its own hero.
 let NativeHeroCarouselView: React.ComponentType<NativeProps> | null = null;
 
 // requireOptionalNativeModule returns null instead of throwing when the
-// module isn't in this binary (old build, Expo Go, or a platform without a
-// native implementation yet — Android today).
+// module isn't in this binary (an old build, or Expo Go).
 if (!Platform.isTV && requireOptionalNativeModule("HeroCarousel")) {
   try {
     NativeHeroCarouselView = requireNativeView<NativeProps>("HeroCarousel");
@@ -38,6 +37,8 @@ if (!Platform.isTV && requireOptionalNativeModule("HeroCarousel")) {
  *
  * iOS 17+: SwiftUI paged ScrollView with interactive parallax and glass
  * info panels. iOS 15/16: paged TabView fallback with the same card design.
+ * Android: Jetpack Compose `HorizontalPager` with the same card design; the
+ * glass panels need Android 12+ and flatten to a solid tint below it.
  * Platforms without a native implementation render nothing.
  */
 const HeroCarouselView: React.FC<HeroCarouselViewProps> = ({

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -12,7 +12,7 @@ export { ExoPlayerView } from "./exoplayer-player";
 // Glass Poster (tvOS 26+)
 export type { GlassPosterViewProps } from "./glass-poster";
 export { GlassPosterView, isGlassEffectAvailable } from "./glass-poster";
-// Hero Carousel (iOS home tab)
+// Hero Carousel (iOS + Android home tab)
 export type {
   HeroCarouselFilterOption,
   HeroCarouselFilterSection,


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Adds the Android side of the hero carousel from #1979, written in Jetpack Compose. It registers under the same `HeroCarousel` name and parses the same JSON payload, so no JS changes were needed apart from comments and one settings gate.

A few things work differently from the SwiftUI version on purpose. Wrap around paging is a `HorizontalPager` over `Int.MAX_VALUE` pages indexed modulo the item count, so there are no sentinel clones and nothing to teleport past. Compose has no `.ultraThinMaterial`, so the info panel draws the card art a second time, offset and blurred, under a dark tint. That needs `RenderEffect` from Android 12, and below that the panel gets a flat tint instead. The SF Symbol names in the payload are mapped to Material icons natively so JS doesn't have to know about two icon sets.

The view is a plain `ExpoView` hosting its own `ComposeView` rather than an `ExpoComposeView`. Registering one of those crashed the app on startup with `UnsupportedOperationException: This function has a reified type parameter`. The props parsing goes through Pika compiler plugin intrinsics and that plugin isn't applied to modules built in this repo, @expo/ui only avoids it by shipping as a prebuilt AAR. The props machinery was unused anyway since everything arrives as one string. I kept the part that matters by hand, pinning the composition to the Activity lifecycle so react-native-screens detaching the Home tab doesn't leave a blank hero behind.

The appearance settings switch now shows when the native view exists instead of when the platform is iOS. It's the only way back once you turn the hero off from its own menu, so it needs to be there on both platforms.

## 🏷️ Ticket / Issue

Stacked on #1979, that one has to merge first.

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. `bun run prebuild` then `bun run android`. There's a new Gradle module, so a Metro reload isn't enough.
2. Open the Home tab. The carousel sits above Continue watching.
3. Swipe through it. It should wrap in both directions, and one flick should move exactly one card.
4. Tap a card and check it opens the right item page.
5. Tap and drag across the page dots. It should scrub through the carousel with haptics.
6. Tap the filter button top right, turn Movies off. The carousel should stay at 10 slides and fill up with TV instead.
7. In the same menu tap Disable hero. The carousel disappears. Turn it back on under Settings > Appearance > Hero carousel.
8. Switch to another tab and back. The carousel should still be there and not blank.
9. On iOS, check the hero still renders and the appearance switch still shows up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hero carousel support on Android, including swipeable paging, filters, loading states, image caching, ratings, progress indicators, and interactive controls.
  * Enabled the hero-carousel setting whenever the feature is available, rather than limiting it to iOS.
  * Added Android support for carousel item selection and filter interactions.
* **Improvements**
  * Expanded hero carousel availability across supported Android and iOS home tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->