### PR TITLE
fix(sentry): resolve the crash and noise findings from the error triage

### DIFF
--- a/app/(auth)/(tabs)/(home)/settings/appearance/hide-libraries/page.tsx
+++ b/app/(auth)/(tabs)/(home)/settings/appearance/hide-libraries/page.tsx
@@ -30,6 +30,9 @@ export default function AppearanceHideLibrariesPage() {
 
       return response.data.Items || null;
     },
+    // On logout the cached query refetches with api null and crashes inside
+    // the SDK (`configuration` of null).
+    enabled: !!api && !!user?.Id,
   });
 
   if (!settings) return null;

--- a/app/(auth)/(tabs)/(home)/settings/hide-libraries/page.tsx
+++ b/app/(auth)/(tabs)/(home)/settings/hide-libraries/page.tsx
@@ -28,6 +28,9 @@ export default function HideLibrariesPage() {
 
       return response.data.Items || null;
     },
+    // On logout the cached query refetches with api null and crashes inside
+    // the SDK (`configuration` of null).
+    enabled: !!api && !!user?.Id,
   });
 
   if (!settings) return null;

--- a/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/jellyseerr/page.tsx
+++ b/app/(auth)/(tabs)/(home,libraries,search,favorites,watchlists)/jellyseerr/page.tsx
@@ -54,6 +54,7 @@ import type {
   TvResult,
 } from "@/utils/jellyseerr/server/models/Search";
 import type { TvDetails } from "@/utils/jellyseerr/server/models/Tv";
+import { writeErrorLog } from "@/utils/log";
 
 // Mobile page component
 const MobilePage: React.FC = () => {
@@ -165,6 +166,12 @@ const MobilePage: React.FC = () => {
           setIssueType(undefined);
           setIssueMessage(undefined);
           bottomSheetModalRef?.current?.close();
+        })
+        // The response interceptor already logs and reports the failure with
+        // its route; an uncaught rejection here would re-report it as a
+        // stackless unhandledrejection event.
+        .catch((error) => {
+          writeErrorLog("Jellyseerr submitIssue failed", String(error));
         });
     }
   }, [jellyseerrApi, details, result, issueType, issueMessage]);

--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -65,6 +65,7 @@ import { OfflineModeProvider } from "@/providers/OfflineModeProvider";
 import { getSubtitlesForItem } from "@/utils/atoms/downloadedSubtitles";
 import { getActivePlayerType, useSettings } from "@/utils/atoms/settings";
 import { getJellyfinHeadersForUrl } from "@/utils/customHeaders";
+import { isExpectedError } from "@/utils/errors";
 import { getDefaultPlaySettings } from "@/utils/jellyfin/getDefaultPlaySettings";
 import { getPrimaryImageUrl } from "@/utils/jellyfin/image/getPrimaryImageUrl";
 import { getStreamUrl } from "@/utils/jellyfin/media/getStreamUrl";
@@ -571,6 +572,11 @@ export default function DirectPlayerPage() {
           player: getActivePlayerType(settings),
           offline,
         });
+        if (isExpectedError(error)) {
+          // The server itself declined to produce a stream (NoCompatibleStream
+          // and friends): say so instead of only flipping the error state.
+          Alert.alert(t("player.error"), t("player.failed_to_get_stream_url"));
+        }
         setStreamStatus({ isLoading: false, isError: true });
         return null;
       }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -306,6 +306,10 @@ const reportDataError = (
   // already says which data path failed.
   const name = typeof key?.[0] === "string" ? key[0] : undefined;
   const http = describeHttpError(error);
+  // A 404 from a Streamystats endpoint is a server that predates the route
+  // (recommendations, watchlists) — feature-unsupported, not an app bug, and
+  // the UI already renders nothing for it.
+  if (name === "streamystats" && http?.status === 404) return;
   const dedupeKey = [
     source,
     name ?? "?",

--- a/components/jellyseerr/RequestModal.tsx
+++ b/components/jellyseerr/RequestModal.tsx
@@ -155,8 +155,21 @@ const RequestModal = forwardRef<
       });
     }, [requestBody?.seasons]);
 
+    // freeSpace is optional on a root folder the service hasn't scanned yet.
     const pathTitleExtractor = (item: RootFolder) =>
