### PR TITLE
fix(player): keep a session that never took the player out of the reports

### DIFF
--- a/providers/NativePlayerProvider.tsx
+++ b/providers/NativePlayerProvider.tsx
@@ -111,7 +111,8 @@ import {
   type PlayRequest,
   toDirectPlayerQuery,
 } from "@/utils/nativePlayer/playRequest";
-import { resolveFinalPositionMs } from "@/utils/nativePlayer/resolveFinalPositionMs";
+import { resolveFailedPresentation } from "@/utils/nativePlayer/resolveFailedPresentation";
+import { resolveTeardownReport } from "@/utils/nativePlayer/resolveTeardownReport";
 import {
   fetchAndParseSegments,
   getSegmentsForItem,
@@ -143,11 +144,27 @@ interface NativeSession extends NativePlayerSessionSeed {
   /**
    * True from session creation until the new stream's onLoad arrives. The
    * engine is swapped in place, so events from the OUTGOING stream can still
-   * arrive after sessionRef points at the new session — every handler except
-   * onLoad/onDismiss drops events while this is set (the fix for the class
-   * of races direct-player guards with currentItemIdRef).
+   * arrive after sessionRef points at the new session — the handlers that
+   * write playback state drop events while this is set (the fix for the
+   * class of races direct-player guards with currentItemIdRef). onDismiss
+   * still tears the session down, but the position it carries belongs to
+   * the outgoing stream, so a committed session's teardown reports the
+   * tracked position instead and an uncommitted one reports nothing
+   * (resolveTeardownReport).
    */
   awaitingLoad: boolean;
+  /**
+   * Set on the edge where the present/load promise resolved with sessionRef
+   * still pointing here: the start report goes out on that edge, and only a
+   * committed session sends the final progress and stop reports at teardown.
+   * A session torn down before it committed never took the player, so a stop
+   * for it would describe a playback the server never saw start and
+   * overwrite the item's resume position with wherever the outgoing stream
+   * was. Not derived from awaitingLoad: on both platforms present() and
+   * load() resolve before onLoad, so every swap passes through a committed
+   * but still loading moment.
+   */
+  committed: boolean;
   lastProgressReportAt: number;
   /** Results of the last remote-subtitle search — download taps key into it. */
   subtitleSearchResults: SubtitleSearchResult[] | null;
@@ -181,7 +198,13 @@ interface NativePlayerContextValue {
   /**
    * Fetch the item, negotiate the stream and present the native player.
    * Resolves false when it declined (unsupported platform, config-build
-   * failure, native throw) so the caller can fall back to the JS route.
+   * failure, a native throw with the player still up) so the caller can fall
+   * back to the JS route. Resolves true when the request was taken,
+   * including when the player was closed while it was in flight: there is
+   * nothing to fall back to for an item the user just closed. A request
+   * superseded by a newer one before it took the player resolves false; one
+   * superseded after its load was issued resolves true, since the newer
+   * request owns the player.
    */
   presentFromRequest: (req: PlayRequest) => Promise<boolean>;
   isActive: boolean;
@@ -445,6 +468,9 @@ const NativePlayerProviderInner: React.FC<{
     async (session: NativeSession, positionTicks?: number) => {
       const currentApi = apiRef.current;
       if (!session.item.Id || !currentApi || !isConnectedRef.current) return;
+      // No start report went out for a session that never committed; a stop
+      // would still overwrite the item's resume position on the server.
+      if (!session.committed) return;
       // Dedupe per session: dismissal and stream replacement can both try to
       // close the same session (sessionId, or item id for downloads).
       const stopKey = session.stream.sessionId || session.item.Id;
@@ -671,6 +697,7 @@ const NativePlayerProviderInner: React.FC<{
         hasPlaybackStarted: false,
         reportedStopKey: null,
         awaitingLoad: true,
+        committed: false,
         lastProgressReportAt: 0,
         subtitleSearchResults: null,
         subtitleSearchToken: 0,
@@ -728,6 +755,19 @@ const NativePlayerProviderInner: React.FC<{
           // old session playing and reportable.
           await reportPlaybackStopped(previous);
           releaseLiveStream(previous);
+          // A newer request started during that round trip: yield to it, as
+          // the token check above does, so the newest request still wins.
+          if (token !== playRequestTokenRef.current) {
+            releaseLiveStream(session);
+            return false;
+          }
+          // A dismiss landed during the round trip (teardownSession clears
+          // sessionRef at once): there is no `previous` to swap out, and a
+          // load issued now would land on a dismissing session.
+          if (sessionRef.current !== previous) {
+            releaseLiveStream(session);
+            return true;
+          }
           sessionRef.current = session;
           await loadNativePlayerStream(built.config);
         } else {
@@ -744,7 +784,7 @@ const NativePlayerProviderInner: React.FC<{
       } catch (error) {
         if (String(error).includes("NoActivePlayerException")) {
           // The user dismissed the player while the replace negotiation was
-          // still in flight — a routine race, fully recovered below.
+          // still in flight — a routine race, recovered below.
           writeErrorLog("NativePlayer load raced dismissal", {
             replace: !!options.replace,
           });
@@ -753,20 +793,54 @@ const NativePlayerProviderInner: React.FC<{
             replace: !!options.replace,
           });
         }
-        if (options.replace && previous) {
-          // The in-place swap failed midway: the old server session is
-          // already closed and the stream state is unknown — tear the whole
-          // player down (onDismiss handles the rest) instead of leaving a
-          // half-dead session behind.
+        const outcome = resolveFailedPresentation({
+          sessionIsCurrent: sessionRef.current === session,
+          swapped: !!(options.replace && previous),
+          playerPresented: isNativePlayerPresented(),
+        });
+        if (outcome === "restore") {
+          // The swap failed with the player still up on the old stream: its
+          // server session is already closed and the stream state is unknown,
+          // so tear the whole player down (onDismiss handles the rest)
+          // instead of leaving a half-dead session behind.
+          releaseLiveStream(session);
           sessionRef.current = previous;
           void dismissNativePlayer();
-        } else {
+        } else if (outcome === "player-gone") {
+          // The player closed while the swap was in flight (a close tap, or
+          // the outgoing stream reaching its end) and no onDismiss can be
+          // relied on for this session: one may still be queued, but
+          // dismiss() with nothing presented resolves silently. Restoring
+          // `previous` here left a session nothing could clear once its own
+          // teardown had finished, so every later play took the replace path
+          // against no player and fell back to the JS player.
+          releaseLiveStream(session);
+          sessionRef.current = null;
+          setActiveItem(null);
+          setIsActive(false);
+          revalidateProgressCache();
+          unlockOrientation();
+        } else if (outcome === "unpresented") {
+          releaseLiveStream(session);
           sessionRef.current = previous;
           unlockOrientation();
         }
-        return false;
+        // "closed": onDismiss or a newer request already moved sessionRef and
+        // released this session's stream. Both it and "player-gone" resolve
+        // true: the player was closed under this request or a newer request
+        // took it, and a false return would send the caller to the JS player
+        // for an item the user just closed.
+        return outcome === "closed" || outcome === "player-gone";
       }
 
+      // The player can go away while the native call is in flight (a close
+      // tap, or the outgoing stream reaching its end; iOS load() still
+      // resolves during the dismiss fade). onDismiss has already torn this
+      // session down: a start report now would describe a player that no
+      // longer exists, and a false return would send the caller to the JS
+      // player for an item the user just closed.
+      if (sessionRef.current !== session) return true;
+      session.committed = true;
       setActiveItem(session.item);
       setIsActive(true);
       // Empty the legacy single-slot state before playback starts: it is
@@ -786,6 +860,7 @@ const NativePlayerProviderInner: React.FC<{
       reportPlaybackStart,
       reportPlaybackStopped,
       releaseLiveStream,
+      revalidateProgressCache,
       clearLastMessage,
       pushSegments,
       pushEpisodeList,
@@ -805,7 +880,8 @@ const NativePlayerProviderInner: React.FC<{
   /**
    * Same-item stream re-negotiation (tracks/bitrate), resuming in place.
    * Resolves false when the swap failed (beginSession swallows and reports
-   * its own errors) — callers that promise success must check.
+   * its own errors) — callers that promise success must check. A swap
+   * abandoned because the player closed under it resolves true.
    */
   const replaceStream = useCallback(
     async (
@@ -875,27 +951,35 @@ const NativePlayerProviderInner: React.FC<{
 
   const teardownSession = useCallback(
     async (session: NativeSession, finalPositionSec?: number) => {
-      session.positionMs = resolveFinalPositionMs(
-        session.positionMs,
-        finalPositionSec,
-      );
-      const positionTicks = msToTicks(session.positionMs);
-      // Final progress write first: it also lands in the downloads DB for
-      // offline items (5%/90% thresholds), then close the server session.
-      const info = buildProgressInfo(session);
-      try {
-        await reportProgressRef.current(info);
-      } catch {}
-      // Both reports carry the ticks resolved above; the stop report does not
-      // re-read session.positionMs after the await.
-      await reportPlaybackStopped(session, positionTicks);
-      releaseLiveStream(session);
-      revalidateProgressCache();
-      unlockOrientation();
+      // Release the ref before the report round trips: a play request that
+      // lands during them must see no session, or it takes the replace path
+      // against a player that is already gone.
       if (sessionRef.current === session) {
         sessionRef.current = null;
         setActiveItem(null);
         setIsActive(false);
+      }
+      const positionMs = resolveTeardownReport(session, finalPositionSec);
+      if (positionMs !== null) {
+        session.positionMs = positionMs;
+        const positionTicks = msToTicks(positionMs);
+        // Final progress write first: it also lands in the downloads DB for
+        // offline items (5%/90% thresholds), then close the server session.
+        const info = buildProgressInfo(session);
+        try {
+          await reportProgressRef.current(info);
+        } catch {}
+        // Both reports carry the ticks resolved above; the stop report does
+        // not re-read session.positionMs after the await.
+        await reportPlaybackStopped(session, positionTicks);
+      }
+      // The stream was negotiated on the server whether or not it loaded.
+      releaseLiveStream(session);
+      revalidateProgressCache();
+      // A play request that landed during the report round trips owns the
+      // player now and holds its own orientation lock.
+      if (sessionRef.current === null) {
+        unlockOrientation();
       }
     },
     [
@@ -1649,7 +1733,11 @@ const NativePlayerProviderInner: React.FC<{
 
       addNativePlayerListener("onPlaybackEnded", (payload) => {
         const session = sessionRef.current;
-        if (!session) return;
+        // The outgoing stream's end during an in-place swap arrives here
+        // first and its dismiss right behind it; the tracked position has to
+        // survive intact for the teardown of a session whose own onLoad has
+        // not arrived (resolveTeardownReport).
+        if (!session || session.awaitingLoad) return;
         session.positionMs = payload.positionSec * 1000;
       }),
 

--- a/utils/nativePlayer/resolveFailedPresentation.test.ts
+++ b/utils/nativePlayer/resolveFailedPresentation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { resolveFailedPresentation } from "./resolveFailedPresentation";
+
+describe("resolveFailedPresentation", () => {
+  test("leaves a session that is no longer current alone", () => {
+    expect(
+      resolveFailedPresentation({
+        sessionIsCurrent: false,
+        swapped: true,
+        playerPresented: false,
+      }),
+    ).toBe("closed");
+    expect(
+      resolveFailedPresentation({
+        sessionIsCurrent: false,
+        swapped: false,
+        playerPresented: true,
+      }),
+    ).toBe("closed");
+  });
+
+  test("restores the old session when a swap failed on a presented player", () => {
+    expect(
+      resolveFailedPresentation({
+        sessionIsCurrent: true,
+        swapped: true,
+        playerPresented: true,
+      }),
+    ).toBe("restore");
+  });
+
+  test("clears the session when a swap failed because the player is gone", () => {
+    // The race: the outgoing stream ended, or the user closed the player,
+    // while the swap was in flight; load() rejected and no onDismiss follows.
+    expect(
+      resolveFailedPresentation({
+        sessionIsCurrent: true,
+        swapped: true,
+        playerPresented: false,
+      }),
+    ).toBe("player-gone");
+  });
+
+  test("unpresents a first presentation that failed", () => {
+    expect(
+      resolveFailedPresentation({
+        sessionIsCurrent: true,
+        swapped: false,
+        playerPresented: false,
+      }),
+    ).toBe("unpresented");
+  });
+});

--- a/utils/nativePlayer/resolveFailedPresentation.ts
+++ b/utils/nativePlayer/resolveFailedPresentation.ts
@@ -1,0 +1,29 @@
+/** What beginSession does after present() or load() rejected. */
+export type FailedPresentationOutcome =
+  | "closed"
+  | "restore"
+  | "player-gone"
+  | "unpresented";
+
+/**
+ * "closed": the session ref no longer points at the failed session, because
+ * an onDismiss tore it down or a newer request took the player; its
+ * bookkeeping is done and touching the ref would undo the newer state.
+ * "restore": an in-place swap failed with the player still up on the old
+ * stream; point the ref back and dismiss so onDismiss closes it.
+ * "player-gone": the swap failed because the player is already gone, and no
+ * onDismiss can be relied on for this session (one may still be queued, but
+ * dismiss() with nothing presented resolves silently); the ref has to be
+ * cleared here, or every later play takes the replace path against no
+ * player.
+ * "unpresented": a first presentation never reached the screen.
+ */
+export function resolveFailedPresentation(input: {
+  sessionIsCurrent: boolean;
+  swapped: boolean;
+  playerPresented: boolean;
+}): FailedPresentationOutcome {
+  if (!input.sessionIsCurrent) return "closed";
+  if (!input.swapped) return "unpresented";
+  return input.playerPresented ? "restore" : "player-gone";
+}

--- a/utils/nativePlayer/resolveTeardownReport.test.ts
+++ b/utils/nativePlayer/resolveTeardownReport.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { resolveTeardownReport } from "./resolveTeardownReport";
+
+describe("resolveTeardownReport", () => {
+  test("reports nothing for a session that never committed", () => {
+    // The onDismiss position is the outgoing episode's end; the incoming
+    // session still sits at its seed and never sent a start report.
+    expect(
+      resolveTeardownReport(
+        { committed: false, awaitingLoad: true, positionMs: 0 },
+        2_518,
+      ),
+    ).toBeNull();
+  });
+
+  test("reports nothing even after onPlaybackEnded moved the tracked position", () => {
+    // Gating only the onPlaybackEnded write was not enough: both readings
+    // belong to the outgoing stream.
+    expect(
+      resolveTeardownReport(
+        { committed: false, awaitingLoad: true, positionMs: 2_518_000 },
+        2_518,
+      ),
+    ).toBeNull();
+  });
+
+  test("reports the tracked position while the committed stream is still loading", () => {
+    // present()/load() resolved (start report sent at the seed) but onLoad
+    // has not arrived, so the native position is still the outgoing stream's.
+    expect(
+      resolveTeardownReport(
+        { committed: true, awaitingLoad: true, positionMs: 300_000 },
+        2_518,
+      ),
+    ).toBe(300_000);
+  });
+
+  test("takes the later of the tracked and native positions once loaded", () => {
+    expect(
+      resolveTeardownReport(
+        { committed: true, awaitingLoad: false, positionMs: 1_200_000 },
+        1_200.5,
+      ),
+    ).toBe(1_200_500);
+    expect(
+      resolveTeardownReport(
+        { committed: true, awaitingLoad: false, positionMs: 1_200_000 },
+        undefined,
+      ),
+    ).toBe(1_200_000);
+  });
+});

--- a/utils/nativePlayer/resolveTeardownReport.ts
+++ b/utils/nativePlayer/resolveTeardownReport.ts
@@ -1,0 +1,31 @@
+import { resolveFinalPositionMs } from "./resolveFinalPositionMs";
+
+/** The slice of the native session a teardown reads. */
+export type TeardownSession = {
+  committed: boolean;
+  awaitingLoad: boolean;
+  positionMs: number;
+};
+
+/**
+ * The position (ms) the final progress and stop reports carry at teardown,
+ * or null when the session reports nothing.
+ *
+ * A session that never committed never sent a start report. The engine is
+ * swapped in place, so the outgoing stream can end or be closed in the hop
+ * between the session ref moving to the incoming session and its stream
+ * loading, and the onDismiss that follows carries the OUTGOING position:
+ * reporting it would mark the incoming item as stopped where the previous
+ * one ended. A committed session whose own onLoad has not arrived is in the
+ * same hop: on both platforms present() and load() resolve before onLoad,
+ * so the native position is still the outgoing stream's and the tracked
+ * position is what the start report said.
+ */
+export function resolveTeardownReport(
+  session: TeardownSession,
+  finalPositionSec: number | undefined,
+): number | null {
+  if (!session.committed) return null;
+  if (session.awaitingLoad) return session.positionMs;
+  return resolveFinalPositionMs(session.positionMs, finalPositionSec);
+}


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description
Fix the native player getting stuck on the fallback player after a swap is interrupted.

If the player closed, or the old stream ended, while a new episode or track was still loading, the new episode was recorded as stopped at the old one's position and could show up as watched. Every later play opened the fallback player until an app restart. Three testers hit it on iOS this week.

A session now reports progress only once it owns the player, and one whose player is gone is cleared. Closing the player during a swap no longer opens the fallback player for the item you just closed. Unit tests cover the decisions. The race has not been reproduced on a device.

## 🏷️ Ticket / Issue
Follow-up to #2003, supersedes #2016. Sentry REACT-NATIVE-10.

### 🖼️ Screenshots / GIFs (if UI)
N/A

## ✅ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions
Ground truth is the Jellyfin server log (`Playback stopped ... Stopped at X ms`) and each item's resume position in the web client.

1. **Close during a swap.** Play episode A in the native player, open the episode list, pick episode B, and close the player at once. Before: B could be recorded as stopped at A's position, and every later Play opened the JS player instead of the native one until an app restart. After: no stop line for B, A's stop line carries A's position, and the next Play opens the native player.
2. **Outgoing end during a swap.** With auto-play next off, let A run to its last seconds and tap Next as it ends. The window is short, so the timing is hard to hit by hand. When it lands: before, B's stop line carried A's end position. After, B has no stop line, the player closes at A's end, and the next Play opens the native player.
3. **Regression checks.** Play an item to its natural end with no swap (stop line at the end, item marked played). Pause 90 s and exit (stop at the paused position). Exit within a second of the player appearing (resume point preserved). Change audio track or quality mid-playback (playback resumes in place, one stop line for the old server session). Start a second item from another client while one is playing (WS Play swaps in place).
