### PR TITLE
feat(settings): read the settings the server resolved for this user

### DIFF
--- a/augmentations/api.ts
+++ b/augmentations/api.ts
@@ -1,6 +1,7 @@
 import { Api, AUTHORIZATION_HEADER } from "@jellyfin/sdk";
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
-import type { StreamyfinPluginConfig } from "@/utils/atoms/settings";
+import type { PluginLockableSettings } from "@/utils/atoms/settings";
+import { fetchPluginSettings } from "@/utils/pluginSettingsSource";
 
 declare module "@jellyfin/sdk" {
   interface Api {
@@ -17,7 +18,7 @@ declare module "@jellyfin/sdk" {
       url: string,
       config?: AxiosRequestConfig<D>,
     ): Promise<AxiosResponse<T>>;
-    getStreamyfinPluginConfig(): Promise<AxiosResponse<StreamyfinPluginConfig>>;
+    getStreamyfinPluginSettings(): Promise<PluginLockableSettings | undefined>;
   }
 }
 
@@ -52,8 +53,8 @@ Api.prototype.delete = function <T, D = any>(
   });
 };
 
-Api.prototype.getStreamyfinPluginConfig = function (): Promise<
-  AxiosResponse<StreamyfinPluginConfig>
+Api.prototype.getStreamyfinPluginSettings = function (): Promise<
+  PluginLockableSettings | undefined
 > {
-  return this.get<StreamyfinPluginConfig>("/Streamyfin/config");
+  return fetchPluginSettings(this);
 };

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -877,22 +877,19 @@ export const useSettings = () => {
         applied,
         normalizePluginValue,
       );
