### PR TITLE
fix(sentry): group HTTP errors by route and status, skip gateway errors

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/utils/background-tasks";
 import { getOrSetDeviceId } from "@/utils/device";
 import {
+  describeHttpError,
   isAbortLikeError,
   isConnectivityError,
   isErrorReported,
@@ -276,9 +277,9 @@ onlineManager.setEventListener((setOnline) => {
 
 // Every React Query failure funnels through here instead of needing per-call
 // handlers. Skipped: anything while offline, aborted requests, connectivity
-// failures with no HTTP response — axios or fetch — (an unreachable server
-// is the user's environment, not an app bug), and 401s (session expiry has
-// its own interceptor in JellyfinProvider).
+// failures — no HTTP response or a gateway error, axios or fetch — (an
+// unreachable server is the user's environment, not an app bug), and 401s
+// (session expiry has its own interceptor in JellyfinProvider).
 const shouldReportDataError = (error: unknown): boolean => {
   if (!onlineManager.isOnline()) return false;
   if (isExpectedError(error) || isErrorReported(error)) return false;
@@ -290,7 +291,7 @@ const shouldReportDataError = (error: unknown): boolean => {
 // A persistently failing query refetches on every mount (staleTime 0), and
 // Sentry's Dedupe integration only drops an event identical to the
 // immediately-previous one — two alternating failing queries defeat it. One
-// report per (source, key, status) per session is enough.
+// report per (source, key, route, status) per session is enough.
 const reportedDataErrors = new Set<string>();
 
 const reportDataError = (
@@ -299,23 +300,39 @@ const reportDataError = (
   error: unknown,
 ) => {
   if (!shouldReportDataError(error)) return;
+  // Only the key's first element (the query's name) is used — later
+  // elements can carry search text or item titles, and the name alone
+  // already says which data path failed.
+  const name = typeof key?.[0] === "string" ? key[0] : undefined;
+  const http = describeHttpError(error);
   const dedupeKey = [
     source,
-    typeof key?.[0] === "string" ? key[0] : "?",
-    isAxiosError(error) ? (error.response?.status ?? "no-status") : "no-http",
+    name ?? "?",
+    http ? `${http.method} ${http.path} ${http.status}` : "no-http",
     error instanceof Error ? error.name : typeof error,
   ].join("|");
   if (reportedDataErrors.has(dedupeKey)) return;
   if (reportedDataErrors.size < 200) reportedDataErrors.add(dedupeKey);
   Sentry.withScope((scope) => {
-    // Only the key's first element (the query's name) is sent — later
-    // elements can carry search text or item titles, and the name alone
-    // already says which data path failed.
     scope.setContext("data_layer", {
       source,
-      key: typeof key?.[0] === "string" ? key[0] : undefined,
+      key: name,
       keyLength: key?.length,
     });
+    if (http) {
+      // An AxiosError's stack has no app frames (it is built inside axios),
+      // so left to Sentry every HTTP failure in the app lands in ONE issue.
+      // Group by the query that failed, its route and the status instead.
+      scope.setContext("http", http);
+      scope.setFingerprint([
+        "data-layer",
+        source,
+        name ?? "?",
+        http.method,
+        http.path,
+        String(http.status),
+      ]);
+    }
     Sentry.captureException(error);
   });
 };

--- a/providers/WebSocketProvider.tsx
+++ b/providers/WebSocketProvider.tsx
@@ -17,6 +17,7 @@ import { apiAtom } from "@/providers/JellyfinProvider";
 import { useNetworkStatus } from "@/providers/NetworkStatusProvider";
 import { getJellyfinHeaders, hasHeaders } from "@/utils/customHeaders";
 import { getOrSetDeviceId } from "@/utils/device";
+import { describeHttpResponse } from "@/utils/errors";
 import { logAndCaptureError } from "@/utils/log";
 
 // Query keys that depend on the set of library items and should be refreshed
@@ -392,9 +393,17 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
       } catch (error) {
         // Connectivity failures are filtered centrally; 401 is routine
         // session expiry (the auth interceptor handles it). What remains is
-        // a server rejection that silently breaks remote control.
+        // a server rejection that silently breaks remote control — and the
+        // response's content type, Server header and plain-text reason are
+        // what tell Jellyfin's own "Session not found" apart from a proxy
+        // that blocks the POST, or turns it into a GET via an http→https
+        // redirect (405).
         if (isAxiosError(error) && error.response?.status === 401) return;
-        logAndCaptureError("Posting session capabilities failed", error);
+        logAndCaptureError(
+          "Posting session capabilities failed",
+          error,
+          describeHttpResponse(error),
+        );
       }
     };
 

--- a/utils/errors.test.ts
+++ b/utils/errors.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { AxiosError, type AxiosResponse } from "axios";
+import {
+  describeHttpError,
+  describeHttpResponse,
+  isConnectivityError,
+  templateRequestPath,
+} from "./errors";
+
+const httpError = (
+  status: number | undefined,
+  {
+    method = "get",
+    url = "https://jellyfin.example.com/Items",
+    headers = {},
+    data,
+  }: {
+    method?: string;
+    url?: string;
+    headers?: Record<string, string>;
+    data?: unknown;
+  } = {},
+) =>
+  new AxiosError(
+    status ? `Request failed with status code ${status}` : "Network Error",
+    status ? AxiosError.ERR_BAD_RESPONSE : AxiosError.ERR_NETWORK,
+    { method, url, headers: {} as never },
+    {},
+    status
+      ? ({ status, headers, data, config: {} } as unknown as AxiosResponse)
+      : undefined,
+  );
+
+describe("templateRequestPath", () => {
+  test("drops the origin and query string", () => {
+    expect(
+      templateRequestPath("https://my.server:8096/Users/Me?api_key=secret"),
+    ).toBe("/Users/Me");
+  });
+
+  test("replaces GUIDs, hex ids and numbers with :id", () => {
+    expect(
+      templateRequestPath(
+        "https://host/Users/3fa85f64-5717-4562-b3fc-2c963f66afa6/Items/f0e1d2c3b4a5968778695a4b3c2d1e0f/Images/Primary/0",
+      ),
+    ).toBe("/Users/:id/Items/:id/Images/Primary/:id");
+    expect(templateRequestPath("/api/v1/tv/1368337/ratings")).toBe(
+      "/api/v1/tv/:id/ratings",
+    );
+  });
+
+  test("replaces free-text segments with :param", () => {
+    expect(templateRequestPath("https://host/Persons/Tom%20Hanks")).toBe(
+      "/Persons/:param",
+    );
+    expect(templateRequestPath("https://host/Videos/x/Show%20S01E02.mp4")).toBe(
+      "/Videos/x/:param",
+    );
+  });
+
+  test("keeps route words, including a server base path", () => {
+    expect(
+      templateRequestPath(
+        "http://192.168.1.2/jellyfin/Sessions/Capabilities/Full",
+      ),
+    ).toBe("/jellyfin/Sessions/Capabilities/Full");
+    expect(templateRequestPath("https://host/generate_204")).toBe(
+      "/generate_204",
+    );
+  });
+
+  test("handles missing and relative urls", () => {
+    expect(templateRequestPath(undefined)).toBe("?");
+    expect(templateRequestPath("Items/Latest?limit=5")).toBe("Items/Latest");
+  });
+});
+
+describe("describeHttpError", () => {
+  test("describes an HTTP response by method, route and status", () => {
+    expect(
+      describeHttpError(
+        httpError(404, {
+          method: "post",
+          url: "https://host/Sessions/Capabilities/Full",
+        }),
+      ),
+    ).toEqual({
+      method: "POST",
+      path: "/Sessions/Capabilities/Full",
+      status: 404,
+    });
+  });
+
+  test("is null without a response or for non-axios errors", () => {
+    expect(describeHttpError(httpError(undefined))).toBeNull();
+    expect(describeHttpError(new Error("boom"))).toBeNull();
+    expect(describeHttpError("string")).toBeNull();
+  });
+});
+
+describe("isConnectivityError", () => {
+  test("no HTTP response is connectivity", () => {
+    expect(isConnectivityError(httpError(undefined))).toBe(true);
+    expect(isConnectivityError(new TypeError("Network request failed"))).toBe(
+      true,
+    );
+  });
+
+  test("gateway statuses are connectivity, other statuses are not", () => {
+    expect(isConnectivityError(httpError(502))).toBe(true);
+    expect(isConnectivityError(httpError(503))).toBe(true);
+    expect(isConnectivityError(httpError(504))).toBe(true);
+    expect(isConnectivityError(httpError(500))).toBe(false);
+    expect(isConnectivityError(httpError(404))).toBe(false);
+    expect(isConnectivityError(httpError(401))).toBe(false);
+  });
+});
+
+describe("describeHttpResponse", () => {
+  test("keeps a plain-text reason and the Server header", () => {
+    expect(
+      describeHttpResponse(
+        httpError(404, {
+          headers: {
+            "content-type": "text/plain; charset=utf-8",
+            server: "Kestrel",
+          },
+          data: "Session not found.",
+        }),
+      ),
+    ).toEqual({
+      status: 404,
+      contentType: "text/plain; charset=utf-8",
+      server: "Kestrel",
+      body: "Session not found.",
+    });
+  });
+
+  test("serialises and truncates a JSON body", () => {
+    const described = describeHttpResponse(
+      httpError(404, {
+        headers: { "content-type": "application/problem+json" },
+        data: { title: "Not Found", detail: "x".repeat(400) },
+      }),
+    );
+    expect(described?.body).toStartWith('{"title":"Not Found"');
+    expect(described?.body).toHaveLength(200);
+  });
+
+  test("drops an HTML body but keeps the headers", () => {
+    expect(
+      describeHttpResponse(
+        httpError(404, {
+          headers: { "content-type": "text/html", server: "nginx/1.25" },
+          data: "<html><title>my-private-host.duckdns.org</title></html>",
+        }),
+      ),
+    ).toEqual({
+      status: 404,
+      contentType: "text/html",
+      server: "nginx/1.25",
+      body: undefined,
+    });
+  });
+
+  test("is undefined without a response", () => {
+    expect(describeHttpResponse(httpError(undefined))).toBeUndefined();
+    expect(describeHttpResponse(new Error("boom"))).toBeUndefined();
+  });
+});

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -42,14 +42,22 @@ export const isAbortLikeError = (error: unknown): boolean =>
   (error instanceof Error &&
     (error.name === "AbortError" || error.name === "CanceledError"));
 
+// A gateway status means the reverse proxy in front of Jellyfin answered but
+// Jellyfin itself did not (container down, restarting, upstream timeout) —
+// from the app's side that is an unreachable server, not an app bug.
+const GATEWAY_STATUSES = new Set([502, 503, 504]);
+
 /**
- * True for requests that never got an HTTP response — the server is
- * unreachable (LAN-only server while roaming, DNS failure, timeout). That is
- * the user's environment, not an app bug, so it must never become a Sentry
- * event. Covers both axios errors and React Native's fetch TypeError.
+ * True for requests that never got a usable HTTP response — the server is
+ * unreachable (LAN-only server while roaming, DNS failure, timeout) or its
+ * proxy could not reach it. That is the user's environment, not an app bug,
+ * so it must never become a Sentry event. Covers both axios errors and React
+ * Native's fetch TypeError.
  */
 export const isConnectivityError = (error: unknown): boolean => {
-  if (isAxiosError(error)) return !error.response;
+  if (isAxiosError(error)) {
+    return !error.response || GATEWAY_STATUSES.has(error.response.status);
+  }
   return (
     error instanceof TypeError && /network request failed/i.test(error.message)
   );
@@ -59,3 +67,97 @@ export const isExpectedError = (error: unknown): boolean =>
   error !== null &&
   typeof error === "object" &&
   (error as Record<symbol, unknown>)[EXPECTED_ERROR] === true;
+
+// Path segments that identify a record rather than name a route: GUIDs (with
+// or without dashes), hex hashes and bare numbers.
+const ID_SEGMENT =
+  /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|\d+)$/i;
+// Anything else that isn't a plain route word (URL-encoded names, search
+// text, filenames) is a parameter too.
+const ROUTE_WORD = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+/**
+ * Reduces a request URL to its route shape: origin and query string dropped,
+ * record identifiers and free-text segments replaced by placeholders.
+ * "https://host/Users/3f2a…/Items/12?api_key=x" → "/Users/:id/Items/:id".
+ * Stable across users and items, so it can key grouping and dedupe without
+ * carrying the user's server address or what they were looking at.
+ */
+export const templateRequestPath = (url: string | undefined): string => {
+  if (!url) return "?";
+  const path = url
+    .replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i, "")
+    .split(/[?#]/)[0];
+  return path
+    .split("/")
+    .map((segment) => {
+      if (segment === "") return segment;
+      if (ID_SEGMENT.test(segment)) return ":id";
+      if (!ROUTE_WORD.test(segment)) return ":param";
+      return segment;
+    })
+    .join("/");
+};
+
+export type HttpErrorDescription = {
+  method: string;
+  path: string;
+  status: number;
+};
+
+/**
+ * The route-level identity of a failed HTTP request, for grouping: an
+ * AxiosError is constructed inside axios, so its stack trace has no app
+ * frames and Sentry would otherwise file every HTTP failure in the app — any
+ * endpoint, any status, any call site — under one issue. Null when the
+ * error isn't an HTTP response (not axios, or no response at all).
+ */
+export const describeHttpError = (
+  error: unknown,
+): HttpErrorDescription | null => {
+  if (!isAxiosError(error) || !error.response) return null;
+  return {
+    method: (error.config?.method ?? "?").toUpperCase(),
+    path: templateRequestPath(error.config?.url),
+    status: error.response.status,
+  };
+};
+
+const MAX_RESPONSE_BODY_CHARS = 200;
+
+/**
+ * What the server said about a rejected request — enough to tell a Jellyfin
+ * rejection apart from a proxy one: Jellyfin answers with a text/plain
+ * reason ("Session not found.") and `Server: Kestrel`; proxies answer with
+ * their own Server header and an HTML page. The body is only kept when it is
+ * plain text or JSON, and truncated: an HTML error page can embed the proxy's
+ * hostname, which is the user's private server address.
+ */
+export const describeHttpResponse = (
+  error: unknown,
+): Record<string, unknown> | undefined => {
+  if (!isAxiosError(error) || !error.response) return undefined;
+  const headers = error.response.headers ?? {};
+  const contentType = headers["content-type"];
+  const server = headers.server;
+  let body: string | undefined;
+  if (
+    /^(?:text\/plain|application\/(?:problem\+)?json)/i.test(
+      String(contentType ?? ""),
+    )
+  ) {
+    const data = error.response.data;
+    try {
+      body = typeof data === "string" ? data : JSON.stringify(data);
+    } catch {
+      body = undefined;
+    }
+    body = body?.slice(0, MAX_RESPONSE_BODY_CHARS);
+  }
+  return {
+    status: error.response.status,
+    contentType: contentType ? String(contentType) : undefined,
+    server: server ? String(server) : undefined,
+    body,
+  };
+};

--- a/utils/log.tsx
+++ b/utils/log.tsx
@@ -5,6 +5,7 @@ import { atomWithStorage, createJSONStorage } from "jotai/utils";
 import type React from "react";
 import { createContext, useContext } from "react";
 import {
+  describeHttpError,
   isAbortLikeError,
   isConnectivityError,
   markErrorReported,
@@ -141,14 +142,20 @@ const describeErrorForLog = (error: unknown): unknown => {
   return error;
 };
 
+// One Sentry event per (call site, endpoint, status) per session. A failing
+// endpoint is hit again by every keystroke in search and by every screen that
+// mounts the same request, and the Nth repeat says nothing the first didn't.
+const reportedHttpErrors = new Set<string>();
+const MAX_REPORTED_HTTP_ERRORS = 200;
+
 /**
  * Records a failure both in the local log and as a Sentry exception — the
  * ONLY path that turns handled errors into Sentry events. Prefer it over
  * writeErrorLog when the caught error object is available.
  *
- * Connectivity failures (aborted requests, no HTTP response) stay in the
- * local log but are never sent: an unreachable server is the user's
- * environment, not an app bug.
+ * Connectivity failures (aborted requests, no HTTP response, gateway errors)
+ * stay in the local log but are never sent: an unreachable server is the
+ * user's environment, not an app bug.
  *
  * `context` is SENT to Sentry (after URL scrubbing), so pass only curated
  * values (codecs, status codes, item IDs) — never raw payloads or settings
@@ -166,9 +173,32 @@ export const logAndCaptureError = (
   // If this error is later rethrown into React Query, the global handler in
   // app/_layout.tsx must not report it again.
   markErrorReported(error);
+  const http = describeHttpError(error);
+  if (http) {
+    const key = [message, http.method, http.path, http.status].join("|");
+    if (reportedHttpErrors.has(key)) {
+      return;
+    }
+    if (reportedHttpErrors.size < MAX_REPORTED_HTTP_ERRORS) {
+      reportedHttpErrors.add(key);
+    }
+  }
   Sentry.withScope((scope) => {
     if (context) {
       scope.setContext("details", context);
+    }
+    if (http) {
+      // An AxiosError's stack has no app frames (it is built inside axios),
+      // so left to Sentry every HTTP failure in the app lands in ONE issue.
+      // Group by what actually separates them: which call failed, to which
+      // route, with which status.
+      scope.setContext("http", http);
+      scope.setFingerprint([
+        message,
+        http.method,
+        http.path,
+        String(http.status),
+      ]);
     }
     if (error instanceof Error) {
       scope.setExtra("log_message", message);


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Fingerprint axios errors in Sentry by call site, method, route and status instead of the stack trace. An AxiosError is created inside axios, so its stack has no app frames. Sentry was putting every HTTP failure in the app into one issue. REACT-NATIVE-9 had 404s from session capabilities, 502s from someone's proxy and a 405 from an http to https redirect, 56 events over 15 users.

Also in here:
- 502/503/504 are treated like connectivity errors and not sent. The proxy answered but Jellyfin didn't, so that's the user's setup.
- One event per call site, route and status per session. Search was sending one per keystroke while a server was down.
- The session capabilities failure now includes content type, Server header and a short text body. That should tell us if the 404 is Jellyfin saying "Session not found" or a proxy blocking the POST. I couldn't tell from the existing events.

Routes are reduced to their shape (ids and free text replaced) so nothing identifying leaves the app. Same rules as #1978.

JS only, not device tested yet. Unit tests cover the new helpers.

## 🏷️ Ticket / Issue

Fixes [REACT-NATIVE-9](https://streamyfin.sentry.io/issues/REACT-NATIVE-9)

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. `bun test utils/errors.test.ts`
2. Use a TestFlight or production build (dev builds don't report since #1991). Trigger an HTTP failure, for example search while Jellyfin is down behind a proxy (502), or connect to a server that rejects `POST /Sessions/Capabilities/Full`.
3. In Sentry, the 502s should not show up at all. Other statuses land in their own issue per route and status with an `http` context. Repeating the same failure in one session doesn't add events.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification for gateway and connectivity failures.
  * Reduced duplicate error reports for repeated HTTP failures.
  * Enhanced error details with normalized request paths, status codes, and safe response information.
  * Continued suppressing routine authentication errors during session-capability checks.

* **Tests**
  * Added comprehensive coverage for HTTP error classification, path normalization, response sanitization, and truncated error content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->