### PR TITLE
fix(image): pass the image uri as expo-image source

### DIFF
--- a/components/common/ItemImage.tsx
+++ b/components/common/ItemImage.tsx
@@ -76,8 +76,8 @@ export const ItemImage: FC<Props> = ({
         width: "100%",
         height: "100%",
       }}
-      // The whole source, not just its uri: getItemImage already resolved the
-      // custom proxy auth headers for it.
+      // Pass the uri only: ServerImage resolves the server's proxy auth headers
+      // from it (and re-resolves them when the custom headers change).
       source={source?.uri}
       {...props}
     />

--- a/components/common/ItemImage.tsx
+++ b/components/common/ItemImage.tsx
@@ -78,7 +78,7 @@ export const ItemImage: FC<Props> = ({
       }}
       // The whole source, not just its uri: getItemImage already resolved the
       // custom proxy auth headers for it.
-      source={source}
+      source={source?.uri}
       {...props}
     />
   );


### PR DESCRIPTION
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description
Fixes `ItemImage` passing the wrong value as the `expo-image` source. `getItemImage` already resolves the custom proxy auth headers into the source object, so the component should pass the resolved `uri` (`source?.uri`) to `expo-image` rather than the whole `source` object — passing the object could break rendering of server images behind gateway auth.

This is a stacked PR:
1. `fix/exoplayer-buffer-subtitles` → #1985 (base)
2. `feat/series-season-deeplink` → #1986
3. `chore/tv-scalesize-focus` → #1987
4. **this PR** — ItemImage source fix

## 🏷️ Ticket / Issue
N/A

### 🖼️ Screenshots / GIFs (if UI)
N/A — bug fix; verify images render on both platforms.

## ✅ Checklist
- [ ] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [ ] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions
1. Browse libraries/continue-watching rows on a server behind a gateway/custom auth header setup and confirm poster images load.
2. Confirm normal (non-authed) servers still render images as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading by passing only the resolved image address, preventing unintended source metadata from being included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->