### PR TITLE
chore(sessions): drop the third-party IP location lookup

### DIFF
--- a/app/(auth)/(tabs)/(home)/sessions/index.tsx
+++ b/app/(auth)/(tabs)/(home)/sessions/index.tsx
@@ -7,8 +7,6 @@ import {
 } from "@jellyfin/sdk/lib/generated-client/models";
 import { getSessionApi } from "@jellyfin/sdk/lib/utils/api/session-api";
 import { FlashList } from "@shopify/flash-list";
-import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
 import { useAtomValue } from "jotai";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -96,24 +94,6 @@ const SessionCard = ({ session }: SessionCardProps) => {
       setRemainingTicks(remainingTimeTicks);
     }
   }, [session]);
-
-  const { data: ipInfo } = useQuery<{
-    cityName?: string;
-    countryCode?: string;
-  }>({
-    queryKey: ["ipinfo", session.RemoteEndPoint],
-    staleTime: Number.POSITIVE_INFINITY,
-    queryFn: async () => {
-      // Plain axios, never `api.axiosInstance`: freeipapi is a third party, and
-      // the Jellyfin instance stamps the server's gateway credentials onto every
-      // request it carries and reads any 401 back as the session having expired.
-      const resp = await axios.get(
-        `https://freeipapi.com/api/json/${session.RemoteEndPoint}`,
-      );
-      return resp.data;
-    },
-    enabled: !!session.RemoteEndPoint,
-  });
 
   // Handle session controls
   const [isControlLoading, setIsControlLoading] = useState<
@@ -231,8 +211,6 @@ const SessionCard = ({ session }: SessionCardProps) => {
               {session.Client}
               {"\n"}
               {session.DeviceName}
-              {"\n"}
-              {ipInfo?.cityName} {ipInfo?.countryCode}
             </Text>
           </View>
           <View className='flex-1' />


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

> [!NOTE]
> **Repurposed.** The first version of this PR hardened the lookup (a private-address
> classifier, a timeout, no retries). On review the lookup itself did not survive the
> question of whether it should exist, so this now removes it instead. One commit on
> `develop`.

## 📝 Description

The admin Sessions screen looked up a city and country for every active session by
sending that session's `RemoteEndPoint` to freeipapi.com.

- The screen is admin-only (`app/(auth)/(tabs)/(home)/_layout.tsx:64`), so the addresses
  sent are **other users'**, on every visit, with no setting to turn it off. For a
  self-hosting audience that is the kind of thing that becomes an issue.
- A LAN session gained nothing from it: freeipapi answers a private address with HTTP
  200 and every field null, so the line under the card was blank anyway.
- Nobody asked for the location. It dates to c29b2cb8 (Mar 2025) and no issue mentions it.

The honest fix is to stop asking rather than to harden what gets sent, so the query, its
`axios` and `useQuery` imports, and the city/country line under each session card are
gone. 22 deletions, nothing added.

## 🏷️ Ticket / Issue

N/A — no issue filed. Related: #2010, which stopped this request carrying the server's
gateway credentials.

### 🖼️ Screenshots / GIFs (if UI)

The fourth line under a session card (city and country code) no longer appears. The
user, client and device lines above it are unchanged.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms — **not done.** Unit
      suite, typecheck and lint only; no device run.
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

## 🔍 Testing Instructions

1. `bun run test:unit` — 316 passing; `bun run i18n:check` clean (no translation key was
   involved).
2. On a device, as an admin, open **Home → Sessions** with at least one session playing.
   Each card shows user, client and device; no city or country. The network tab shows no
   request to freeipapi.com.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed inaccurate or unavailable location details from session cards.
  * Improved the sessions screen by eliminating unnecessary location lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->