-      const enableStreamystats =
-        newPluginSettings.streamyStatsServerUrl?.value &&
-        _settings.searchEngine !== "Streamystats";
-
-      if (Object.keys(pending).length > 0 || enableStreamystats) {
+      // Only what the admin declared is applied here. An admin who wants to
+      // impose a search engine declares searchEngine, locked to impose it or
+      // unlocked to propose it, like any other setting. Inferring it from a
+      // Streamystats URL took the choice away without saying so.
+      if (Object.keys(pending).length > 0) {
         const newSettings = {
           ...defaultValues,
           ..._settings,
           ...pending,
-          ...(enableStreamystats ? { searchEngine: "Streamystats" } : {}),
         } as Settings;
         setSettings(newSettings);
         saveSettings(newSettings);
-        if (Object.keys(pending).length > 0) {
-          storage.setAny(PLUGIN_APPLIED_DEFAULTS, { ...applied, ...pending });
-        }
+        storage.setAny(PLUGIN_APPLIED_DEFAULTS, { ...applied, ...pending });
       }
     }
 

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -861,12 +861,21 @@ export const useSettings = () => {
     if (!api) {
       return;
     }
-    const newPluginSettings = await api.getStreamyfinPluginSettings().then(
-      (settings) => {
-        writeInfoLog("Got plugin settings", redactPluginSettings(settings));
-        return settings;
-      },
-      (_err) => undefined,
+    let newPluginSettings: PluginLockableSettings | undefined;
+    try {
+      newPluginSettings = await api.getStreamyfinPluginSettings();
+    } catch (error) {
+      // A server that cannot be reached has not said it has no plugin. This
+      // runs on every foreground, so overwriting the stored policy here would
+      // unlock every setting the admin pinned and drop the URLs they supplied
+      // on nothing worse than a flaky network. Keep what is stored and report
+      // the failure, which is what the plugins page turns into a toast.
+      logAndCaptureError("Refreshing plugin settings failed", error);
+      return undefined;
+    }
+    writeInfoLog(
+      "Got plugin settings",
+      redactPluginSettings(newPluginSettings),
     );
     setPluginSettings(newPluginSettings);
 

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -861,13 +861,10 @@ export const useSettings = () => {
     if (!api) {
       return;
     }
-    const newPluginSettings = await api.getStreamyfinPluginConfig().then(
-      ({ data }) => {
-        writeInfoLog(
-          "Got plugin settings",
-          redactPluginSettings(data?.settings),
-        );
-        return data?.settings;
+    const newPluginSettings = await api.getStreamyfinPluginSettings().then(
+      (settings) => {
+        writeInfoLog("Got plugin settings", redactPluginSettings(settings));
+        return settings;
       },
       (_err) => undefined,
     );

--- a/utils/pluginSettingsSource.test.ts
+++ b/utils/pluginSettingsSource.test.ts
@@ -78,10 +78,23 @@ describe("fetchPluginSettings", () => {
     expect(asked).toEqual([RESOLVED_SETTINGS_PATH]);
   });
 
-  test("surfaces a server with no plugin at all rather than inventing an answer", async () => {
-    const { api } = server({});
+  test("a server with no plugin has answered: there is no policy to apply", async () => {
+    const { api, asked } = server({});
 
-    await expect(fetchPluginSettings(api)).rejects.toThrow("HTTP 404");
+    expect(await fetchPluginSettings(api)).toBeUndefined();
+    expect(asked).toEqual([RESOLVED_SETTINGS_PATH, LEGACY_CONFIG_PATH]);
+  });
+
+  test("a server that cannot be reached has not said it has no plugin", async () => {
+    // The two must not look the same to the caller. Refreshing runs on every
+    // foreground, so treating a flaky network as "no plugin here" would unlock
+    // every setting the admin pinned until the next successful refresh.
+    const { api } = server({
+      [RESOLVED_SETTINGS_PATH]: httpError(404),
+      [LEGACY_CONFIG_PATH]: httpError(503),
+    });
+
+    await expect(fetchPluginSettings(api)).rejects.toThrow("HTTP 503");
   });
 
   test("treats a configuration with no settings block as nothing to apply", async () => {

--- a/utils/pluginSettingsSource.test.ts
+++ b/utils/pluginSettingsSource.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import type { PluginLockableSettings, Settings } from "@/utils/atoms/settings";
+import {
+  pendingPluginDefaults,
+  resolveEffectiveSettings,
+} from "@/utils/atoms/settingsOverrides";
+import {
+  fetchPluginSettings,
+  LEGACY_CONFIG_PATH,
+  type PluginSettingsReader,
+  RESOLVED_SETTINGS_PATH,
+} from "@/utils/pluginSettingsSource";
+
+const plugin = (
+  entries: Record<string, { locked: boolean; value: unknown }>,
+): PluginLockableSettings => entries as unknown as PluginLockableSettings;
+
+/** An axios rejection, which is the only thing that identifies an absent route. */
+const httpError = (status: number) =>
+  Object.assign(new Error(`HTTP ${status}`), { response: { status } });
+
+/**
+ * A server that answers the paths it is given and rejects with 404 for the rest,
+ * recording what was asked so the order can be asserted.
+ */
+const server = (routes: Record<string, unknown>) => {
+  const asked: string[] = [];
+  const api: PluginSettingsReader = {
+    get: async <T>(url: string) => {
+      asked.push(url);
+      if (!(url in routes)) throw httpError(404);
+      const answer = routes[url];
+      if (answer instanceof Error) throw answer;
+      return { data: answer as T };
+    },
+  };
+  return { api, asked };
+};
+
+const resolvedSettings = plugin({
+  subtitleSize: { locked: true, value: 120 },
+  marlinServerUrl: { locked: false, value: "https://marlin.example" },
+});
+
+describe("fetchPluginSettings", () => {
+  test("asks the server what applies to this user", async () => {
+    const { api, asked } = server({
+      [RESOLVED_SETTINGS_PATH]: resolvedSettings,
+      [LEGACY_CONFIG_PATH]: { settings: plugin({}) },
+    });
+
+    expect(await fetchPluginSettings(api)).toEqual(resolvedSettings);
+    // The stored configuration is never asked for when the server can resolve.
+    expect(asked).toEqual([RESOLVED_SETTINGS_PATH]);
+  });
+
+  test("falls back to the stored configuration on a plugin too old to resolve", async () => {
+    // Every published plugin is this one today, so the fallback is the normal
+    // path rather than an edge case.
+    const { api, asked } = server({
+      [LEGACY_CONFIG_PATH]: { settings: resolvedSettings },
+    });
+
+    expect(await fetchPluginSettings(api)).toEqual(resolvedSettings);
+    expect(asked).toEqual([RESOLVED_SETTINGS_PATH, LEGACY_CONFIG_PATH]);
+  });
+
+  test("does not fall back when the request failed for another reason", async () => {
+    // A server that is down or a token that expired fails the same way on the
+    // old path. Asking twice only doubles the wait before the same failure, and
+    // treating it as an old server would hide a real one.
+    const { api, asked } = server({
+      [RESOLVED_SETTINGS_PATH]: httpError(401),
+      [LEGACY_CONFIG_PATH]: { settings: resolvedSettings },
+    });
+
+    await expect(fetchPluginSettings(api)).rejects.toThrow("HTTP 401");
+    expect(asked).toEqual([RESOLVED_SETTINGS_PATH]);
+  });
+
+  test("surfaces a server with no plugin at all rather than inventing an answer", async () => {
+    const { api } = server({});
+
+    await expect(fetchPluginSettings(api)).rejects.toThrow("HTTP 404");
+  });
+
+  test("treats a configuration with no settings block as nothing to apply", async () => {
+    const { api } = server({ [LEGACY_CONFIG_PATH]: {} });
+
+    expect(await fetchPluginSettings(api)).toBeUndefined();
+  });
+});
+
+describe("what the endpoints have in common", () => {
+  // The reason switching endpoints is safe: both answer with the same map of
+  // key -> { locked, value }, so locked pins a value and unlocked seeds a
+  // default once, whichever one answered. A server that started resolving must
+  // not change what any of that means.
+  const defaults = { subtitleSize: 80, marlinServerUrl: "" } as Settings;
+  const identity = (_key: keyof Settings, value: unknown) => value;
+
+  test("either endpoint feeds the same locked and unlocked rules", async () => {
+    const fromResolved = await fetchPluginSettings(
+      server({ [RESOLVED_SETTINGS_PATH]: resolvedSettings }).api,
+    );
+    const fromLegacy = await fetchPluginSettings(
+      server({ [LEGACY_CONFIG_PATH]: { settings: resolvedSettings } }).api,
+    );
+
+    expect(fromResolved).toEqual(fromLegacy!);
+
+    for (const settings of [fromResolved, fromLegacy]) {
+      const effective = resolveEffectiveSettings(
+        { subtitleSize: 100 },
+        settings,
+        defaults,
+        identity,
+      );
+      // Locked pins, over a value the user holds.
+      expect(effective.subtitleSize).toBe(120);
+      // Unlocked only fills a gap, and seeds storage once.
+      expect(effective.marlinServerUrl).toBe("https://marlin.example");
+      expect(pendingPluginDefaults(settings, {}, identity)).toEqual({
+        marlinServerUrl: "https://marlin.example",
+      } as Partial<Settings>);
+    }
+  });
+});

--- a/utils/pluginSettingsSource.ts
+++ b/utils/pluginSettingsSource.ts
@@ -1,0 +1,85 @@
+/**
+ * Where the Streamyfin plugin's settings come from.
+ *
+ * The plugin serves two endpoints and the difference between them is the whole
+ * point of asking the right one:
+ *
+ * - `v1/config/resolved` answers with what applies to *this* caller. The server
+ *   merges its three targeting levels (what it declares for everyone, then the
+ *   caller's groups, then anything aimed at that account alone) and removes the
+ *   credentials on the way out.
+ * - `config` answers with what the server *stores*. An administrator gets the
+ *   global configuration raw and unresolved, on purpose: the admin pages save
+ *   what they load, so serving a resolved view there would write one admin's own
+ *   group overrides back into everybody's configuration.
+ *
+ * The app consumes settings, it never edits them, so it wants the first one.
+ * Reading the second gave an administrator who belongs to a targeted group the
+ * values the server stores rather than the ones aimed at them, and gave every
+ * other account the resolved set only as a side effect of the server filtering
+ * its answer.
+ *
+ * No published plugin serves `v1/config/resolved` yet, so the fallback below is
+ * the normal path today rather than an edge case, and stays correct afterwards:
+ * `config` keeps working, it is just the wrong question.
+ */
+import type {
+  PluginLockableSettings,
+  StreamyfinPluginConfig,
+} from "@/utils/atoms/settings";
+
+/** What applies to the caller, resolved and redacted by the server. */
+export const RESOLVED_SETTINGS_PATH = "/Streamyfin/v1/config/resolved";
+
+/** What the server stores. Older plugins serve only this. */
+export const LEGACY_CONFIG_PATH = "/Streamyfin/config";
+
+/**
+ * The slice of the Jellyfin `Api` this needs.
+ *
+ * Narrow on purpose: the policy below is the part worth testing, and a full
+ * `Api` cannot be built without a server.
+ */
+export interface PluginSettingsReader {
+  get<T>(url: string): Promise<{ data: T }>;
+}
+
+/**
+ * A route the server does not serve, which is how a plugin too old to resolve
+ * anything identifies itself.
+ */
+const isMissingRoute = (error: unknown): boolean =>
+  (error as { response?: { status?: number } } | undefined)?.response
+    ?.status === 404;
+
+/**
+ * The settings that apply to the signed-in user, whatever the server's age.
+ *
+ * Both endpoints answer with the same map of `key -> { locked, value }`, so
+ * which one answered changes nothing downstream: locked still pins a value,
+ * unlocked still seeds a default once, and an absent key still leaves the user
+ * alone.
+ *
+ * @throws whatever the request failed with, when it failed for any reason other
+ * than the route being absent.
+ */
+export const fetchPluginSettings = async (
+  api: PluginSettingsReader,
+): Promise<PluginLockableSettings | undefined> => {
+  try {
+    const { data } = await api.get<PluginLockableSettings>(
+      RESOLVED_SETTINGS_PATH,
+    );
+    return data ?? undefined;
+  } catch (error) {
+    // Only a missing route means "older plugin". A server that is down or a
+    // token that expired would fail the same way on the old path, and asking
+    // it there as well only doubles the wait before the same failure.
+    if (!isMissingRoute(error)) {
+      throw error;
+    }
+  }
+
+  const { data } = await api.get<StreamyfinPluginConfig>(LEGACY_CONFIG_PATH);
+  return data?.settings ?? undefined;
+};

--- a/utils/pluginSettingsSource.ts
+++ b/utils/pluginSettingsSource.ts
@@ -60,8 +60,12 @@ const isMissingRoute = (error: unknown): boolean =>
  * unlocked still seeds a default once, and an absent key still leaves the user
  * alone.
  *
- * @throws whatever the request failed with, when it failed for any reason other
- * than the route being absent.
+ * Returns `undefined` for a server that serves neither route, which is a server
+ * without the plugin. That is an answer: there is no policy to apply.
+ *
+ * @throws whatever the request failed with, for anything else. A server that
+ * cannot be reached has not told the caller it has no plugin, and the two must
+ * not look the same to whoever decides what to keep.
  */
 export const fetchPluginSettings = async (
   api: PluginSettingsReader,
@@ -80,6 +84,13 @@ export const fetchPluginSettings = async (
     }
   }
 
-  const { data } = await api.get<StreamyfinPluginConfig>(LEGACY_CONFIG_PATH);
-  return data?.settings ?? undefined;
+  try {
+    const { data } = await api.get<StreamyfinPluginConfig>(LEGACY_CONFIG_PATH);
+    return data?.settings ?? undefined;
+  } catch (error) {
+    if (!isMissingRoute(error)) {
+      throw error;
+    }
+    return undefined;
+  }
 };


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

The Streamyfin plugin serves two settings endpoints and the app was reading the wrong one.

`config` is what the server **stores**. It answers an administrator with the global configuration raw and unresolved, on purpose: the admin pages save what they load, so a resolved view there would write one admin's own group overrides back into everybody's configuration. `v1/config/resolved` is what **applies to the caller**, merged across the plugin's three targeting levels (global, groups, per user) with the credentials removed.

The app consumes settings, it never edits them, so it wants the second one. Today an administrator who belongs to a targeted group gets the stored values instead of the ones aimed at them, and every other account gets the resolved set only as a side effect of the server filtering its answer.

Three changes, one per commit.

**Read the resolved endpoint, and tolerate a server that does not serve it.** No published plugin has that route yet, so the fallback to `config` is the normal path today rather than an edge case. Only a missing route counts as an old server: a server that is down or a token that expired fails the same way on the old path, so asking twice would just double the wait before the same failure, and treating it as an old plugin would hide a real problem. The fetch policy lives in `utils/pluginSettingsSource.ts` with the `Api` narrowed to the one method it needs, so it is testable without a server.

Both endpoints answer with the same map of key to `{ locked, value }`, so nothing downstream changes. A test pins that, because it is the reason the switch is safe: locked still pins a value, unlocked still seeds a default once, an absent key still leaves the user alone.

**Stop inferring the search engine from a Streamystats URL.** An admin who declared `streamyStatsServerUrl` also forced `searchEngine` to Streamystats, on every refresh, through a rule written into the settings loading path and declared nowhere. A user who turned "use for search" off on the Streamystats page got it back on the next refresh, which on a foregrounded app is a few seconds later, so the toggle looked broken rather than overruled. It also contradicted the plugin, whose `DefaultConfig()` declares `searchEngine` as Jellyfin.

Nothing is lost: `searchEngine` is already a lockable plugin setting, so an admin who wants Streamystats search locks it to impose it or leaves it unlocked to propose it as a starting value. **This is visible to admins who relied on the inference**: they have to declare the setting now, and until they do, their users' search goes back to Jellyfin.

**Keep the admin's policy when the server cannot be reached.** Refreshing mapped every failure to "no settings", and it runs on every foreground. Open the app on a flaky network and the stored policy was overwritten with nothing: locked settings became editable, and the URLs the admin supplied for Jellyseerr, Marlin and Streamystats disappeared, taking the features behind them with them. Only a server that answers 404 on both routes has actually said it has no plugin, and that one still clears the policy the way it always did. Signing out still clears it explicitly, which is where that belongs.

## 🏷️ Ticket / Issue

Part P2 of streamyfin/jellyfin-plugin-streamyfin#114, the plugin rewrite. The server side it consumes is P1, already merged on the plugin's `develop`.

Not fixed here: streamyfin/jellyfin-plugin-streamyfin#69. Hiding a section built on a library the user cannot see needs the plugin to filter sections by library access, which the resolution does not do yet.

### 🖼️ Screenshots / GIFs (if UI)

N/A, no UI change. The settings screens render exactly what they rendered before, from a better source.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

`bun run typecheck`, `bun run lint`, `bun run format` and `bun run i18n:check` are clean. `bun run test:unit` is 266 passing, 7 of them new.

The endpoint behaviour was checked against two real servers rather than read off the plugin source:

| Server | `v1/config/resolved` | `config` |
|---|---|---|
| Jellyfin 12, plugin built from the rewrite branch | 200 | 200 |
| Jellyfin 10.11.11, published plugin 0.68.1.0 | 404 | 200 |

Running `fetchPluginSettings` against both returned the same shape from each, and a base URL with no plugin behind it returned nothing to apply rather than throwing. On a real non-admin account the resolved endpoint carried neither `jellyseerrApiKey` nor the notification block.

On a device:

1. **An old server, which is every published one today.** Sign in against a server running the released plugin. The settings arrive as before, an admin-locked setting still shows greyed out, and a URL the admin supplied is still pre-filled.
2. **A new server.** Sign in against a server running the rewrite branch. Same result for a normal account. On an **administrator** account that belongs to a group with an override, the app now shows the group's value rather than the global one, which is the regression this fixes and only shows on an admin.
3. **The server going away.** Sign in, confirm a locked setting is greyed out, turn on airplane mode, background the app and come back. The setting stays greyed out and the admin's URLs are still there. Before this, both vanished.
4. **The search engine.** On a server where the admin set `streamyStatsServerUrl` without locking `searchEngine`, turn "use for search" off on the Streamystats page and save, then background the app and come back. The choice sticks. Locking `searchEngine` to Streamystats on the plugin greys the row and imposes it.
5. **The refresh button.** Settings, Plugins, "refresh from server" still toasts success, and on an unreachable server it toasts failure without changing what is displayed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving resolved plugin settings, with automatic fallback to legacy configuration endpoints.
  * Plugin settings now support locked values and controlled default settings.

* **Bug Fixes**
  * Preserved existing settings when servers are unreachable or refresh requests fail.
  * Improved handling of unavailable plugins and configuration errors.
  * Prevented search engine defaults from being inferred solely from a configured service URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->