### PR TITLE
fix(network): give the Jellyfin api its own axios instance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ bun run ios:install-metal-toolchain   # Fixes "missing Metal Toolchain" build er
 | `plugins/` | Expo config plugins |
 | `patches/` | Patch package overrides |
 | `augmentations/` | Type augmentations |
-| `test-utils/` | Shared test doubles for the Jellyfin API and React Native |
+| `test-utils/` | Shared test doubles: Jellyfin API, MMKV, custom headers, React Native |
 | `translations/` | i18n catalogues, `en.json` is the only source |
 | `scripts/` | Repo tooling run through bun |
 | `docs/` | Conventions and deep dives |

--- a/app/(auth)/(tabs)/(home)/sessions/index.tsx
+++ b/app/(auth)/(tabs)/(home)/sessions/index.tsx
@@ -8,6 +8,7 @@ import {
 import { getSessionApi } from "@jellyfin/sdk/lib/utils/api/session-api";
 import { FlashList } from "@shopify/flash-list";
 import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
 import { useAtomValue } from "jotai";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -103,12 +104,15 @@ const SessionCard = ({ session }: SessionCardProps) => {
     queryKey: ["ipinfo", session.RemoteEndPoint],
     staleTime: Number.POSITIVE_INFINITY,
     queryFn: async () => {
-      const resp = await api!.axiosInstance.get(
+      // Plain axios, never `api.axiosInstance`: freeipapi is a third party, and
+      // the Jellyfin instance stamps the server's gateway credentials onto every
+      // request it carries and reads any 401 back as the session having expired.
+      const resp = await axios.get(
         `https://freeipapi.com/api/json/${session.RemoteEndPoint}`,
       );
       return resp.data;
     },
-    enabled: !!api,
+    enabled: !!session.RemoteEndPoint,
   });
 
   // Handle session controls

--- a/providers/Downloads/additionalDownloads.test.ts
+++ b/providers/Downloads/additionalDownloads.test.ts
@@ -25,6 +25,9 @@ mock.module("@/utils/customHeaders", () => ({
   optionsWithOptionalHeaders,
   // No proxy headers configured in these specs.
   getJellyfinHeadersForUrl: () => undefined,
+  // Unused here, but the mock is global: another spec's module can be
+  // re-linked to this one and would otherwise lose the resolver.
+  getJellyfinHeaders: () => ({}),
 }));
 mock.module("@/providers/JellyfinProvider", () => ({
   apiAtom: atom<Api | null>(null),

--- a/providers/Downloads/additionalDownloads.test.ts
+++ b/providers/Downloads/additionalDownloads.test.ts
@@ -5,9 +5,8 @@ import type {
   MediaSourceInfo,
 } from "@jellyfin/sdk/lib/generated-client/models";
 import { atom } from "jotai";
+import { stubCustomHeaders } from "@/test-utils/customHeaders";
 import { stubReactNative } from "@/test-utils/reactNative";
-import { normalizeCustomHeaders } from "@/utils/customHeaders/normalize";
-import { optionsWithOptionalHeaders } from "@/utils/customHeaders/optionalHeaders";
 
 // --- Module-boundary stubs (React Native / Expo can't load under bun:test) ---
 stubReactNative();
@@ -16,19 +15,7 @@ mock.module("expo", () => ({
   requireOptionalNativeModule: () => null,
 }));
 mock.module("@/components/BitrateSelector", () => ({}));
-// The custom-header barrel re-exports modules with native dependencies (MMKV,
-// SecureStore). Replace it with the real pure helpers plus a resolver stub —
-// mock.module is global, so the shape has to stay compatible with the other
-// specs that stub this same barrel (utils/jellyfin/checkServer.test.ts).
-mock.module("@/utils/customHeaders", () => ({
-  normalizeCustomHeaders,
-  optionsWithOptionalHeaders,
-  // No proxy headers configured in these specs.
-  getJellyfinHeadersForUrl: () => undefined,
-  // Unused here, but the mock is global: another spec's module can be
-  // re-linked to this one and would otherwise lose the resolver.
-  getJellyfinHeaders: () => ({}),
-}));
+stubCustomHeaders();
 mock.module("@/providers/JellyfinProvider", () => ({
   apiAtom: atom<Api | null>(null),
 }));

--- a/providers/Downloads/additionalDownloads.test.ts
+++ b/providers/Downloads/additionalDownloads.test.ts
@@ -5,7 +5,10 @@ import type {
   MediaSourceInfo,
 } from "@jellyfin/sdk/lib/generated-client/models";
 import { atom } from "jotai";
-import { stubCustomHeaders } from "@/test-utils/customHeaders";
+import {
+  setJellyfinHeaders,
+  stubCustomHeaders,
+} from "@/test-utils/customHeaders";
 import { stubReactNative } from "@/test-utils/reactNative";
 
 // --- Module-boundary stubs (React Native / Expo can't load under bun:test) ---
@@ -16,6 +19,9 @@ mock.module("expo", () => ({
 }));
 mock.module("@/components/BitrateSelector", () => ({}));
 stubCustomHeaders();
+// No proxy headers in these specs, set per test so another file cannot
+// leave its own behind.
+beforeEach(() => setJellyfinHeaders());
 mock.module("@/providers/JellyfinProvider", () => ({
   apiAtom: atom<Api | null>(null),
 }));

--- a/test-utils/customHeaders.ts
+++ b/test-utils/customHeaders.ts
@@ -2,9 +2,16 @@ import { mock } from "bun:test";
 import { normalizeCustomHeaders } from "@/utils/customHeaders/normalize";
 import { optionsWithOptionalHeaders } from "@/utils/customHeaders/optionalHeaders";
 
-type Overrides = {
-  /** Proxy auth headers configured for the Jellyfin server, if any. */
-  jellyfinHeaders?: Record<string, string>;
+let jellyfinHeaders: Record<string, string> = {};
+
+/**
+ * Sets the proxy auth headers the stub reports. Call it from a spec's
+ * `beforeEach`, not once at load: `mock.module` re-links every importer, so the
+ * last registration to run decides what a value captured at registration would
+ * be, and file order is not ours to choose.
+ */
+export const setJellyfinHeaders = (headers: Record<string, string> = {}) => {
+  jellyfinHeaders = headers;
 };
 
 /**
@@ -18,13 +25,13 @@ type Overrides = {
  * file links after it, and CI orders the files differently than a local run
  * does, so the break shows up there and not here.
  */
-export const stubCustomHeaders = (overrides: Overrides = {}) =>
+export const stubCustomHeaders = () =>
   mock.module("@/utils/customHeaders", () => ({
     normalizeCustomHeaders,
     optionsWithOptionalHeaders,
-    getJellyfinHeaders: () => overrides.jellyfinHeaders ?? {},
+    // Read through the binding rather than captured: a spec sets what it needs
+    // in beforeEach, so a later registration cannot decide it retroactively.
+    getJellyfinHeaders: () => jellyfinHeaders,
     getJellyfinHeadersForUrl: () =>
-      overrides.jellyfinHeaders && Object.keys(overrides.jellyfinHeaders).length
-        ? overrides.jellyfinHeaders
-        : undefined,
+      Object.keys(jellyfinHeaders).length ? jellyfinHeaders : undefined,
   }));

--- a/test-utils/customHeaders.ts
+++ b/test-utils/customHeaders.ts
@@ -1,18 +1,45 @@
-import { mock } from "bun:test";
-import { normalizeCustomHeaders } from "@/utils/customHeaders/normalize";
-import { optionsWithOptionalHeaders } from "@/utils/customHeaders/optionalHeaders";
+import { afterEach, mock } from "bun:test";
+import { atom } from "jotai";
+import {
+  normalizeCustomHeaders,
+  usableCustomHeaders,
+} from "@/utils/customHeaders/normalize";
+import {
+  hasHeaders,
+  optionsWithOptionalHeaders,
+  sourceWithOptionalHeaders,
+} from "@/utils/customHeaders/optionalHeaders";
+import { HEADER_PRESETS, presetRows } from "@/utils/customHeaders/presets";
+import {
+  isUrlForBaseUrl,
+  normalizeHttpBaseUrl,
+} from "@/utils/customHeaders/urlMatching";
 
 let jellyfinHeaders: Record<string, string> = {};
+let configuredFor: string | undefined;
 
 /**
  * Sets the proxy auth headers the stub reports. Call it from a spec's
  * `beforeEach`, not once at load: `mock.module` re-links every importer, so the
  * last registration to run decides what a value captured at registration would
  * be, and file order is not ours to choose.
+ *
+ * Pass `serverUrl` to pin the headers to one server, so a spec can prove that
+ * production looks them up under the key it claims to. Left out, any server
+ * gets them.
  */
-export const setJellyfinHeaders = (headers: Record<string, string> = {}) => {
+export const setJellyfinHeaders = (
+  headers: Record<string, string> = {},
+  serverUrl?: string,
+) => {
   jellyfinHeaders = headers;
+  configuredFor = serverUrl;
 };
+
+const configuredForServer = (serverUrl?: string | null): boolean =>
+  configuredFor === undefined ||
+  (!!serverUrl &&
+    normalizeHttpBaseUrl(serverUrl) === normalizeHttpBaseUrl(configuredFor));
 
 /**
  * The custom-header barrel re-exports modules with native dependencies (MMKV,
@@ -23,15 +50,58 @@ export const setJellyfinHeaders = (headers: Record<string, string> = {}) => {
  * `mock.module` is global and re-links every importer, so all of them have to
  * publish the same export surface. A stub missing one name breaks whichever
  * file links after it, and CI orders the files differently than a local run
- * does, so the break shows up there and not here.
+ * does, so the break shows up there and not here. That is why the list below
+ * is the barrel's, not the four names the first spec happened to need — the
+ * pure modules are re-exported for real, and only what touches the native side
+ * is stubbed.
  */
-export const stubCustomHeaders = () =>
+export const stubCustomHeaders = () => {
+  // Registered here rather than left to each spec to remember: the state above
+  // is module level and outlives a file, so one spec that forgets its reset
+  // hands its credentials to whichever file bun links next.
+  afterEach(() => setJellyfinHeaders());
+
   mock.module("@/utils/customHeaders", () => ({
+    // Pure, so the specs exercise the real thing.
     normalizeCustomHeaders,
+    usableCustomHeaders,
+    hasHeaders,
     optionsWithOptionalHeaders,
+    sourceWithOptionalHeaders,
+    HEADER_PRESETS,
+    presetRows,
+    isUrlForBaseUrl,
+    normalizeHttpBaseUrl,
+
     // Read through the binding rather than captured: a spec sets what it needs
     // in beforeEach, so a later registration cannot decide it retroactively.
-    getJellyfinHeaders: () => jellyfinHeaders,
-    getJellyfinHeadersForUrl: () =>
-      Object.keys(jellyfinHeaders).length ? jellyfinHeaders : undefined,
+    getJellyfinHeaders: (serverUrl?: string | null) =>
+      configuredForServer(serverUrl) ? jellyfinHeaders : {},
+    // Keeps the real gate: this function exists so a poster or stream hosted
+    // off-server never receives the proxy credentials, and a stub that answers
+    // for every URL would let a spec assert that leak away.
+    getJellyfinHeadersForUrl: (
+      url?: string | null,
+      serverUrl?: string | null,
+    ) => {
+      if (!url || !serverUrl || !isUrlForBaseUrl(url, serverUrl)) {
+        return undefined;
+      }
+      const headers = configuredForServer(serverUrl) ? jellyfinHeaders : {};
+      return Object.keys(headers).length > 0 ? headers : undefined;
+    },
+    getHeadersForUrl: () => undefined,
+    getIntegrationHeaders: () => ({}),
+    getIntegrationHeaderConfig: () => undefined,
+    updateIntegrationHeaderConfig: () => {},
+    resolveIntegrationHeaders: () => ({}),
+    INTEGRATION_CONFIG_KEY_PREFIX: "custom_headers_config_",
+
+    customHeadersVersionAtom: atom(0),
+    bumpCustomHeadersVersion: () => {},
+    deleteSecureCustomHeaderValues: async () => {},
+    isStoredCustomHeader: () => false,
+    resolveCustomHeaderValues: () => [],
+    secureCustomHeaderMetadata: () => [],
   }));
+};

--- a/test-utils/customHeaders.ts
+++ b/test-utils/customHeaders.ts
@@ -1,0 +1,30 @@
+import { mock } from "bun:test";
+import { normalizeCustomHeaders } from "@/utils/customHeaders/normalize";
+import { optionsWithOptionalHeaders } from "@/utils/customHeaders/optionalHeaders";
+
+type Overrides = {
+  /** Proxy auth headers configured for the Jellyfin server, if any. */
+  jellyfinHeaders?: Record<string, string>;
+};
+
+/**
+ * The custom-header barrel re-exports modules with native dependencies (MMKV,
+ * SecureStore), which `bun:test` cannot load, so specs replace it with the real
+ * pure helpers plus stubbed resolvers.
+ *
+ * Shared rather than written per spec for the same reason as `stubReactNative`:
+ * `mock.module` is global and re-links every importer, so all of them have to
+ * publish the same export surface. A stub missing one name breaks whichever
+ * file links after it, and CI orders the files differently than a local run
+ * does, so the break shows up there and not here.
+ */
+export const stubCustomHeaders = (overrides: Overrides = {}) =>
+  mock.module("@/utils/customHeaders", () => ({
+    normalizeCustomHeaders,
+    optionsWithOptionalHeaders,
+    getJellyfinHeaders: () => overrides.jellyfinHeaders ?? {},
+    getJellyfinHeadersForUrl: () =>
+      overrides.jellyfinHeaders && Object.keys(overrides.jellyfinHeaders).length
+        ? overrides.jellyfinHeaders
+        : undefined,
+  }));

--- a/utils/jellyfin/checkServer.test.ts
+++ b/utils/jellyfin/checkServer.test.ts
@@ -1,11 +1,17 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { stubCustomHeaders } from "@/test-utils/customHeaders";
+import {
+  setJellyfinHeaders,
+  stubCustomHeaders,
+} from "@/test-utils/customHeaders";
 import type { CustomHeader } from "@/utils/customHeaders/types";
 
 // checkServer pulls the two helpers through the barrel file, which also
 // re-exports modules with native dependencies (MMKV, SecureStore) — so the
 // barrel is replaced with just the real implementations of what it needs.
 stubCustomHeaders();
+// No proxy headers in these specs, set per test so another file cannot
+// leave its own behind.
+beforeEach(() => setJellyfinHeaders());
 
 // Bun's mock.module retroactively re-links every module already importing the
 // specifier, so a log mock must cover the module's full function surface —

--- a/utils/jellyfin/checkServer.test.ts
+++ b/utils/jellyfin/checkServer.test.ts
@@ -12,6 +12,7 @@ mock.module("@/utils/customHeaders", () => ({
   // Unused here, but the mock is global: another spec's module can be
   // re-linked to this one and would otherwise lose the resolver.
   getJellyfinHeadersForUrl: () => undefined,
+  getJellyfinHeaders: () => ({}),
 }));
 
 // Bun's mock.module retroactively re-links every module already importing the

--- a/utils/jellyfin/checkServer.test.ts
+++ b/utils/jellyfin/checkServer.test.ts
@@ -1,19 +1,11 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { normalizeCustomHeaders } from "@/utils/customHeaders/normalize";
-import { optionsWithOptionalHeaders } from "@/utils/customHeaders/optionalHeaders";
+import { stubCustomHeaders } from "@/test-utils/customHeaders";
 import type { CustomHeader } from "@/utils/customHeaders/types";
 
 // checkServer pulls the two helpers through the barrel file, which also
 // re-exports modules with native dependencies (MMKV, SecureStore) — so the
 // barrel is replaced with just the real implementations of what it needs.
-mock.module("@/utils/customHeaders", () => ({
-  normalizeCustomHeaders,
-  optionsWithOptionalHeaders,
-  // Unused here, but the mock is global: another spec's module can be
-  // re-linked to this one and would otherwise lose the resolver.
-  getJellyfinHeadersForUrl: () => undefined,
-  getJellyfinHeaders: () => ({}),
-}));
+stubCustomHeaders();
 
 // Bun's mock.module retroactively re-links every module already importing the
 // specifier, so a log mock must cover the module's full function surface —

--- a/utils/jellyfin/createApi.test.ts
+++ b/utils/jellyfin/createApi.test.ts
@@ -1,20 +1,12 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { Api, Jellyfin } from "@jellyfin/sdk";
 import axios, {
   type AxiosInstance,
   type InternalAxiosRequestConfig,
 } from "axios";
+import { stubCustomHeaders } from "@/test-utils/customHeaders";
 
-const headers: Record<string, string> = { "cf-access-client-id": "abc" };
-
-// The barrel re-exports modules with native dependencies (MMKV, SecureStore),
-// so it is replaced with the one resolver this module reads.
-mock.module("@/utils/customHeaders", () => ({
-  getJellyfinHeaders: () => headers,
-  // Unused here, but the mock is global: another spec's module can be
-  // re-linked to this one and would otherwise lose the resolver.
-  getJellyfinHeadersForUrl: () => undefined,
-}));
+stubCustomHeaders({ jellyfinHeaders: { "cf-access-client-id": "abc" } });
 
 const { createApiWithCustomHeaders } = await import("./createApi");
 

--- a/utils/jellyfin/createApi.test.ts
+++ b/utils/jellyfin/createApi.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, test } from "bun:test";
-import type { Api, Jellyfin } from "@jellyfin/sdk";
+import { describe, expect, test } from "bun:test";
+import { Jellyfin } from "@jellyfin/sdk";
+import { getSystemApi } from "@jellyfin/sdk/lib/utils/api/system-api";
 import axios, {
   type AxiosInstance,
   type InternalAxiosRequestConfig,
@@ -10,30 +11,33 @@ import {
 } from "@/test-utils/customHeaders";
 
 stubCustomHeaders();
-beforeEach(() => setJellyfinHeaders({ "cf-access-client-id": "abc" }));
 
 const { createApiWithCustomHeaders } = await import("./createApi");
 
-/**
- * Stands in for the SDK, which falls back to the global axios instance when it
- * is handed none:
- *
- *   constructor(basePath, clientInfo, deviceInfo, accessToken = '',
- *               axiosInstance = globalAxios)
- */
-const fakeJellyfin = (): Jellyfin =>
-  ({
-    createApi: (basePath: string, _token?: string, instance?: AxiosInstance) =>
-      ({
-        basePath,
-        axiosInstance: instance ?? axios,
-      }) as Api,
-  }) as unknown as Jellyfin;
+const SERVER = "https://jellyfin.example";
 
-/** How many request interceptors sit on an instance, which axios does not expose. */
+/**
+ * The real SDK, not a double: the argument this wrapper cares about is the
+ * third one of `Jellyfin.createApi(basePath, accessToken?, axiosInstance?)`,
+ * and a fake that hard-codes that position would keep passing after an SDK bump
+ * moved it — while `Api` quietly fell back to `axiosInstance = globalAxios` and
+ * put every interceptor back on the shared instance.
+ */
+const jellyfin = () =>
+  new Jellyfin({
+    clientInfo: { name: "streamyfin-tests", version: "0.0.0" },
+    deviceInfo: { name: "test-device", id: "device-1" },
+  });
+
+/**
+ * How many *live* request interceptors sit on an instance, which axios does not
+ * expose. `eject` nulls its slot in place rather than splicing, so the raw
+ * length would count interceptors that have already been removed.
+ */
 const requestInterceptorCount = (instance: AxiosInstance): number =>
-  (instance.interceptors.request as unknown as { handlers: unknown[] }).handlers
-    .length;
+  (
+    instance.interceptors.request as unknown as { handlers: unknown[] }
+  ).handlers.filter(Boolean).length;
 
 /** Answers every request without a network, and keeps what was about to be sent. */
 const captureRequests = (instance: AxiosInstance) => {
@@ -45,55 +49,122 @@ const captureRequests = (instance: AxiosInstance) => {
   return sent;
 };
 
+/** The headers one request went out with. */
+const headersOf = async (
+  url: string,
+  config?: { baseURL?: string },
+  serverUrl = SERVER,
+) => {
+  setJellyfinHeaders({ "cf-access-client-id": "abc" }, serverUrl);
+  const api = createApiWithCustomHeaders(jellyfin(), serverUrl);
+  const sent = captureRequests(api.axiosInstance);
+
+  await api.axiosInstance.get(url, config);
+
+  expect(sent).toHaveLength(1);
+  return sent[0].headers;
+};
+
 describe("createApiWithCustomHeaders", () => {
-  test("does not put the Jellyfin api on the global axios instance", () => {
-    // Everything attached to that instance would otherwise watch every bare
-    // axios call in the app: a 401 from a third-party integration reached the
-    // session-expiry interceptor and signed the user out of Jellyfin.
-    const api = createApiWithCustomHeaders(
-      fakeJellyfin(),
-      "https://jellyfin.example",
-    );
+  test("gives each api an axios instance of its own", () => {
+    // Everything attached to the global instance would otherwise watch every
+    // bare axios call in the app: a 401 from a third-party integration reached
+    // the session-expiry interceptor and signed the user out of Jellyfin. And
+    // because the header interceptor is never ejected, a shared instance
+    // collected another one on every login and every server switch.
+    const sdk = jellyfin();
 
-    expect(api.axiosInstance).not.toBe(axios);
-  });
+    const first = createApiWithCustomHeaders(sdk, "https://one.example");
+    const second = createApiWithCustomHeaders(sdk, "https://two.example");
 
-  test("gives each api its own instance rather than sharing one", () => {
-    // Neither interceptor is ever ejected, and this runs again on every login
-    // and every server switch, so a shared instance collected another pair
-    // each time.
-    const jellyfin = fakeJellyfin();
-
-    const first = createApiWithCustomHeaders(jellyfin, "https://one.example");
-    const second = createApiWithCustomHeaders(jellyfin, "https://two.example");
-
+    expect(first.axiosInstance).not.toBe(axios);
     expect(first.axiosInstance).not.toBe(second.axiosInstance);
   });
 
-  test("still attaches the configured proxy auth headers", async () => {
-    // The whole reason this wrapper exists. Moving off the global instance
-    // must not cost a Cloudflare Access or Pangolin user their headers.
-    const api = createApiWithCustomHeaders(
-      fakeJellyfin(),
-      "https://jellyfin.example",
-    );
+  test("adds nothing to the global instance", () => {
+    const before = requestInterceptorCount(axios);
+
+    createApiWithCustomHeaders(jellyfin(), SERVER);
+    createApiWithCustomHeaders(jellyfin(), SERVER);
+
+    expect(requestInterceptorCount(axios)).toBe(before);
+  });
+
+  test("attaches the configured proxy auth headers", async () => {
+    // The whole reason this wrapper exists. Moving off the global instance must
+    // not cost a Cloudflare Access or Pangolin user their headers.
+    //
+    // Driven through a real SDK operation rather than a hand-written url: the
+    // SDK prepends `basePath` when the instance has no `baseURL`, so every
+    // request it makes is absolute, and a spec that asks for a relative path
+    // returns before the guard it means to be covering.
+    setJellyfinHeaders({ "cf-access-client-id": "abc" }, SERVER);
+    const api = createApiWithCustomHeaders(jellyfin(), SERVER);
     const sent = captureRequests(api.axiosInstance);
 
-    await api.axiosInstance.get("https://jellyfin.example/System/Info/Public");
+    await getSystemApi(api).getPublicSystemInfo();
 
     expect(sent).toHaveLength(1);
+    expect(sent[0].url).toBe(`${SERVER}/System/Info/Public`);
     expect(sent[0].headers.get("cf-access-client-id")).toBe("abc");
   });
 
-  test("adds nothing to the global instance", () => {
-    // The header interceptor used to land on the instance every bare axios call
-    // in the app goes through, so a Streamystats request carried the
-    // credentials of the Jellyfin gateway, and a login piled on another one.
-    const before = requestInterceptorCount(axios);
+  test("looks the headers up under the server it was created for", async () => {
+    // Headers are saved per server, so passing the wrong key here returns none
+    // at all — which reads to the user as the gateway rejecting every request.
+    setJellyfinHeaders(
+      { "cf-access-client-id": "abc" },
+      "https://other.example",
+    );
+    const api = createApiWithCustomHeaders(jellyfin(), SERVER);
+    const sent = captureRequests(api.axiosInstance);
 
-    createApiWithCustomHeaders(fakeJellyfin(), "https://jellyfin.example");
-    createApiWithCustomHeaders(fakeJellyfin(), "https://jellyfin.example");
+    // Absolute, so the guard lets it through and what is left under test is the
+    // lookup key rather than the destination check.
+    await api.axiosInstance.get(`${SERVER}/System/Info/Public`);
 
-    expect(requestInterceptorCount(axios)).toBe(before);
+    expect(sent[0].headers.get("cf-access-client-id")).toBeUndefined();
+  });
+
+  test("does not send them to a url it cannot place", async () => {
+    // Relative with no base: nothing says where this lands, and an
+    // unverifiable destination does not get the credentials.
+    const headers = await headersOf("/System/Info/Public");
+
+    expect(headers.get("cf-access-client-id")).toBeUndefined();
+  });
+
+  test("does not send the headers to a third-party host", async () => {
+    // The sessions screen used this instance for a geo-IP lookup, so Cloudflare
+    // Access credentials went to freeipapi.com on every visit for over a year.
+    const headers = await headersOf("https://freeipapi.com/api/json/1.2.3.4");
+
+    expect(headers.get("cf-access-client-id")).toBeUndefined();
+  });
+
+  test("does not send them to a third-party base url either", async () => {
+    // Being relative is not what makes a request safe: the base it resolves
+    // against is per request, so a caller can point one anywhere.
+    const headers = await headersOf("/api/json/1.2.3.4", {
+      baseURL: "https://freeipapi.com",
+    });
+
+    expect(headers.get("cf-access-client-id")).toBeUndefined();
+  });
+
+  test("still sends them to an absolute url on the server", async () => {
+    // Guarding absolute URLs must not cost the callers that build a full URL
+    // against the server themselves.
+    const headers = await headersOf(`${SERVER}/Items/1/Images/Primary`);
+
+    expect(headers.get("cf-access-client-id")).toBe("abc");
+  });
+
+  test("still sends them to a relative url on the server's base", async () => {
+    const headers = await headersOf("/Items/1/Images/Primary", {
+      baseURL: SERVER,
+    });
+
+    expect(headers.get("cf-access-client-id")).toBe("abc");
   });
 });

--- a/utils/jellyfin/createApi.test.ts
+++ b/utils/jellyfin/createApi.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { Api, Jellyfin } from "@jellyfin/sdk";
+import axios, {
+  type AxiosInstance,
+  type InternalAxiosRequestConfig,
+} from "axios";
+
+const headers: Record<string, string> = { "cf-access-client-id": "abc" };
+
+// The barrel re-exports modules with native dependencies (MMKV, SecureStore),
+// so it is replaced with the one resolver this module reads.
+mock.module("@/utils/customHeaders", () => ({
+  getJellyfinHeaders: () => headers,
+  // Unused here, but the mock is global: another spec's module can be
+  // re-linked to this one and would otherwise lose the resolver.
+  getJellyfinHeadersForUrl: () => undefined,
+}));
+
+const { createApiWithCustomHeaders } = await import("./createApi");
+
+/**
+ * Stands in for the SDK, which falls back to the global axios instance when it
+ * is handed none:
+ *
+ *   constructor(basePath, clientInfo, deviceInfo, accessToken = '',
+ *               axiosInstance = globalAxios)
+ */
+const fakeJellyfin = (): Jellyfin =>
+  ({
+    createApi: (basePath: string, _token?: string, instance?: AxiosInstance) =>
+      ({
+        basePath,
+        axiosInstance: instance ?? axios,
+      }) as Api,
+  }) as unknown as Jellyfin;
+
+/** How many request interceptors sit on an instance, which axios does not expose. */
+const requestInterceptorCount = (instance: AxiosInstance): number =>
+  (instance.interceptors.request as unknown as { handlers: unknown[] }).handlers
+    .length;
+
+/** Answers every request without a network, and keeps what was about to be sent. */
+const captureRequests = (instance: AxiosInstance) => {
+  const sent: InternalAxiosRequestConfig[] = [];
+  instance.defaults.adapter = async (config) => {
+    sent.push(config);
+    return { data: null, status: 200, statusText: "OK", headers: {}, config };
+  };
+  return sent;
+};
+
+describe("createApiWithCustomHeaders", () => {
+  test("does not put the Jellyfin api on the global axios instance", () => {
+    // Everything attached to that instance would otherwise watch every bare
+    // axios call in the app: a 401 from a third-party integration reached the
+    // session-expiry interceptor and signed the user out of Jellyfin.
+    const api = createApiWithCustomHeaders(
+      fakeJellyfin(),
+      "https://jellyfin.example",
+    );
+
+    expect(api.axiosInstance).not.toBe(axios);
+  });
+
+  test("gives each api its own instance rather than sharing one", () => {
+    // Neither interceptor is ever ejected, and this runs again on every login
+    // and every server switch, so a shared instance collected another pair
+    // each time.
+    const jellyfin = fakeJellyfin();
+
+    const first = createApiWithCustomHeaders(jellyfin, "https://one.example");
+    const second = createApiWithCustomHeaders(jellyfin, "https://two.example");
+
+    expect(first.axiosInstance).not.toBe(second.axiosInstance);
+  });
+
+  test("still attaches the configured proxy auth headers", async () => {
+    // The whole reason this wrapper exists. Moving off the global instance
+    // must not cost a Cloudflare Access or Pangolin user their headers.
+    const api = createApiWithCustomHeaders(
+      fakeJellyfin(),
+      "https://jellyfin.example",
+    );
+    const sent = captureRequests(api.axiosInstance);
+
+    await api.axiosInstance.get("https://jellyfin.example/System/Info/Public");
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].headers.get("cf-access-client-id")).toBe("abc");
+  });
+
+  test("adds nothing to the global instance", () => {
+    // The header interceptor used to land on the instance every bare axios call
+    // in the app goes through, so a Streamystats request carried the
+    // credentials of the Jellyfin gateway, and a login piled on another one.
+    const before = requestInterceptorCount(axios);
+
+    createApiWithCustomHeaders(fakeJellyfin(), "https://jellyfin.example");
+    createApiWithCustomHeaders(fakeJellyfin(), "https://jellyfin.example");
+
+    expect(requestInterceptorCount(axios)).toBe(before);
+  });
+});

--- a/utils/jellyfin/createApi.test.ts
+++ b/utils/jellyfin/createApi.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { Api, Jellyfin } from "@jellyfin/sdk";
 import axios, {
   type AxiosInstance,
   type InternalAxiosRequestConfig,
 } from "axios";
-import { stubCustomHeaders } from "@/test-utils/customHeaders";
+import {
+  setJellyfinHeaders,
+  stubCustomHeaders,
+} from "@/test-utils/customHeaders";
 
-stubCustomHeaders({ jellyfinHeaders: { "cf-access-client-id": "abc" } });
+stubCustomHeaders();
+beforeEach(() => setJellyfinHeaders({ "cf-access-client-id": "abc" }));
 
 const { createApiWithCustomHeaders } = await import("./createApi");
 

--- a/utils/jellyfin/createApi.ts
+++ b/utils/jellyfin/createApi.ts
@@ -1,4 +1,5 @@
 import type { Api, Jellyfin } from "@jellyfin/sdk";
+import axios from "axios";
 import { getJellyfinHeaders } from "@/utils/customHeaders";
 
 /**
@@ -12,13 +13,29 @@ import { getJellyfinHeaders } from "@/utils/customHeaders";
  *
  * Headers are read per request (they are memoized until the configuration
  * changes), so an edit in settings applies without recreating the `Api`.
+ *
+ * ## Why the axios instance is passed in
+ *
+ * `createApi` defaults to the global axios instance, so everything attached to
+ * `api.axiosInstance` used to watch every bare `axios` call in the app rather
+ * than the Jellyfin ones. Three things came out of that: a 401 from a
+ * Streamystats server reached the session-expiry interceptor and signed the
+ * user out of Jellyfin, the headers below went out to Streamystats and to the
+ * server URL probes as well, and neither interceptor was ever ejected so both
+ * piled up again on every login and server switch.
+ *
+ * An instance of its own settles all three at the source. It also means every
+ * request seen here is by construction a request to `serverUrl`, so the headers
+ * do not need the `getJellyfinHeadersForUrl` guard the rest of the app uses:
+ * that guard is for shared paths, and adding it to a private instance would
+ * only invent a way to drop the headers on a relative URL.
  */
 export function createApiWithCustomHeaders(
   jellyfin: Jellyfin,
   serverUrl: string,
   accessToken?: string,
 ): Api {
-  const api = jellyfin.createApi(serverUrl, accessToken);
+  const api = jellyfin.createApi(serverUrl, accessToken, axios.create());
 
   api.axiosInstance.interceptors.request.use((config) => {
     for (const [key, value] of Object.entries(getJellyfinHeaders(serverUrl))) {

--- a/utils/jellyfin/createApi.ts
+++ b/utils/jellyfin/createApi.ts
@@ -1,6 +1,30 @@
 import type { Api, Jellyfin } from "@jellyfin/sdk";
-import axios from "axios";
-import { getJellyfinHeaders } from "@/utils/customHeaders";
+import axios, { type InternalAxiosRequestConfig } from "axios";
+import { getJellyfinHeaders, isUrlForBaseUrl } from "@/utils/customHeaders";
+
+/**
+ * Whether a request URL carries its own origin, and so ignores whatever base
+ * the request was given. Covers the protocol-relative form axios also treats
+ * as absolute.
+ */
+const isAbsoluteUrl = (url: string): boolean =>
+  /^([a-z][a-z0-9+.-]*:)?\/\//i.test(url);
+
+/** Whether a request is bound for `serverUrl`, and may carry its credentials. */
+const isForServer = (
+  config: InternalAxiosRequestConfig,
+  serverUrl: string,
+): boolean => {
+  const url = config.url ?? "";
+  if (isAbsoluteUrl(url)) return isUrlForBaseUrl(url, serverUrl);
+
+  // A relative url lands wherever the request's own base points, and a caller
+  // sets that per request — so it is not safe by being relative. With no base
+  // at all there is nothing to check it against, and an unverifiable
+  // destination does not get the credentials. Every caller in the app builds
+  // its url from `api.basePath`, so nothing real takes this branch.
+  return !!config.baseURL && isUrlForBaseUrl(config.baseURL, serverUrl);
+};
 
 /**
  * Creates a Jellyfin `Api` whose every request carries the custom proxy auth
@@ -21,14 +45,25 @@ import { getJellyfinHeaders } from "@/utils/customHeaders";
  * than the Jellyfin ones. Three things came out of that: a 401 from a
  * Streamystats server reached the session-expiry interceptor and signed the
  * user out of Jellyfin, the headers below went out to Streamystats and to the
- * server URL probes as well, and neither interceptor was ever ejected so both
- * piled up again on every login and server switch.
+ * server URL probes as well, and the request interceptor added here was never
+ * ejected, so it piled up again on every login and server switch. (The
+ * session-expiry interceptor in `JellyfinProvider` is ejected by its effect
+ * cleanup; only this one leaked.)
  *
- * An instance of its own settles all three at the source. It also means every
- * request seen here is by construction a request to `serverUrl`, so the headers
- * do not need the `getJellyfinHeadersForUrl` guard the rest of the app uses:
- * that guard is for shared paths, and adding it to a private instance would
- * only invent a way to drop the headers on a relative URL.
+ * An instance of its own settles all three.
+ *
+ * ## Why the headers are still guarded
+ *
+ * A private instance narrows who can reach this interceptor; it does not make
+ * every request a request to `serverUrl`. `api.axiosInstance` is public, and
+ * callers do hand it absolute URLs: the sessions screen used it for a geo-IP
+ * lookup and sent the gateway credentials to a third party for over a year.
+ *
+ * The SDK builds an absolute URL for every request of its own — it prepends
+ * `basePath` whenever the instance has no `baseURL`, and this one is created
+ * without any — so that is the shape real traffic takes and the guard runs on
+ * all of it. A caller can still pass a relative url with a `baseURL` of its
+ * own, which is why both are read rather than either being trusted.
  */
 export function createApiWithCustomHeaders(
   jellyfin: Jellyfin,
@@ -38,6 +73,8 @@ export function createApiWithCustomHeaders(
   const api = jellyfin.createApi(serverUrl, accessToken, axios.create());
 
   api.axiosInstance.interceptors.request.use((config) => {
+    if (!isForServer(config, serverUrl)) return config;
+
     for (const [key, value] of Object.entries(getJellyfinHeaders(serverUrl))) {
       config.headers.set(key, value);
     }


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

> [!IMPORTANT]
> **Force-pushed after a review pass.** Rebased onto current `develop`, the `test-utils/mmkv.ts`
> commit dropped (it landed on `develop` in c73470bb via #2005), and one commit added on top of
> the original three, covering the sessions call site, the URL guard, and the shared header
> double. The paragraphs this invalidated are corrected below and marked ~~struck~~ where the
> original claim was wrong. Old tip was `bcd96676`.

## 📝 Description

`jellyfin.createApi(serverUrl, accessToken)` is called without an axios instance, and the SDK falls back to the global one:

```js
// @jellyfin/sdk/lib/api.js:11
constructor(basePath, clientInfo, deviceInfo, accessToken = '', axiosInstance = globalAxios) {
```

So `api.axiosInstance` is the global instance, and everything attached to it watches every bare `axios` call in the app rather than the Jellyfin ones. Three things come out of that one default.

**A third-party 401 signs you out of Jellyfin.** The session-expiry interceptor sits on `api.axiosInstance`, and `utils/streamystats/api.ts` calls `axios.get(...)` on the same instance, so any 401 from a Streamystats server runs `handleSessionExpired()` and clears the Jellyfin session. Reproduced repeatedly: sign in to an account Streamystats does not know and the app returns to the login screen about twenty seconds later.

**Gateway headers go to hosts they were never meant for.** `createApiWithCustomHeaders` adds `getJellyfinHeaders(serverUrl)` to every request on that instance, so the Cloudflare Access or Pangolin headers configured for the Jellyfin server ride along on Streamystats calls and on the server URL probes.

**The interceptor accumulates.** ~~Neither is ejected~~ — the session-expiry interceptor *is* ejected by its effect cleanup in `JellyfinProvider`; only the request interceptor added in `createApi.ts` leaked, and this runs again on every login and every server switch.

An instance of its own settles all three at the source, and it is what `test-utils/jellyfinApi.ts` has been passing all along.

### The headers are guarded after all

~~No URL guard on the headers. Every request on a private instance is by construction a request to that server.~~ That was wrong, and this PR's own other half is the counter-example: `app/(auth)/(tabs)/(home)/sessions/index.tsx` called `api.axiosInstance.get("https://freeipapi.com/api/json/…")` and shipped the Cloudflare Access credentials to a third party on every visit to the Sessions screen — since c29b2cb8, March 2025.

A private instance narrows *who* can reach the interceptor; it does not make every request a request to the server. `api.axiosInstance` is public and seven call sites use it directly, so fixing the one leak would have left the next one free to repeat it. The interceptor now checks the request against `serverUrl` before attaching anything, reading **both** `config.url` and `config.baseURL` — a relative URL is not safe by being relative, since the base it resolves against is set per request, and one carrying no base at all cannot be placed so it gets nothing. Every caller in the app builds its URL from `api.basePath`, so no real request takes that last branch.

The objection to a guard was that it would drop the headers on a relative URL. In practice the SDK prepends `basePath` whenever the instance has no `baseURL`, and this one is created without any, so every request it builds is absolute and the guard runs on all of it.

### What this removes, deliberately

Moving off the global instance also takes away headers that other callers were receiving **by accident**. `utils/streamystats/api.ts` and the Marlin search in `app/(auth)/(tabs)/(search)/index.tsx` call bare `axios` with `getIntegrationHeaders(key)`, whose `DEFAULT_CONFIG.source` is `"none"` → `{}`; the leaked global interceptor was stamping the Jellyfin headers on them regardless. So a user running Streamystats behind the same gateway who never opened the per-integration header picker has a working integration today and will not after this ships. The same applies to the three probes in `utils/serverUrl/probes/`.

~~Checked that nothing relied on the wider reach: the three bare-`axios` callers all pass their own headers explicitly.~~ They pass a header *argument*, but it resolves to `{}` unless the user configured one. This is the one behaviour change here that is not strictly a fix, and it has no test coverage anywhere — worth a release note.

## 🏷️ Ticket / Issue

Closes #2009

### 🖼️ Screenshots / GIFs (if UI)

N/A, no UI change.

## 🧱 Stacked on this

- #2014 — `fix(sessions): only look up session locations that can be answered`. Bounds and encodes the geo-IP lookup this PR moved off the Jellyfin instance.
- #2013 (draft) — `fix(network): resolve custom headers by canonical server address`. A latent trailing-slash mismatch that this PR makes reachable: the leaked interceptor was masking it. Not mergeable yet, see its description.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

Nine tests, `bun test` at 316 passing. The spec drives the real `Jellyfin` SDK rather than a hand-rolled double, so an SDK bump that reorders the axios-instance parameter fails here instead of silently putting every interceptor back on the global instance. Each claim is mutation-checked: removing the instance argument, removing the guard, ignoring `config.baseURL`, and passing the wrong lookup key each fail at least one test and no other.

The two sibling specs that had grown their own `@/utils/customHeaders` mock now share `test-utils/customHeaders.ts`. Bun's `mock.module` re-links retroactively and globally, so a stub of that barrel has to carry every name any spec needs — the shared double publishes the whole surface, keeps the real `isUrlForBaseUrl` gate so a spec cannot assert a credential leak away, and resets itself between files.

## 🔍 Testing Instructions

For the sign-out:

1. Configure a Streamystats server, then sign in with a Jellyfin account that server does not know
2. Open the home screen so the recommendation requests fire and answer 401
3. Before this change the app returns to the login screen. After it, the 401 is logged and the session stays

For the headers, configure a custom header for the Jellyfin server, then watch a Streamystats request or a server URL probe: it should no longer carry that header, while every Jellyfin request still does.

For the guard, open **Home → Sessions** with a session playing and watch the request to `freeipapi.com`: it must carry no `CF-Access-*` header. Every Jellyfin request on the same screen still carries them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented Jellyfin proxy authentication headers from being sent to unrelated services.
  - Improved request isolation when switching servers or signing in repeatedly.
  - Prevented unrelated service errors from incorrectly triggering Jellyfin session expiry.
  - Improved session location lookups by using the appropriate network connection.
- **Tests**
  - Added coverage for server-specific header handling and request isolation.
- **Documentation**
  - Clarified the shared testing utilities included in the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

