### PR TITLE
fix(exoplayer): clamp buffer durations and report side-loaded subtitle tracks

### DIFF
--- a/modules/exoplayer-player/android/src/main/java/expo/modules/exoplayerplayer/ExoPlayerModule.kt
+++ b/modules/exoplayer-player/android/src/main/java/expo/modules/exoplayerplayer/ExoPlayerModule.kt
@@ -40,7 +40,10 @@ class ExoPlayerModule : Module() {
             // Now Playing metadata is iOS-only on MPV; no-op here (TV has
             // no Control Center equivalent — Android handles media sessions
             // via MediaSessionCompat which we don't wire up for TV).
-            Prop("nowPlayingMetadata") { _: ExoPlayerView, _: Map<String, String>? ->
+            // Typed loosely on purpose: the metadata carries nested values
+            // (artworkHeaders), and a Map<String, String> signature makes Expo
+            // reject the whole prop rather than ignore what it can't convert.
+            Prop("nowPlayingMetadata") { _: ExoPlayerView, _: Map<String, Any?>? ->
                 // No-op
             }
 

--- a/modules/exoplayer-player/android/src/main/java/expo/modules/exoplayerplayer/ExoPlayerView.kt
+++ b/modules/exoplayer-player/android/src/main/java/expo/modules/exoplayerplayer/ExoPlayerView.kt
@@ -371,12 +371,22 @@ class ExoPlayerView(context: Context, appContext: AppContext) : ExpoView(context
         val minBufferMs = minOf(defaultMinBufferMs, targetBufferMs)
             .coerceAtLeast(defaultBufferForPlaybackAfterRebufferMs)
 
+        // demuxerMaxBytes is in MiB; multiplying in Int overflows at 2048 MiB
+        // (2048 * 1024 * 1024 wraps negative). A negative byte target behaves
+        // like the 0 case documented below — loading halts immediately — so
+        // convert in Long and clamp to the largest representable value.
+        val targetBufferBytes =
+            if (!cacheEnabled) C.LENGTH_UNSET
+            else ((config.demuxerMaxBytes ?: 150).toLong() * 1024 * 1024)
+                .coerceAtMost(Int.MAX_VALUE.toLong())
+                .toInt()
+
         val builder = DefaultLoadControl.Builder()
             // C.LENGTH_UNSET lets ExoPlayer auto-derive the byte target from the
             // selected tracks. A literal 0 makes targetBufferSizeReached true on
             // the first allocation (prioritizeTimeOverSizeThresholds is false),
             // so loading halts with <500ms buffered and playback starves.
-            .setTargetBufferBytes(if (!cacheEnabled) C.LENGTH_UNSET else ((config.demuxerMaxBytes ?: 150) * 1024 * 1024))
+            .setTargetBufferBytes(targetBufferBytes)
             .setBufferDurationsMs(
                 /* minBufferMs = */ minBufferMs,
                 /* maxBufferMs = */ targetBufferMs,

--- a/modules/exoplayer-player/android/src/main/java/expo/modules/exoplayerplayer/ExoPlayerView.kt
+++ b/modules/exoplayer-player/android/src/main/java/expo/modules/exoplayerplayer/ExoPlayerView.kt
@@ -375,9 +375,12 @@ class ExoPlayerView(context: Context, appContext: AppContext) : ExpoView(context
         // (2048 * 1024 * 1024 wraps negative). A negative byte target behaves
         // like the 0 case documented below — loading halts immediately — so
         // convert in Long and clamp to the largest representable value.
+        // Non-positive maxBytes (0 or -1) would likewise produce a 0 or
+        // negative target, so fall back to the positive default.
+        val mb = config.demuxerMaxBytes?.takeIf { it > 0 } ?: 150
         val targetBufferBytes =
             if (!cacheEnabled) C.LENGTH_UNSET
-            else ((config.demuxerMaxBytes ?: 150).toLong() * 1024 * 1024)
+            else (mb.toLong() * 1024 * 1024)
                 .coerceAtMost(Int.MAX_VALUE.toLong())
                 .toInt()
 

--- a/modules/exoplayer-player/android/src/main/java/expo/modules/exoplayerplayer/ExoPlayerView.kt
+++ b/modules/exoplayer-player/android/src/main/java/expo/modules/exoplayerplayer/ExoPlayerView.kt
@@ -62,6 +62,14 @@ class ExoPlayerView(context: Context, appContext: AppContext) : ExpoView(context
     companion object {
         private const val TAG = "ExoPlayerView"
         private const val PROGRESS_INTERVAL_MS = 1000L
+        // Prefix stamped into Format.id of side-loaded subtitle tracks so
+        // getSubtitleTracks() can tell them from in-container tracks and
+        // report the source URL the JS resolver matches against (mirrors
+        // mpv's external / external-filename track-list fields). A bare URL
+        // isn't a safe discriminator: some extractors set their own
+        // Format.id on embedded tracks. Format.id is the only field that
+        // survives from SubtitleConfiguration into the track list.
+        private const val SIDELOAD_ID_PREFIX = "sideload:"
     }
 
     // Event dispatchers — names must match the Events() declaration in the module.
@@ -352,6 +360,17 @@ class ExoPlayerView(context: Context, appContext: AppContext) : ExpoView(context
             (mb * 1000).coerceAtLeast(1000)
         }
 
+        // DefaultLoadControl's builder validates maxBufferMs >= minBufferMs
+        // (and minBufferMs >= both start thresholds) and throws
+        // IllegalArgumentException otherwise. The user's cacheSeconds can be
+        // as low as 5s — below the 15s default min — so derive the min from
+        // the same target. An unclamped pair (e.g. the 10s default) throws
+        // inside ensurePlayer(), which the Expo prop layer swallows into
+        // LogBox: the view is left with no player, no events ever fire, and
+        // the JS loader spins forever.
+        val minBufferMs = minOf(defaultMinBufferMs, targetBufferMs)
+            .coerceAtLeast(defaultBufferForPlaybackAfterRebufferMs)
+
         val builder = DefaultLoadControl.Builder()
             // C.LENGTH_UNSET lets ExoPlayer auto-derive the byte target from the
             // selected tracks. A literal 0 makes targetBufferSizeReached true on
@@ -359,7 +378,7 @@ class ExoPlayerView(context: Context, appContext: AppContext) : ExpoView(context
             // so loading halts with <500ms buffered and playback starves.
             .setTargetBufferBytes(if (!cacheEnabled) C.LENGTH_UNSET else ((config.demuxerMaxBytes ?: 150) * 1024 * 1024))
             .setBufferDurationsMs(
-                /* minBufferMs = */ defaultMinBufferMs,
+                /* minBufferMs = */ minBufferMs,
                 /* maxBufferMs = */ targetBufferMs,
                 /* bufferForPlaybackMs = */ defaultBufferForPlaybackMs,
                 /* bufferForPlaybackAfterRebufferMs = */ defaultBufferForPlaybackAfterRebufferMs
@@ -409,13 +428,17 @@ class ExoPlayerView(context: Context, appContext: AppContext) : ExpoView(context
         val builder = MediaItem.Builder().setUri(config.url)
 
         // External subtitles: add as side-loaded SubtitleConfigurations.
-        // MIME-type sniffed from the file extension.
+        // MIME-type sniffed from the file extension. The URL is stamped into
+        // the config's id so it reaches Format.id in the track list — the
+        // JS resolver matches external subs by that URL (mpv's
+        // external-filename equivalent).
         val subs = config.externalSubtitles
         if (!subs.isNullOrEmpty()) {
             val subtitleConfigs = subs.mapNotNull { subUrl ->
                 val mime = mimeTypeForSubtitleUrl(subUrl) ?: return@mapNotNull null
                 MediaItem.SubtitleConfiguration.Builder(Uri.parse(subUrl))
                     .setMimeType(mime)
+                    .setId(SIDELOAD_ID_PREFIX + subUrl)
                     .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
                     .build()
             }
@@ -582,10 +605,18 @@ class ExoPlayerView(context: Context, appContext: AppContext) : ExpoView(context
         if (cfg.initialAudioId != null && cfg.initialAudioId > 0) {
             setAudioTrack(cfg.initialAudioId)
         }
-        if (cfg.initialSubtitleId == null || cfg.initialSubtitleId <= 0) {
-            disableSubtitles()
-        } else {
-            setSubtitleTrack(cfg.initialSubtitleId)
+        // Only disable text when JS asked for no subtitle (id 0) or passed an
+        // explicit id. When initialSubtitleId is absent the JS layer defers
+        // selection to onTracksReady (it resolves by URL identity via
+        // getSubtitleTracks) — disabling here would kill Media3's auto-pick of
+        // the SELECTION_FLAG_DEFAULT sidecar before that resolves, and the
+        // notFound fallback would leave subtitles off entirely.
+        if (cfg.initialSubtitleId != null) {
+            if (cfg.initialSubtitleId <= 0) {
+                disableSubtitles()
+            } else {
+                setSubtitleTrack(cfg.initialSubtitleId)
+            }
         }
 
         // Only apply once per source load.
@@ -596,11 +627,21 @@ class ExoPlayerView(context: Context, appContext: AppContext) : ExpoView(context
 
     fun getSubtitleTracks(): List<Map<String, Any>> {
         return subtitleTrackList.map { entry ->
-            mapOf(
+            val map = mutableMapOf<String, Any>(
                 "id" to entry.id,
                 "title" to (entry.format.label ?: ""),
                 "lang" to (entry.format.language ?: "")
             )
+            // Mirror mpv's external / external-filename fields for side-loaded
+            // tracks (stamped into Format.id at build time — see
+            // SIDELOAD_ID_PREFIX). The JS resolver matches a Jellyfin External
+            // sub to a player track by that URL; without these fields every
+            // external sub resolves notFound and never renders.
+            entry.format.id?.takeIf { it.startsWith(SIDELOAD_ID_PREFIX) }?.let { id ->
+                map["external"] = true
+                map["externalFilename"] = id.removePrefix(SIDELOAD_ID_PREFIX)
+            }
+            map
         }
     }
 
@@ -640,6 +681,7 @@ class ExoPlayerView(context: Context, appContext: AppContext) : ExpoView(context
         val currentMediaItem = p.currentMediaItem ?: return
         val newSubConfig = MediaItem.SubtitleConfiguration.Builder(Uri.parse(url))
             .setMimeType(mime)
+            .setId(SIDELOAD_ID_PREFIX + url)
             .setSelectionFlags(if (select) C.SELECTION_FLAG_DEFAULT else 0)
             .build()
 

--- a/modules/exoplayer-player/android/src/main/java/expo/modules/exoplayerplayer/ExoPlayerView.kt
+++ b/modules/exoplayer-player/android/src/main/java/expo/modules/exoplayerplayer/ExoPlayerView.kt
@@ -637,11 +637,32 @@ class ExoPlayerView(context: Context, appContext: AppContext) : ExpoView(context
             // SIDELOAD_ID_PREFIX). The JS resolver matches a Jellyfin External
             // sub to a player track by that URL; without these fields every
             // external sub resolves notFound and never renders.
-            entry.format.id?.takeIf { it.startsWith(SIDELOAD_ID_PREFIX) }?.let { id ->
+            //
+            // Media3's MergingMediaPeriod prefixes every merged Format.id with
+            // its child source index (e.g. "1:sideload:<url>"), so strip that
+            // before matching the application prefix.
+            val formatId = stripMergingSourcePrefix(entry.format.id)
+            if (formatId?.startsWith(SIDELOAD_ID_PREFIX) == true) {
                 map["external"] = true
-                map["externalFilename"] = id.removePrefix(SIDELOAD_ID_PREFIX)
+                map["externalFilename"] = formatId.removePrefix(SIDELOAD_ID_PREFIX)
             }
             map
+        }
+    }
+
+    /**
+     * Media3's MergingMediaPeriod prefixes every merged Format.id with the
+     * child source index (e.g. "1:sideload:<url>"). Strip a leading numeric
+     * source index so the application's SIDELOAD_ID_PREFIX matches. Returns
+     * null for a null id and the id unchanged when there is no such prefix.
+     */
+    private fun stripMergingSourcePrefix(id: String?): String? {
+        if (id == null) return null
+        val colon = id.indexOf(':')
+        return if (colon > 0 && id.substring(0, colon).all { it.isDigit() }) {
+            id.substring(colon + 1)
+        } else {
+            id
         }
     }
 


### PR DESCRIPTION
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description
Fixes to the native Android ExoPlayer module surfaced while testing subtitle/track handling:

- **Buffer clamp**: `minBufferMs` is now derived from the cache target so `DefaultLoadControl.Builder` never throws on a `cacheSeconds` below the 15s default. Previously the view was left without a player, no events fired, and the JS loader spun forever.
- **Side-loaded subtitle tracks**: external subtitle URLs are stamped into `Format.id` (via a `sideload:` prefix) and surfaced as `external` / `externalFilename` in `getSubtitleTracks()`, mirroring mpv's `external-filename` fields so the JS resolver can match Jellyfin external subs by URL.
- **Subtitle selection**: only auto-disable text when JS explicitly passed id 0 or a specific id; an absent id now defers selection to `onTracksReady`, preserving Media3's auto-pick of the default sidecar.
- **nowPlayingMetadata prop**: widened to `Map<String, Any?>` so Expo doesn't reject the prop because of nested `artworkHeaders`.

This is the base PR of a stacked PR set:
1. **this PR** — exoplayer fixes (→ `develop`)
2. `feat/series-season-deeplink` → based on this
3. `chore/tv-scalesize-focus` → based on that
4. `fix/item-image-source` → top of the stack

## 🏷️ Ticket / Issue
N/A

### 🖼️ Screenshots / GIFs (if UI)
N/A — no UI change (Android native module)

## ✅ Checklist
- [ ] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [ ] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions
1. Play media with `cacheSeconds` set to 5 (below the default) and confirm playback starts and events fire.
2. Play a title with an external (side-loaded) subtitle; confirm the subtitle is matched by URL and renders.
3. Play a title with embedded subtitles; confirm auto-pick of the default subtitle still works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved subtitle track identification and metadata, including external subtitle status and filenames.
  - Dynamically added subtitle tracks now receive consistent identification.
  - External subtitle sources retain their associated URLs.
  - Initial subtitle selection works correctly when no explicit track ID is provided.
  - Now-playing metadata supports nested values.

- **Bug Fixes**
  - Improved buffering behavior for smaller cache configurations to support more reliable playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->