### PR TITLE
fix(sentry): keep dev builds out of the issue stream

### DIFF
--- a/components/settings/PluginSettings.tsx
+++ b/components/settings/PluginSettings.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner-native";
 import { SettingSwitch } from "@/components/common/SettingSwitch";
 import useRouter from "@/hooks/useAppRouter";
 import { useSettings } from "@/utils/atoms/settings";
+import { sentryDebugInDev } from "@/utils/sentry";
 import { ListGroup } from "../list/ListGroup";
 import { ListItem } from "../list/ListItem";
 
@@ -73,8 +74,10 @@ export const PluginSettings = () => {
           onValueChange={(value) => updateSettings({ sentryEnabled: value })}
         />
       </ListItem>
-      {/* Dev-only smoke test for the Sentry pipeline; never ships in release. */}
-      {__DEV__ && settings.sentryEnabled && (
+      {/* Dev-only smoke test for the Sentry pipeline; never ships in release.
+          Dev builds don't report unless EXPO_PUBLIC_SENTRY_DEBUG=1, so the
+          button is hidden when the event would go nowhere. */}
+      {__DEV__ && sentryDebugInDev && settings.sentryEnabled && (
         <ListItem
           title='Send test error to Sentry'
           textColor='blue'

--- a/utils/sentry.test.ts
+++ b/utils/sentry.test.ts
@@ -4,8 +4,11 @@ import { describe, expect, mock, test } from "bun:test";
 // only the pure scrubbers are under test here. Bun's mock.module is
 // retroactive and process-wide, so each mock covers the full surface the
 // module under test touches.
+const initCalls: unknown[] = [];
 mock.module("@sentry/react-native", () => ({
-  init: () => undefined,
+  init: (options: unknown) => {
+    initCalls.push(options);
+  },
   close: () => Promise.resolve(),
   breadcrumbsIntegration: () => ({ name: "Breadcrumbs" }),
 }));
@@ -32,7 +35,8 @@ mock.module("react-native", () => ({
   Platform: { OS: "ios", isTV: false },
 }));
 
-const { scrubDeep, isUserInteractionBreadcrumb } = await import("./sentry");
+const { scrubDeep, isUserInteractionBreadcrumb, initializeSentryIfConsented } =
+  await import("./sentry");
 
 describe("isUserInteractionBreadcrumb — no behaviour tracking, no titles", () => {
   test("drops touch breadcrumbs, whose labels are media titles", () => {
@@ -180,5 +184,28 @@ describe("scrubDeep — the privacy boundary for outgoing Sentry data", () => {
     const scrubbed = scrubDeep(node) as Record<string, unknown>;
     expect(scrubbed.url).toBe("https://[server]");
     expect(scrubbed.self).toBe(scrubbed);
+  });
+});
+
+// The project's first 22 events were all local dev noise — test errors and
+// stack frames naming a developer's home directory — so a dev build must not
+// reach the SDK at all, not merely tag itself as "development".
+describe("dev builds do not report", () => {
+  const setDev = (value: boolean) => {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = value;
+  };
+
+  test("a dev build never initializes the SDK", () => {
+    setDev(true);
+    initializeSentryIfConsented();
+    expect(initCalls).toHaveLength(0);
+  });
+
+  // Ordering matters: initializeSentry latches on success, so the release
+  // case runs last or it would mask the dev case above.
+  test("a release build initializes as normal", () => {
+    setDev(false);
+    initializeSentryIfConsented();
+    expect(initCalls).toHaveLength(1);
   });
 });

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -13,6 +13,21 @@ const SENTRY_DSN =
   process.env.EXPO_PUBLIC_SENTRY_DSN ??
   "https://5c548edf47663532bb529ba72b2ddbb1@o4509610343596032.ingest.de.sentry.io/4509610370728016";
 
+// Dev builds stay out of Sentry entirely. Their frames carry local absolute
+// paths — the developer's username and worktree layout — Metro reloads throw
+// errors that no user will ever hit, and the same bug grouped under a handful
+// of different local paths fragments into separate issues that then compete
+// with real reports. Tagging the environment isn't enough: the event still
+// leaves the device and still lands in the project's issue stream.
+//
+// Set EXPO_PUBLIC_SENTRY_DEBUG=1 to smoke-test the pipeline from a dev build;
+// those events report under the "development" environment.
+export const sentryDebugInDev = process.env.EXPO_PUBLIC_SENTRY_DEBUG === "1";
+
+// Read at call time rather than module scope so the gate is observable in
+// tests, which drive __DEV__ per case.
+const reportsFromThisBuild = (): boolean => !__DEV__ || sentryDebugInDev;
+
 let initialized = false;
 
 /**
@@ -128,7 +143,7 @@ const NATIVE_SDK_OPTIONS = {
 } as Partial<Parameters<typeof Sentry.init>[0]>;
 
 const initializeSentry = () => {
-  if (initialized || !SENTRY_DSN) return;
+  if (initialized || !SENTRY_DSN || !reportsFromThisBuild()) return;
   initialized = true;
   try {
     // Build-identity tags so an event can be pinned to an exact source state.


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Stop dev builds from sending anything to Sentry. They were tagged `environment: development` but still reported, so all 22 events in the project so far are local noise. Mostly test errors and stack frames with our own home directory paths in them, including one contributor's username.

I put the check in `initializeSentry()` so both the startup path and the settings toggle are covered. Set `EXPO_PUBLIC_SENTRY_DEBUG=1` if you want a dev build to report anyway. The "Send test error" button follows the same flag now, before this it showed a success toast while sending nothing.

Preview and ci builds still report as production since `__DEV__` is false there. The `build.profile` tag from #1978 tells them apart. We can give them their own environment later if it gets noisy.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [ ] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

Not run on a device yet.

## 🔍 Testing Instructions

1. Run the app normally. In Settings > Plugins the blue "Send test error to Sentry" row should be gone. Trigger any error, nothing new should show up in Sentry.
2. Run with `EXPO_PUBLIC_SENTRY_DEBUG=1`. The row is back, and tapping it should land an event under `environment: development`.
3. Build a preview build and check errors still report. That's the part this could break.
4. Toggle Crash reports off and on in settings, should work as before.

`bun test utils/sentry.test.ts` covers 1 and 3 (18 pass).
