### PR TITLE
fix(player): ignore an outgoing stream's EOF during an in-place swap

### DIFF
--- a/providers/NativePlayerProvider.tsx
+++ b/providers/NativePlayerProvider.tsx
@@ -100,6 +100,7 @@ import {
   type SubtitleSelectablePlayer,
 } from "@/utils/jellyfin/subtitleUtils";
 import { logAndCaptureError, writeToLog } from "@/utils/log";
+import { applyPlaybackEnded } from "@/utils/nativePlayer/applyPlaybackEnded";
 import { applyProgressTick } from "@/utils/nativePlayer/applyProgressTick";
 import {
   buildNativePlayerConfig,
@@ -1640,9 +1641,7 @@ const NativePlayerProviderInner: React.FC<{
       }),
 
       addNativePlayerListener("onPlaybackEnded", (payload) => {
-        const session = sessionRef.current;
-        if (!session) return;
-        session.positionMs = payload.positionSec * 1000;
+        applyPlaybackEnded(sessionRef.current, payload.positionSec);
       }),
 
       addNativePlayerListener("onDismiss", (payload) => {

--- a/utils/nativePlayer/applyPlaybackEnded.test.ts
+++ b/utils/nativePlayer/applyPlaybackEnded.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyPlaybackEnded,
+  type PlaybackEndedSession,
+} from "./applyPlaybackEnded";
+
+const session = (
+  overrides: Partial<PlaybackEndedSession> = {},
+): PlaybackEndedSession => ({
+  positionMs: 600_000,
+  awaitingLoad: false,
+  ...overrides,
+});
+
+describe("applyPlaybackEnded", () => {
+  test("moves the tracked position to where the stream ended", () => {
+    const s = session();
+    expect(applyPlaybackEnded(s, 2_640.5)).toBe(true);
+    expect(s.positionMs).toBe(2_640_500);
+  });
+
+  test("ignores the outgoing stream's end of file during an in-place swap", () => {
+    // The incoming session still sits at its seeded start; the event carries
+    // the outgoing stream's final position and must not land on it.
+    const s = session({ positionMs: 0, awaitingLoad: true });
+    expect(applyPlaybackEnded(s, 2_640.5)).toBe(false);
+    expect(s.positionMs).toBe(0);
+  });
+
+  test("ignores the event when no session is active", () => {
+    expect(applyPlaybackEnded(null, 2_640.5)).toBe(false);
+    expect(applyPlaybackEnded(undefined, 2_640.5)).toBe(false);
+  });
+});

--- a/utils/nativePlayer/applyPlaybackEnded.ts
+++ b/utils/nativePlayer/applyPlaybackEnded.ts
@@ -1,0 +1,26 @@
+/** The slice of the native session an end-of-file event reads and writes. */
+export type PlaybackEndedSession = {
+  positionMs: number;
+  awaitingLoad: boolean;
+};
+
+/**
+ * Applies one native onPlaybackEnded event to the session and says whether it
+ * was taken.
+ *
+ * beginSession points the session ref at the incoming session (awaitingLoad)
+ * before its stream has loaded, while the outgoing stream keeps playing in
+ * mpv. If that stream reaches end of file inside the window, the event
+ * carries the outgoing stream's position; writing it onto the incoming
+ * session would make the final progress and stop reports mark the new item
+ * as stopped where the previous one ended. Every sibling listener already
+ * drops events while awaitingLoad is set, so this one does too.
+ */
+export function applyPlaybackEnded(
+  session: PlaybackEndedSession | null | undefined,
+  positionSec: number,
+): boolean {
+  if (!session || session.awaitingLoad) return false;
+  session.positionMs = positionSec * 1000;
+  return true;
+}


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description
Split out of #2003 (sibling bug, same listener block).

`beginSession` in `providers/NativePlayerProvider.tsx` points `sessionRef` at the incoming session with `awaitingLoad: true` before the new stream has loaded, while the outgoing stream keeps playing in mpv. If the outgoing stream reaches end of file inside that window, both native players emit `onPlaybackEnded` with the outgoing stream's position, and the `onPlaybackEnded` listener wrote it onto the incoming session, so the final progress and stop reports marked the new item as stopped where the previous one ended. Every sibling listener already drops events while `awaitingLoad` is set (`onNextEpisodeRequested` documents the same swap-EOF window); this one now does too.

The listener body moved into `applyPlaybackEnded` (`utils/nativePlayer/`) so the guard is unit tested, following `applyProgressTick` from #2003. No native code changes.

## 🏷️ Ticket / Issue
N/A — follow-up to #2003.

### 🖼️ Screenshots / GIFs (if UI)
N/A

## ✅ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions
Ground truth is the Jellyfin server log (`Playback stopped ... Stopped at X ms`) and each item's resume position in the web client.

1. With auto-play next enabled, play episode A in the native player from a few seconds before its end and let the countdown swap to episode B.
2. Make B slow to load (a transcode or a throttled network) so A reaches its end while B is still loading.
3. Exit the player as soon as B starts. Before: B's stop line carries A's end-of-file position. After: B's stop line carries B's real position (a few seconds in).
4. Regression check: play any item to its natural end with no swap. The stop line must still carry the end position and the item must be marked played.

The guard is covered by `utils/nativePlayer/applyPlaybackEnded.test.ts`; the race itself has not been reproduced on a device, hence the unticked platform box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback completion handling so the final position is saved accurately.
  * Prevented stale end-of-playback events from interrupting content while a new stream is loading.
  * Improved stability when playback events occur without an active session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->