-      `${item.path} (${item.freeSpace.bytesToReadable()})`;
+      `${item.path}${item.freeSpace ? ` (${item.freeSpace.bytesToReadable()})` : ""}`;
+
+    // The service's active directory may not match any root folder (changed
+    // or removed server-side), so `defaultFolder` — despite its type — can be
+    // undefined and must never be handed to pathTitleExtractor unchecked.
+    const selectedFolder: RootFolder | undefined = useMemo(
+      () =>
+        defaultServiceDetails?.rootFolders.find(
+          (f) =>
+            f.path === (requestOverrides.rootFolder || defaultFolder?.path),
+        ) ?? defaultFolder,
+      [defaultServiceDetails, requestOverrides.rootFolder, defaultFolder],
+    );
 
     const qualityProfileOptions = useMemo(
       () => [
@@ -350,21 +363,9 @@ const RequestModal = forwardRef<
                       trigger={
                         <View className='bg-neutral-900 h-10 rounded-xl border-neutral-800 border px-3 py-2 flex flex-row items-center justify-between'>
                           <Text numberOfLines={1}>
-                            {defaultServiceDetails.rootFolders.find(
-                              (f) =>
-                                f.path ===
-                                (requestOverrides.rootFolder ||
-                                  defaultFolder?.path),
-                            )
-                              ? pathTitleExtractor(
-                                  defaultServiceDetails.rootFolders.find(
-                                    (f) =>
-                                      f.path ===
-                                      (requestOverrides.rootFolder ||
-                                        defaultFolder?.path),
-                                  )!,
-                                )
-                              : pathTitleExtractor(defaultFolder!)}
+                            {selectedFolder
+                              ? pathTitleExtractor(selectedFolder)
+                              : "—"}
                           </Text>
                         </View>
                       }

--- a/components/library/Libraries.tsx
+++ b/components/library/Libraries.tsx
@@ -33,6 +33,9 @@ export const Libraries: React.FC = () => {
       return response.data.Items || null;
     },
     staleTime: 60,
+    // On logout the cached query refetches with api null and crashes inside
+    // the SDK (`configuration` of null).
+    enabled: !!api && !!user?.Id,
   });
 
   const libraries = useMemo(

--- a/components/settings/Jellyseerr.tsx
+++ b/components/settings/Jellyseerr.tsx
@@ -8,6 +8,7 @@ import { useIntegrationHeaders } from "@/hooks/useIntegrationHeaders";
 import { JellyseerrApi, useJellyseerr } from "@/hooks/useJellyseerr";
 import { userAtom } from "@/providers/JellyfinProvider";
 import { useSettings } from "@/utils/atoms/settings";
+import { markExpectedError } from "@/utils/errors";
 import { writeErrorLog } from "@/utils/log";
 import { storage } from "@/utils/mmkv";
 import { deleteJellyseerrPassword } from "@/utils/secureCredentials";
@@ -62,8 +63,12 @@ export const JellyseerrSettings = () => {
 
   const loginToJellyseerrMutation = useMutation({
     mutationFn: async () => {
+      // Everything thrown in this mutation is a user-facing outcome of what
+      // they typed (or didn't) — surfaced by onError's toast, never Sentry.
       if (!user?.Name)
-        throw new Error("Missing required information for login");
+        throw markExpectedError(
+          new Error("Missing required information for login"),
+        );
 
       // When the URL is admin-pinned, target that server directly. Otherwise
       // trust resolvedUrl only while it matches the field (the field adopts
@@ -81,10 +86,11 @@ export const JellyseerrSettings = () => {
           jellyseerrProbe,
           { headers: customHeaders },
         );
-        if (!resolved.ok) throw new Error("Invalid server url");
+        if (!resolved.ok)
+          throw markExpectedError(new Error("Invalid server url"));
         finalUrl = resolved.url;
       }
-      if (!finalUrl) throw new Error("Missing server url");
+      if (!finalUrl) throw markExpectedError(new Error("Missing server url"));
 
       // An API key signs in via the Seerr account linked to the Jellyfin user
       // — no password involved. Falls back to the classic password login.
@@ -98,10 +104,14 @@ export const JellyseerrSettings = () => {
         apiKey,
       );
       const testResult = await jellyseerrTempApi.test();
-      if (!testResult.isValid) throw new Error("Invalid server url");
+      if (!testResult.isValid)
+        throw markExpectedError(new Error("Invalid server url"));
 
       if (apiKey) {
-        if (!user.Id) throw new Error("Missing required information for login");
+        if (!user.Id)
+          throw markExpectedError(
+            new Error("Missing required information for login"),
+          );
         const loggedInUser = await jellyseerrTempApi.loginWithApiKey(user.Id);
         return { user: loggedInUser, url: finalUrl, apiKey };
       }

--- a/hooks/useItemQuery.ts
+++ b/hooks/useItemQuery.ts
@@ -41,8 +41,10 @@ export const useItemQuery = (
     queryFn: async () => {
       if (!itemId) throw new Error("Item ID is required");
 
+      // null, never undefined: React Query treats a queryFn that resolves
+      // undefined as an error ("<key> data is undefined" thrown at the user).
       if (isOffline) {
-        return getDownloadedItemById(itemId)?.item;
+        return getDownloadedItemById(itemId)?.item ?? null;
       }
 
       if (!api || !user) return null;
@@ -53,7 +55,8 @@ export const useItemQuery = (
         ...(finalFields && { fields: finalFields }),
       });
 
-      return response.data.Items?.[0];
+      // Zero items (deleted on the server, access revoked) is a valid answer.
+      return response.data.Items?.[0] ?? null;
     },
     enabled: !!itemId,
     staleTime: isOffline ? Infinity : 60 * 1000,

--- a/hooks/useJellyseerr.ts
+++ b/hooks/useJellyseerr.ts
@@ -127,8 +127,25 @@ const JELLYSEERR_REPORT_THROTTLE_MS = 60_000;
 const shouldReportJellyseerrError = (
   status: number | undefined,
   path: string | undefined,
+  method?: string,
 ): boolean => {
   if (status === 401 || status === 403) return false;
+  // Answers Jellyseerr gives in the normal course of business, not defects:
+  // - /ratings 404/500: no Rotten Tomatoes entry for the title (404) or its
+  //   ratings upstream failed (500) — the badge simply doesn't render.
+  // - /user/jellyfin/:id 404: Seerr servers predating the route (seerr#2074);
+  //   the caller falls back to password login.
+  // - POST /request 400: request validation (already requested, no seasons
+  //   selected) — the request flow surfaces it to the user.
+  if (path?.endsWith(Endpoints.RATINGS) && (status === 404 || status === 500))
+    return false;
+  if (status === 404 && path?.includes(Endpoints.USER_JELLYFIN)) return false;
+  if (
+    status === 400 &&
+    method?.toUpperCase() === "POST" &&
+    path?.endsWith(Endpoints.REQUEST)
+  )
+    return false;
   const key = `${status}|${path}`;
   const now = Date.now();
   const last = recentJellyseerrReports.get(key);
@@ -483,7 +500,10 @@ export class JellyseerrApi {
       (error: AxiosError) => {
         const status = error.response?.status;
         const path = error.config?.url?.split("?")[0];
-        if (error.response && shouldReportJellyseerrError(status, path)) {
+        if (
+          error.response &&
+          shouldReportJellyseerrError(status, path, error.config?.method)
+        ) {
           // A real server response — one capture covers the entire
           // Jellyseerr surface. 401/403 are excluded (expired cookies are
           // routine and self-heal via auto-login), and repeats of the same

--- a/hooks/useJellyseerr.ts
+++ b/hooks/useJellyseerr.ts
@@ -531,7 +531,14 @@ export class JellyseerrApi {
           );
         }
         if (error.response?.status === 403) {
-          clearJellyseerrStorageData();
+          // A 403 on one request's detail is about THAT request (another
+          // user's, without MANAGE_REQUESTS) — the session itself is fine,
+          // and the recent-requests slide polls these every few seconds, so
+          // wiping here signed the user out of Jellyseerr in a loop.
+          const isRequestDetail = /\/request\/\d+$/.test(path ?? "");
+          if (!isRequestDetail) {
+            clearJellyseerrStorageData();
+          }
         }
         return Promise.reject(error);
       },

--- a/hooks/useSessions.ts
+++ b/hooks/useSessions.ts
@@ -28,7 +28,10 @@ export const useSessions = ({
         activeWithinSeconds: activeWithinSeconds,
       });
 
-      const result = response.data
+      // A reverse proxy can answer this route with a non-array body (an HTML
+      // error page, an error object) that axios passes through as-is.
+      const sessions = Array.isArray(response.data) ? response.data : [];
+      const result = sessions
         .filter((s) => s.NowPlayingItem)
         .sort((a, b) =>
           (b.NowPlayingItem?.Name ?? "").localeCompare(
@@ -61,7 +64,8 @@ export const useAllSessions = ({
       const response = await getSessionApi(api).getSessions({
         activeWithinSeconds: activeWithinSeconds,
       });
-      return response.data;
+      // Same proxy caveat as useSessions above.
+      return Array.isArray(response.data) ? response.data : [];
     },
     refetchInterval: refetchInterval,
   });

--- a/hooks/useWikidataAwards.ts
+++ b/hooks/useWikidataAwards.ts
@@ -1,6 +1,7 @@
 import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client/models";
 import { useQuery } from "@tanstack/react-query";
 import { useSettings } from "@/utils/atoms/settings";
+import { markExpectedError } from "@/utils/errors";
 
 const WIKIDATA_API = "https://www.wikidata.org/w/api.php";
 const WIKIDATA_SPARQL = "https://query.wikidata.org/sparql";
@@ -30,7 +31,11 @@ interface WikidataError extends Error {
 function wikidataError(message: string, retryAfterMs?: number): WikidataError {
   const error: WikidataError = new Error(message);
   error.retryAfterMs = retryAfterMs;
-  return error;
+  // The badge is decoration and Wikidata is a third party the user can't do
+  // anything about: 429s are Wikimedia throttling by design, 403s its UA
+  // policy. Failures still propagate for React Query's Retry-After retry —
+  // they just never become Sentry events.
+  return markExpectedError(error);
 }
 
 /** Parse a Retry-After header given in seconds. */

--- a/modules/mpv-player/ios/MPVLayerRenderer.swift
+++ b/modules/mpv-player/ios/MPVLayerRenderer.swift
@@ -39,6 +39,20 @@ final class MPVLayerRenderer {
 
     // Key to identify if we're on the mpv queue (to avoid deadlock in stop())
     private static let queueKey = DispatchSpecificKey<Bool>()
+
+    // Key to identify if we're already on stateQueue. deinit can run ON a
+    // stateQueue worker: when an async barrier block holding the last strong
+    // reference to self is released while the lane drains, deinit → stop() →
+    // isStopping would stateQueue.sync onto the queue this thread already
+    // owns, and libdispatch traps that as EXC_BREAKPOINT. The weak captures
+    // in the async setters prevent that ownership, and the accessors below
+    // read the backing field directly when already on the queue as a second
+    // line of defence.
+    private static let stateQueueKey = DispatchSpecificKey<Bool>()
+
+    private var isOnStateQueue: Bool {
+        DispatchQueue.getSpecific(key: Self.stateQueueKey) == true
+    }
     
     private var mpv: OpaquePointer?
     
@@ -52,13 +66,25 @@ final class MPVLayerRenderer {
     private var routeChangeObserver: NSObjectProtocol?
 
     private var isRunning: Bool {
-        get { stateQueue.sync { _isRunning } }
-        set { stateQueue.async(flags: .barrier) { self._isRunning = newValue } }
+        get {
+            if isOnStateQueue { return _isRunning }
+            return stateQueue.sync { _isRunning }
+        }
+        set { stateQueue.async(flags: .barrier) { [weak self] in self?._isRunning = newValue } }
     }
 
     private var isStopping: Bool {
-        get { stateQueue.sync { _isStopping } }
-        set { stateQueue.sync(flags: .barrier) { _isStopping = newValue } }  // Must be sync for stop() to work
+        get {
+            if isOnStateQueue { return _isStopping }
+            return stateQueue.sync { _isStopping }
+        }
+        set {  // Must be sync for stop() to work
+            if isOnStateQueue {
+                _isStopping = newValue
+                return
+            }
+            stateQueue.sync(flags: .barrier) { _isStopping = newValue }
+        }
     }
 
     /// Retained across mpv re-creation; see setMute. Sync setter like
@@ -117,35 +143,35 @@ final class MPVLayerRenderer {
     // Thread-safe accessors
     private var cachedDuration: Double {
         get { stateQueue.sync { _cachedDuration } }
-        set { stateQueue.async(flags: .barrier) { self._cachedDuration = newValue } }
+        set { stateQueue.async(flags: .barrier) { [weak self] in self?._cachedDuration = newValue } }
     }
     private var cachedPosition: Double {
         get { stateQueue.sync { _cachedPosition } }
-        set { stateQueue.async(flags: .barrier) { self._cachedPosition = newValue } }
+        set { stateQueue.async(flags: .barrier) { [weak self] in self?._cachedPosition = newValue } }
     }
     private var cachedCacheSeconds: Double {
         get { stateQueue.sync { _cachedCacheSeconds } }
-        set { stateQueue.async(flags: .barrier) { self._cachedCacheSeconds = newValue } }
+        set { stateQueue.async(flags: .barrier) { [weak self] in self?._cachedCacheSeconds = newValue } }
     }
     private var isPaused: Bool {
         get { stateQueue.sync { _isPaused } }
-        set { stateQueue.async(flags: .barrier) { self._isPaused = newValue } }
+        set { stateQueue.async(flags: .barrier) { [weak self] in self?._isPaused = newValue } }
     }
     private var playbackSpeed: Double {
         get { stateQueue.sync { _playbackSpeed } }
-        set { stateQueue.async(flags: .barrier) { self._playbackSpeed = newValue } }
+        set { stateQueue.async(flags: .barrier) { [weak self] in self?._playbackSpeed = newValue } }
     }
     private var isLoading: Bool {
         get { stateQueue.sync { _isLoading } }
-        set { stateQueue.async(flags: .barrier) { self._isLoading = newValue } }
+        set { stateQueue.async(flags: .barrier) { [weak self] in self?._isLoading = newValue } }
     }
     private var isReadyToSeek: Bool {
         get { stateQueue.sync { _isReadyToSeek } }
-        set { stateQueue.async(flags: .barrier) { self._isReadyToSeek = newValue } }
+        set { stateQueue.async(flags: .barrier) { [weak self] in self?._isReadyToSeek = newValue } }
     }
     private var isSeeking: Bool {
         get { stateQueue.sync { _isSeeking } }
-        set { stateQueue.async(flags: .barrier) { self._isSeeking = newValue } }
+        set { stateQueue.async(flags: .barrier) { [weak self] in self?._isSeeking = newValue } }
     }
     
     var isPausedState: Bool {
@@ -156,6 +182,7 @@ final class MPVLayerRenderer {
         self.displayLayer = displayLayer
         self.queue = DispatchQueue(label: "mpv.avfoundation", qos: .userInitiated)
         queue.setSpecific(key: Self.queueKey, value: true)
+        stateQueue.setSpecific(key: Self.stateQueueKey, value: true)
         observeDisplayLayerStatus()
     }
     

--- a/providers/Downloads/hooks/useDownloadEventHandlers.ts
+++ b/providers/Downloads/hooks/useDownloadEventHandlers.ts
@@ -259,16 +259,17 @@ export function useDownloadEventHandlers({
         const record = getPendingDownload(itemId);
         if (!record) return;
 
-        // Native error payloads are plain strings, so connectivity failures
-        // (walking out of Wi-Fi range is the normal downloads scenario) are
-        // classified by keyword and kept out of Sentry; the scrubbers redact
-        // any scheme-less host/IP the native message embeds.
+        // Native error payloads are plain strings, so user-environment
+        // failures — connectivity (walking out of Wi-Fi range is the normal
+        // downloads scenario) and a full disk — are classified by keyword and
+        // kept out of Sentry; the scrubbers redact any scheme-less host/IP
+        // the native message embeds.
         if (
-          /connect|network|internet|offline|time.?out|timed out|unreachable|resolve|dns|route/i.test(
+          /connect|network|internet|offline|time.?out|timed out|unreachable|resolve|dns|route|no space|enospc|disk full|not enough (?:free )?space|insufficient storage/i.test(
             event.error,
           )
         ) {
-          writeToLog("WARN", "Download failed (connectivity)", event.error);
+          writeToLog("WARN", "Download failed (user environment)", event.error);
         } else {
           logAndCaptureError("Download failed", event.error, {
             itemType: record.item?.Type,

--- a/providers/NativePlayerProvider.tsx
+++ b/providers/NativePlayerProvider.tsx
@@ -98,7 +98,7 @@ import {
   pickAutoSubtitleTrack,
   type SubtitleSelectablePlayer,
 } from "@/utils/jellyfin/subtitleUtils";
-import { logAndCaptureError, writeToLog } from "@/utils/log";
+import { logAndCaptureError, writeErrorLog, writeToLog } from "@/utils/log";
 import {
   buildNativePlayerConfig,
   buildNativePlayerStrings,
@@ -740,9 +740,17 @@ const NativePlayerProviderInner: React.FC<{
           await presentNativePlayer(built.config);
         }
       } catch (error) {
-        logAndCaptureError("NativePlayer present/load failed", error, {
-          replace: !!options.replace,
-        });
+        if (String(error).includes("NoActivePlayerException")) {
+          // The user dismissed the player while the replace negotiation was
+          // still in flight — a routine race, fully recovered below.
+          writeErrorLog("NativePlayer load raced dismissal", {
+            replace: !!options.replace,
+          });
+        } else {
+          logAndCaptureError("NativePlayer present/load failed", error, {
+            replace: !!options.replace,
+          });
+        }
         if (options.replace && previous) {
           // The in-place swap failed midway: the old server session is
           // already closed and the stream state is unknown — tear the whole

--- a/providers/WebSocketProvider.tsx
+++ b/providers/WebSocketProvider.tsx
@@ -19,7 +19,7 @@ import { getJellyfinHeaders, hasHeaders } from "@/utils/customHeaders";
 import { getOrSetDeviceId } from "@/utils/device";
 import { describeHttpResponse } from "@/utils/errors";
 import { getWebSocketUrl } from "@/utils/jellyfin/getWebSocketUrl";
-import { logAndCaptureError } from "@/utils/log";
+import { logAndCaptureError, writeErrorLog } from "@/utils/log";
 
 // Query keys that depend on the set of library items and should be refreshed
 // when the server reports that the library changed (items added/removed/updated).
@@ -395,6 +395,18 @@ export const WebSocketProvider = ({ children }: WebSocketProviderProps) => {
         // that blocks the POST, or turns it into a GET via an http→https
         // redirect (405).
         if (isAxiosError(error) && error.response?.status === 401) return;
+        if (isAxiosError(error) && error.response?.status === 404) {
+          // Jellyfin's own ExceptionMiddleware answers 404 ("Error processing
+          // request.", text/plain) when this POST races session registration
+          // at start/resume; the session appears moments later and the effect
+          // re-posts on the next api/network change. Timing, not an app bug —
+          // local log only.
+          writeErrorLog(
+            "Posting session capabilities failed",
+            describeHttpResponse(error),
+          );
+          return;
+        }
         logAndCaptureError(
           "Posting session capabilities failed",
           error,

--- a/utils/errors.test.ts
+++ b/utils/errors.test.ts
@@ -3,6 +3,7 @@ import { AxiosError, type AxiosResponse } from "axios";
 import {
   describeHttpError,
   describeHttpResponse,
+  isAbortLikeError,
   isConnectivityError,
   templateRequestPath,
 } from "./errors";
@@ -113,6 +114,31 @@ describe("isConnectivityError", () => {
     expect(isConnectivityError(httpError(500))).toBe(false);
     expect(isConnectivityError(httpError(404))).toBe(false);
     expect(isConnectivityError(httpError(401))).toBe(false);
+  });
+
+  test("Cloudflare origin-down statuses are connectivity", () => {
+    expect(isConnectivityError(httpError(521))).toBe(true);
+    expect(isConnectivityError(httpError(522))).toBe(true);
+    expect(isConnectivityError(httpError(523))).toBe(true);
+  });
+});
+
+describe("isAbortLikeError", () => {
+  test("expo/fetch cancellations are aborts despite the plain Error shape", () => {
+    expect(
+      isAbortLikeError(
+        new Error(
+          "fetch failed: FetchRequestCanceledException: Fetch request has been canceled",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  test("other plain errors are not aborts", () => {
+    expect(isAbortLikeError(new Error("fetch failed: connection lost"))).toBe(
+      false,
+    );
+    expect(isAbortLikeError(httpError(404))).toBe(false);
   });
 });
 

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -35,17 +35,27 @@ export const isErrorReported = (error: unknown): boolean =>
   typeof error === "object" &&
   (error as Record<symbol, unknown>)[REPORTED_ERROR] === true;
 
+// expo/fetch rejects a cancelled request with a plain Error whose message
+// carries the native exception name, not with an AbortError — without this
+// match a timeout abort or an iOS backgrounding cancel reads as a failure.
+const FETCH_CANCEL_PATTERN =
+  /FetchRequestCanceledException|fetch request has been canceled/i;
+
 /** True for cancelled/aborted requests (navigation away, new keystroke) —
  * routine control flow that should never be reported as a failure. */
 export const isAbortLikeError = (error: unknown): boolean =>
   isCancel(error) ||
   (error instanceof Error &&
-    (error.name === "AbortError" || error.name === "CanceledError"));
+    (error.name === "AbortError" ||
+      error.name === "CanceledError" ||
+      FETCH_CANCEL_PATTERN.test(error.message)));
 
 // A gateway status means the reverse proxy in front of Jellyfin answered but
 // Jellyfin itself did not (container down, restarting, upstream timeout) —
-// from the app's side that is an unreachable server, not an app bug.
-const GATEWAY_STATUSES = new Set([502, 503, 504]);
+// from the app's side that is an unreachable server, not an app bug. 521-523
+// are Cloudflare's spellings of the same thing (origin down/unreachable); one
+// origin-down blip otherwise fans out into one issue per in-flight route.
+const GATEWAY_STATUSES = new Set([502, 503, 504, 521, 522, 523]);
 
 /**
  * True for requests that never got a usable HTTP response — the server is

--- a/utils/jellyfin/media/getStreamUrl.ts
+++ b/utils/jellyfin/media/getStreamUrl.ts
@@ -5,6 +5,7 @@ import type {
 } from "@jellyfin/sdk/lib/generated-client/models";
 import { BaseItemKind } from "@jellyfin/sdk/lib/generated-client/models/base-item-kind";
 import { getMediaInfoApi } from "@jellyfin/sdk/lib/utils/api";
+import { markExpectedError } from "../../errors";
 import { generateDownloadProfile } from "../../profiles/download";
 import type { AudioTranscodeModeType } from "../../profiles/native";
 
@@ -173,8 +174,13 @@ export const getStreamUrl = async ({
     sessionId = res.data.PlaySessionId || null;
     mediaSource = res.data.MediaSources?.[0];
     if (!mediaSource) {
-      throw new Error(
-        `PlaybackInfo returned no media source for live channel (${res.data.ErrorCode ?? "no ErrorCode"})`,
+      // A server-side negotiation outcome (profile can't be satisfied,
+      // transcoding disabled), not an app defect: expected keeps it out of
+      // Sentry while the player surfaces it to the user.
+      throw markExpectedError(
+        new Error(
+          `PlaybackInfo returned no media source for live channel (${res.data.ErrorCode ?? "no ErrorCode"})`,
+        ),
       );
     }
     const url = getPlaybackUrl(api, item.ChannelId!, mediaSource, {
@@ -228,8 +234,12 @@ export const getStreamUrl = async ({
   // Fabricating a stream URL anyway just moves the failure into an opaque
   // decoder error minutes later, so fail here where the reason is known.
   if (!mediaSource) {
-    throw new Error(
-      `PlaybackInfo returned no media source (${res.data.ErrorCode ?? "no ErrorCode"})`,
+    // Same as the live-channel case: the server said no (NoCompatibleStream,
+    // RateLimitExceeded), which is its configuration, not an app bug.
+    throw markExpectedError(
+      new Error(
+        `PlaybackInfo returned no media source (${res.data.ErrorCode ?? "no ErrorCode"})`,
+      ),
     );
   }
 

--- a/utils/log.tsx
+++ b/utils/log.tsx
@@ -8,6 +8,7 @@ import {
   describeHttpError,
   isAbortLikeError,
   isConnectivityError,
+  isExpectedError,
   markErrorReported,
 } from "./errors";
 import { storage } from "./mmkv";
@@ -170,7 +171,14 @@ export const logAndCaptureError = (
   context?: Record<string, unknown>,
 ) => {
   appendLogEntry("ERROR", message, describeErrorForLog(error));
-  if (isAbortLikeError(error) || isConnectivityError(error)) {
+  // Expected errors (markExpectedError) are user-facing outcomes — a wrong
+  // URL, a server that can't satisfy the device profile — logged locally
+  // like everything else, but never a Sentry event.
+  if (
+    isExpectedError(error) ||
+    isAbortLikeError(error) ||
+    isConnectivityError(error)
+  ) {
     return;
   }
   // If this error is later rethrown into React Query, the global handler in

--- a/utils/sentry.test.ts
+++ b/utils/sentry.test.ts
@@ -34,8 +34,14 @@ mock.module("@/utils/version", () => ({
 }));
 stubReactNative();
 
-const { scrubDeep, isUserInteractionBreadcrumb, initializeSentryIfConsented } =
-  await import("./sentry");
+const {
+  scrubDeep,
+  isUserInteractionBreadcrumb,
+  initializeSentryIfConsented,
+  classifyOutgoingEvent,
+} = await import("./sentry");
+const { AxiosError } = await import("axios");
+const { markExpectedError } = await import("./errors");
 
 describe("isUserInteractionBreadcrumb — no behaviour tracking, no titles", () => {
   test("drops touch breadcrumbs, whose labels are media titles", () => {
@@ -206,5 +212,73 @@ describe("dev builds do not report", () => {
     setDev(false);
     initializeSentryIfConsented();
     expect(initCalls).toHaveLength(1);
+  });
+});
+
+describe("classifyOutgoingEvent — axios errors on the unhandledrejection path", () => {
+  const axiosError = (status?: number) =>
+    new AxiosError(
+      status ? `Request failed with status code ${status}` : "Network Error",
+      status ? AxiosError.ERR_BAD_RESPONSE : AxiosError.ERR_NETWORK,
+      { method: "get", url: "https://server/Items/abc", headers: {} as never },
+      {},
+      status ? ({ status, headers: {}, config: {} } as never) : undefined,
+    );
+
+  test("connectivity failures are dropped", () => {
+    expect(
+      classifyOutgoingEvent({} as never, { originalException: axiosError() }),
+    ).toBeNull();
+    expect(
+      classifyOutgoingEvent({} as never, {
+        originalException: axiosError(502),
+      }),
+    ).toBeNull();
+  });
+
+  test("expected errors are dropped", () => {
+    expect(
+      classifyOutgoingEvent({} as never, {
+        originalException: markExpectedError(axiosError(400)),
+      }),
+    ).toBeNull();
+  });
+
+  test("a real HTTP failure gets the route+status fingerprint", () => {
+    const event = { contexts: {} } as never as Parameters<
+      typeof classifyOutgoingEvent
+    >[0];
+    const out = classifyOutgoingEvent(event, {
+      originalException: axiosError(400),
+    });
+    expect(out?.fingerprint).toEqual([
+      "unhandled-http",
+      "GET",
+      "/Items/abc",
+      "400",
+    ]);
+    expect(out?.contexts?.http).toEqual({
+      method: "GET",
+      path: "/Items/abc",
+      status: 400,
+    });
+  });
+
+  test("a fingerprint set by an explicit capture path is not overwritten", () => {
+    const event = { fingerprint: ["data-layer"] } as never as Parameters<
+      typeof classifyOutgoingEvent
+    >[0];
+    const out = classifyOutgoingEvent(event, {
+      originalException: axiosError(400),
+    });
+    expect(out?.fingerprint).toEqual(["data-layer"]);
+  });
+
+  test("non-axios exceptions pass through untouched", () => {
+    const event = {} as never as Parameters<typeof classifyOutgoingEvent>[0];
+    expect(
+      classifyOutgoingEvent(event, { originalException: new Error("x") }),
+    ).toBe(event);
+    expect(classifyOutgoingEvent(event, undefined)).toBe(event);
   });
 });

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -1,5 +1,12 @@
 import * as Sentry from "@sentry/react-native";
+import { isAxiosError } from "axios";
 import { Platform } from "react-native";
+import {
+  describeHttpError,
+  isAbortLikeError,
+  isConnectivityError,
+  isExpectedError,
+} from "@/utils/errors";
 import {
   readStoredPluginSettings,
   readStoredSettings,
@@ -140,7 +147,48 @@ export const isUserInteractionBreadcrumb = (
 const NATIVE_SDK_OPTIONS = {
   enableSwizzling: false,
   enableNetworkBreadcrumbs: false,
+  // "Non fully blocked" hangs are main-thread stalls where some run loop
+  // still turns: every event so far was a 2-3s startup stall on a slow
+  // device whose stack held only UIApplicationMain/CFRunLoop frames —
+  // nothing to act on. Fully blocked hangs keep reporting.
+  enableReportNonFullyBlockedAppHangs: false,
 } as Partial<Parameters<typeof Sentry.init>[0]>;
+
+/**
+ * The last line of defence for axios failures that reach Sentry OUTSIDE the
+ * explicit capture paths (a floating promise → onunhandledrejection): those
+ * events carry no app frames and none of the route identity the data-layer
+ * and logAndCaptureError paths attach, so every such failure — any endpoint,
+ * any status — regroups into one stackless issue. Apply the same rules here:
+ * connectivity/aborted/expected failures never leave the app, and the rest
+ * are fingerprinted by route and status. Exported for tests.
+ */
+export const classifyOutgoingEvent = (
+  event: Sentry.ErrorEvent,
+  // Structural type: the RN SDK doesn't re-export @sentry/core's EventHint.
+  hint: { originalException?: unknown } | undefined,
+): Sentry.ErrorEvent | null => {
+  const cause = hint?.originalException;
+  if (!isAxiosError(cause)) return event;
+  if (
+    isAbortLikeError(cause) ||
+    isConnectivityError(cause) ||
+    isExpectedError(cause)
+  ) {
+    return null;
+  }
+  const http = describeHttpError(cause);
+  if (http && !event.fingerprint) {
+    event.contexts = { ...event.contexts, http };
+    event.fingerprint = [
+      "unhandled-http",
+      http.method,
+      http.path,
+      String(http.status),
+    ];
+  }
+  return event;
+};
 
 const initializeSentry = () => {
   if (initialized || !SENTRY_DSN || !reportsFromThisBuild()) return;
@@ -172,7 +220,10 @@ const initializeSentry = () => {
           "build.run": build.runNumber ?? "none",
         },
       },
-      beforeSend: (event) => scrubDeep(event) as typeof event,
+      beforeSend: (event, hint) => {
+        const classified = classifyOutgoingEvent(event, hint);
+        return classified ? (scrubDeep(classified) as typeof classified) : null;
+      },
       beforeBreadcrumb: (breadcrumb) =>
         isUserInteractionBreadcrumb(breadcrumb)
           ? null


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

We went through every open error report in Sentry. This PR fixes what was fixable and stops the reports that were never real bugs. Four groups, one commit each:

**1. Less noise in Sentry**

A lot of reports were things we can't fix and don't need to see:
- The user's internet dropped, the server was unreachable, or a request was cancelled because the user navigated away. These are now filtered out before they reach Sentry.
- Things the user is told about directly anyway, like typing a wrong Jellyseerr server address, now don't also create a Sentry issue.
- Errors we understand but can't act on, like a known Jellyfin server hiccup at startup or a full disk on the user's phone, are now only written to the local log.

The reports that *do* still go to Sentry are now labeled with which exact request failed. Before, hundreds of unrelated network errors were lumped into one giant issue because they all looked the same to Sentry.

**2. Crashes fixed**

- A few screens crashed in production because a data fetch came back empty in a way our data library refuses. They now return an explicit "nothing" it accepts.
- Logging out while a library screen was open crashed the app, because the screen tried to refresh its data after the connection was already gone. It no longer refreshes when you're logged out.
- The Jellyseerr request window crashed when the server had no default download folder. It now shows a "—" placeholder instead.

**3. Jellyseerr stopped logging people out**

Opening one request you're not allowed to see used to wipe your whole Jellyseerr login. Now it just fails for that one request and you stay logged in.

**4. Video player crash on exit**

Closing the player at exactly the wrong moment (for example while switching quality or episode) could make the app freeze and then crash. This was a threading bug in the native player code: the cleanup could end up waiting for itself, forever. The cleanup is now written so that can't happen (`modules/mpv-player/ios/MPVLayerRenderer.swift`).

There's also a test commit covering the new Sentry filtering rules.

## 🏷️ Ticket / Issue

N/A — this comes from a review of the Sentry error reports, not a single tracked issue.

### 🖼️ Screenshots / GIFs (if UI)

N/A — the only visible change is the folder label in the Jellyseerr request window, which now shows the chosen folder and its free space instead of crashing when there's no default.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

The platform box stays unticked until the player fix gets a test on a real build — it's native code, so it needs a full rebuild, not just a Metro reload.

## 🔍 Testing Instructions

1. `bun i && bun run prebuild && bun run ios` (the player fix is native code and needs a full rebuild).
2. Player: start a video, switch quality or episode, and close the player mid-switch. Repeat a few times. It should always close cleanly — before, this could freeze and crash.
3. Jellyseerr: open a request your user isn't allowed to see. You should stay logged in — before, this logged you out of Jellyseerr.
4. Logout: browse the Libraries tab, then log out. No crash — before, the app could crash right after logout.
5. Request window: open a request on a server with no default download folder. You should see a "—" placeholder — before, this crashed.
6. Sentry (needs a preview/TestFlight build, dev builds don't report): turn off Wi-Fi mid-browse, cancel loads by navigating away, or mistype the Jellyseerr address. None of these should create new Sentry issues, and real errors should show up as separate, clearly-labeled issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented crashes and unnecessary requests during logout or offline use.
  - Improved playback error alerts when compatible streams cannot be provided.
  - Fixed Jellyseerr folder display issues and prevented login/request validation errors from being misreported.
  - Improved download, session, WebSocket, and native-player error handling.
  - Prevented sign-out loops while viewing Jellyseerr request details.
  - Improved handling of canceled requests, server availability issues, and storage-full download failures.
- **Tests**
  - Added coverage for cancellation, connectivity, and error-reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->