### PR TITLE
fix(hero-carousel): don't measure the Compose hero without a window

### DIFF
--- a/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselView.kt
+++ b/modules/hero-carousel/android/src/main/java/expo/modules/herocarousel/HeroCarouselView.kt
@@ -76,8 +76,72 @@ class HeroCarouselExpoView(context: Context, appContext: AppContext) :
   }
 
   // React Native does not re-layout a native view when it calls
-  // `requestLayout` itself, which Compose does whenever its content resizes.
-  override val shouldUseAndroidLayout = true
+  // `requestLayout` itself, which Compose does whenever its content resizes,
+  // so the relayout has to be posted by hand. `shouldUseAndroidLayout = true`
+  // is expo-modules-core's version of exactly that, but it posts the
+  // runnable unconditionally: Compose calls `requestLayout` on its way down
+  // too, so passes stay queued for a view React Native has already dropped,
+  // and a burst of them within one frame measures the whole Compose tree
+  // once per call. Owning the post keeps that to one pass per frame and
+  // drops it once the view is gone.
+  //
+  // Dropping a pass costs nothing: this view's bounds come from Yoga and
+  // cannot change while React Native is not laying it out, and Compose
+  // re-runs its own measure and layout from `dispatchDraw` when it is next
+  // drawn. What keeps a stray pass from being fatal is `onMeasure` below.
+  override val shouldUseAndroidLayout = false
+
+  private var disposed = false
+  private var relayoutPending = false
+
+  override fun requestLayout() {
+    super.requestLayout()
+    if (relayoutPending) {
+      return
+    }
+    relayoutPending = true
+    post {
+      // Cleared first, so a `requestLayout` that the pass itself provokes
+      // schedules the next one rather than being swallowed.
+      relayoutPending = false
+      if (!disposed && isAttachedToWindow) {
+        measureAndLayout()
+      }
+    }
+  }
+
+  /**
+   * Measures to the size React Native asked for without touching the Compose
+   * subtree while this view has no window.
+   *
+   * React Native measures every mounted view with the exact size Yoga gave
+   * it (`SurfaceMountingManager.updateLayout`), attached to a window or not.
+   * That is fatal for a ComposeView: `AbstractComposeView.onMeasure` creates
+   * the composition on first measure, and creating one has to find the
+   * window recomposer. Switching the hero back on from the appearance
+   * settings mounts it into the Home screen while react-native-screens has
+   * that screen detached behind the settings screen, so the measure lands
+   * with no window and throws `IllegalStateException: Cannot locate
+   * windowRecomposer`. The same throw ends a pass that arrives after the
+   * view has already been dropped.
+   *
+   * React Native's comment on that call allows exactly this: a view may stub
+   * `onMeasure` out to nothing more than `setMeasuredDimension`. Skipping it
+   * costs nothing, since `AbstractComposeView` also creates its composition
+   * from `onAttachedToWindow` and lays out once it has. ComposeView is final
+   * and so is its `onMeasure`, so the guard sits here and keeps the measure
+   * from reaching the child at all.
+   */
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    if (!isAttachedToWindow) {
+      setMeasuredDimension(
+        getDefaultSize(suggestedMinimumWidth, widthMeasureSpec),
+        getDefaultSize(suggestedMinimumHeight, heightMeasureSpec)
+      )
+      return
+    }
+    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+  }
 
   init {
     // Card shadows and the scaled neighbour cards draw outside our bounds.
@@ -103,6 +167,7 @@ class HeroCarouselExpoView(context: Context, appContext: AppContext) :
    * otherwise the Activity's lifecycle observer keeps this view alive.
    */
   fun dispose() {
+    disposed = true
     composeView.setViewCompositionStrategy(
       ViewCompositionStrategy.DisposeOnDetachedFromWindow
     )


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Stop the Android hero carousel from measuring its Compose view while that view has no window. Switching the hero off and back on crashed the app with `IllegalStateException: Cannot locate windowRecomposer`. `AbstractComposeView` creates its composition on first measure, and creating one has to find the window recomposer, so any measure without a window is fatal.

Two different measures were doing it. Switching the hero on mounts it into the Home screen while react-native-screens holds that screen detached behind the settings screen, and React Native measures every mounted view with the exact size Yoga gave it (`SurfaceMountingManager.updateLayout`) whether it is attached or not. Switching it off leaves a relayout queued, since `shouldUseAndroidLayout = true` is expo-modules-core posting `measureAndLayout()` on every `requestLayout`, and Compose calls `requestLayout` on its way down.

So `onMeasure` now reports the size it was asked for and leaves the Compose subtree alone when there is no window (ComposeView and its `onMeasure` are both final, so the guard sits on the ExpoView). Nothing is lost by waiting, `AbstractComposeView` creates its composition from `onAttachedToWindow` too. I also took the posted relayout off expo and queue it myself, so it can skip a view that has been dropped.

## 🏷️ Ticket / Issue

Sentry [REACT-NATIVE-D](https://streamyfin.sentry.io/issues/REACT-NATIVE-D), Android only. Follow-up to #1983.

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

Needs a full Android rebuild, a Metro reload won't pick up a Kotlin change.

1. Settings > Appearance, switch the hero on, then go back to Home. On develop the app dies here.
2. On Home, tap the hero's filter button, then Disable. On develop the app dies here too.
3. Switch tabs away from Home and back a few times. The hero should keep rendering and paging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hero Carousel layout updates on Android.
  * Prevented unnecessary layout work when the carousel is detached or being disposed.
  * Coalesced layout requests to improve rendering stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->