### PR TITLE
fix(login): store the canonical server address on deep-link login

### DIFF
--- a/providers/JellyfinProvider.tsx
+++ b/providers/JellyfinProvider.tsx
@@ -26,7 +26,10 @@ import useRouter from "@/hooks/useAppRouter";
 import { useInterval } from "@/hooks/useInterval";
 import { JellyseerrApi, useJellyseerr } from "@/hooks/useJellyseerr";
 import { settingsAtom, useSettings } from "@/utils/atoms/settings";
-import { getIntegrationHeaders } from "@/utils/customHeaders";
+import {
+  getIntegrationHeaders,
+  normalizeHttpBaseUrl,
+} from "@/utils/customHeaders";
 import { getOrSetDeviceId } from "@/utils/device";
 import { markExpectedError } from "@/utils/errors";
 import { createApiWithCustomHeaders } from "@/utils/jellyfin/createApi";
@@ -987,7 +990,14 @@ export const JellyfinProvider: React.FC<{ children: ReactNode }> = ({
 
   const contextValue: JellyfinContextValue = {
     discoverServers,
-    setServer: (server) => setServerMutation.mutateAsync(server),
+    // A deep link hands the address over exactly as typed, trailing slash
+    // included, while the SDK strips one off `api.basePath`. Every later read
+    // keys on the spelling stored here, so store the canonical one.
+    setServer: (server) =>
+      setServerMutation.mutateAsync({
+        ...server,
+        address: normalizeHttpBaseUrl(server.address),
+      }),
     removeServer: () => removeServerMutation.mutateAsync(),
     login: (username, password, serverName, options) =>
       loginMutation.mutateAsync({ username, password, serverName, options }),

--- a/utils/customHeaders/urlMatching.test.ts
+++ b/utils/customHeaders/urlMatching.test.ts
@@ -13,6 +13,12 @@ describe("normalizeHttpBaseUrl", () => {
       "http://192.168.1.10:8096",
     );
   });
+
+  test("strips every trailing slash, so applying it again changes nothing", () => {
+    const once = normalizeHttpBaseUrl("https://jellyfin.example.com//");
+    expect(once).toBe("https://jellyfin.example.com");
+    expect(normalizeHttpBaseUrl(once)).toBe(once);
+  });
 });
 
 describe("isUrlForBaseUrl", () => {

--- a/utils/customHeaders/urlMatching.ts
+++ b/utils/customHeaders/urlMatching.ts
@@ -5,7 +5,7 @@ function withHttpProtocol(url: string): string {
 
 /** Canonical form of a configured base URL: protocol present, no trailing slash. */
 export function normalizeHttpBaseUrl(url: string): string {
-  return withHttpProtocol(url).replace(/\/$/, "");
+  return withHttpProtocol(url).replace(/\/+$/, "");
 }
 
 /**


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

> [!NOTE]
> **Shrunk from 887 lines to 20.** The previous version canonicalised every lookup in
> `secureCredentials.ts` and shipped a storage migration that merged saved-server rows
> and re-keyed SecureStore. On review, the only way a trailing-slash address gets into
> the app is the `?apiUrl=` deep-link parameter, nothing in the org emits that link, and
> no issue or Sentry event has ever shown the symptom — so the migration was repairing
> installs no signal says exist. This version closes the entry point and nothing more.
> One commit on `develop`.

## 📝 Description

The login form strips a trailing slash before connecting
(`components/login/Login.tsx:248`); the deep-link path does not
(`components/login/Login.tsx:147-151`, `components/login/TVLogin.tsx:160-161`), and the
SDK strips one off `api.basePath` regardless (`@jellyfin/sdk/lib/api.js:13`). So for a
server reached through a link ending in `/`, saves keyed on `api.basePath` and reads keyed
on the stored address missed each other: the saved account would not quick-login, the
request interceptor could not find the server's custom headers, and the Jellyseerr
password was asked for again on every launch.

**What changes.** `setServer` canonicalises the address once, where it enters the
provider, so the stored spelling is the one every later read uses. `normalizeHttpBaseUrl`
strips every trailing slash rather than one, so applying it again is a no-op; a test pins
that.

**What does not change.** Existing rows are left as they are. Someone who already holds a
slashed row will see it as a second entry in the saved-servers list next to the canonical
one and enter their password once more; that is the whole cost, and it did not justify a
migration.

## 🏷️ Ticket / Issue

N/A — no issue filed. Same shape as #518 and #1257, both fixed by normalising at the
entry point.

### 🖼️ Screenshots / GIFs (if UI)

N/A — no UI change.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms — **not done.** Unit
      suite only. The provider has no test harness, and building one would be larger than
      the fix; the `setServer` line is covered by the manual step below.
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

## 🔍 Testing Instructions

1. `bun run test:unit` — 317 passing. Reverting the regex in `normalizeHttpBaseUrl` fails
   the new test.
2. On a fresh install, open the app through a deep link whose address ends in a slash,
   e.g. `xcrun simctl openurl booted "streamyfin://login?apiUrl=https://jellyfin.example.com/"`,
   log in and save the account. Then kill the app, reopen it, and tap the saved account:
   it logs in without asking for the password. Before this change it said
   "No saved credential found".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server address handling by removing extra trailing slashes from URLs.
  * Ensured deep-link server addresses are consistently normalized before connection.
  * Prevented inconsistent behavior when normalized URLs are processed repeatedly.

* **Tests**
  * Added regression coverage for URLs with multiple trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->