### PR TITLE
fix(mpv): pin tvOS audio output back to audiounit

### DIFF
--- a/app.json
+++ b/app.json
@@ -163,7 +163,7 @@
         "./plugins/withGitPod.ts",
         {
           "podName": "MPVKit",
-          "podspecUrl": "https://raw.githubusercontent.com/streamyfin/MPVKit/0.41.0-av2/MPVKit.podspec"
+          "podspecUrl": "https://raw.githubusercontent.com/streamyfin/MPVKit/0.41.0-av3/MPVKit.podspec"
         }
       ]
     ],

--- a/modules/mpv-player/ios/MPVLayerRenderer.swift
+++ b/modules/mpv-player/ios/MPVLayerRenderer.swift
@@ -263,13 +263,31 @@ final class MPVLayerRenderer {
         checkError(mpv_set_option_string(handle, "target-colorspace-hint", "yes"))
         #endif
 
-        // Audio output: with Atmos "Continuous Audio Output" enabled, some HDMI
-        // routes report 32 output channels, which the audiounit AO cannot open -
-        // playback stays silent. Prefer the avfoundation AO
-        // (AVSampleBufferAudioRenderer), which handles these routes, with
-        // audiounit as fallback if it fails to initialize. iOS is unchanged.
+        // Audio output: pin tvOS to audiounit. Do NOT reach for the
+        // avfoundation AO here - it is a macOS-oriented driver, and the audio
+        // clock it hands mpv is what video timing is scheduled against:
+        //
+        //   ao_read_data(ao, data, n, end_time_av - cur_time_av + cur_time_mp + dt, ...)
+        //
+        // That anchor is polled off [AVSampleBufferRenderSynchronizer currentTime]
+        // and carries no device-latency term at all. On a real Apple TV the HDMI
+        // route adds tens of ms of unmodelled output latency and currentTime is
+        // coarse, so the anchor is both offset and noisy at the feed rate
+        // (samplerate/10, ~100ms chunks) - video stalls, stutters, then jumps on
+        // the correction. audiounit instead anchors off the hardware
+        // AudioTimeStamp per render callback plus AVAudioSession output latency,
+        // which is stable over HDMI. The simulator hides all of this: ~0 output
+        // latency and a fine-grained device clock, so avfoundation looks fine
+        // there and only fails on device.
+        //
+        // This leaves #1970 (silence on HDMI routes reporting 32 output channels
+        // with Atmos "Continuous Audio Output") unfixed. That one is a real bug
+        // in ao_audiounit.m, which adopts the hardware layout wholesale -
+        // `ao->channels.num = layout->mNumberChannelDescriptions` with speaker IDs
+        // that come back unknown - and it needs a clamp in the MPVKit fork, not
+        // a different AO. iOS is unchanged.
         #if os(tvOS)
-        checkError(mpv_set_option_string(handle, "ao", "avfoundation,audiounit"))
+        checkError(mpv_set_option_string(handle, "ao", "audiounit"))
         #endif
 
         // Subtitle and audio settings

--- a/modules/mpv-player/ios/MPVLayerRenderer.swift
+++ b/modules/mpv-player/ios/MPVLayerRenderer.swift
@@ -280,12 +280,13 @@ final class MPVLayerRenderer {
         // latency and a fine-grained device clock, so avfoundation looks fine
         // there and only fails on device.
         //
-        // This leaves #1970 (silence on HDMI routes reporting 32 output channels
-        // with Atmos "Continuous Audio Output") unfixed. That one is a real bug
-        // in ao_audiounit.m, which adopts the hardware layout wholesale -
-        // `ao->channels.num = layout->mNumberChannelDescriptions` with speaker IDs
-        // that come back unknown - and it needs a clamp in the MPVKit fork, not
-        // a different AO. iOS is unchanged.
+        // The silence #1970 was chasing (#1673) is fixed in the AO itself as of
+        // MPVKit 0.41.0-av3, not by swapping AOs: HDMI routes carrying Dolby MAT
+        // report a channel layout whose labels have no mp speaker ID, and
+        // ao_audiounit.m adopted it wholesale, so the chmap came out invalid and
+        // playback was silent. av3 clamps that to a layout mpv can use. iOS is
+        // unchanged either way - its autoprobe already picks audiounit ahead of
+        // avfoundation.
         #if os(tvOS)
         checkError(mpv_set_option_string(handle, "ao", "audiounit"))
         #endif

--- a/plugins/withGitPod.ts
+++ b/plugins/withGitPod.ts
@@ -10,14 +10,20 @@ const withGitPod: ConfigPlugin<GitPodOptions> = (
   { podName, podspecUrl },
 ) => {
   return withPodfile(config, (config) => {
-    const podfile = config.modResults.contents;
-
     const podLine = `  pod '${podName}', :podspec => '${podspecUrl}'`;
 
-    // Check if already added
-    if (podfile.includes(podLine)) {
-      return config;
-    }
+    // Drop any existing declaration for this pod before inserting. The guard
+    // here used to compare the whole line, podspec URL included, so bumping the
+    // URL left the old line sitting next to the new one and `pod install` failed
+    // with conflicting sources for the same pod. Only shows up on a prebuild
+    // that reuses an existing ios/, since a clean one has no line to collide
+    // with, which is why it went unnoticed until the 0.41.0-av2 -> av3 bump.
+    const escapedName = podName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const existingPod = new RegExp(
+      `^[ \\t]*pod ['"]${escapedName}['"].*$\\n?`,
+      "gm",
+    );
+    const podfile = config.modResults.contents.replace(existingPod, "");
 
     // Insert after "use_expo_modules!"
     config.modResults.contents = podfile.replace(


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Puts tvOS audio back on the audiounit output, and bumps MPVKit to 0.41.0-av3.

#1970 moved tvOS onto mpv's avfoundation audio output. On a real Apple TV that stutters video on everything, not just Atmos. The simulator doesn't show it, which is how it got through. I tested on device and the stutter is gone.

Going back to audiounit on its own would bring back the silent audio from #1673, so av3 fixes that one in mpv instead. On setups with Continuous Audio Connection and an Atmos receiver, tvOS reports a speaker layout mpv can't read. mpv used it anyway and played nothing. av3 checks the layout first, and falls back to stereo when it can't read it.

To be clear about the stereo bit: nobody with working surround loses it. That fallback only runs where audio is silent today. Those setups get stereo instead of nothing. We can probably do better than stereo later, but I'd rather see a log from an affected setup than guess a third time.

I can't test that half myself. My Apple TV reads its layout fine, so it never reaches the fallback.

## 🏷️ Ticket / Issue

Fixes #1673. Reverts the audio output change from #1970.

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

`app.json` changed, so run `bun run prebuild:tv` first.

1. Build to a physical Apple TV with `bun run ios:tv --device`. The simulator won't show the stutter either way.
2. Play anything. Video should be smooth, no stuttering and no spinner flickering.
3. Play a 7.1 track and check audio still works. I used House of the Dragon S1E3.
4. If you run Continuous Audio Connection with an Atmos receiver, check whether audio plays at all. That's the #1673 case.
