### PR TITLE
fix(settings): ship the subtitle preview sample video in EAS builds

### DIFF
--- a/.claude/learned-facts/bun-test-discovery-leaks-fds.md
+++ b/.claude/learned-facts/bun-test-discovery-leaks-fds.md
@@ -1,0 +1,27 @@
+# bun test discovery leaks file descriptors, which breaks child-process stdio in tests
+
+**Date**: 2026-08-30
+**Category**: testing
+**Key files**: `assets/bundled-assets.test.ts`
+
+## Detail
+
+Whenever `bun test` (bun 1.3.5) has to discover test files itself — the bare
+`bun test` that `test:unit` and CI run, or a filter such as
+`bun test assets/foo.test.ts` — it walks the whole tree (with `ios/` present,
+about 4,600 directories) and leaves roughly 14,000 file descriptors open while
+the tests run. A child spawned from a test then gets stdio pipes on very high
+descriptors and every write to them fails: `spawnSync` reports the real exit
+code but empty stdout/stderr, `/bin/echo` exits 1, and a `git check-ignore`
+that should have printed matches prints nothing, so an assertion on its output
+passes vacuously. Running the file explicitly (`bun test ./assets/foo.test.ts`
+or an absolute path) skips discovery and works, which is why the failure only
+shows up in the full suite.
+
+Rules:
+
+- Do not spawn processes from unit tests; do the work in-process (the ignore
+  guard uses the `ignore` package instead of `git check-ignore`).
+- When a test must shell out, verify it under a bare `bun test`, not only under
+  an explicit path, and have the child write its result to a file rather than
+  a pipe.

--- a/.claude/learned-facts/eas-archive-drops-gitignored-tracked-files.md
+++ b/.claude/learned-facts/eas-archive-drops-gitignored-tracked-files.md
@@ -1,0 +1,30 @@
+# EAS archives drop files that match .gitignore, even when git tracks them
+
+**Date**: 2026-08-30
+**Category**: build
+**Key files**: `.gitignore`, `assets/bundled-assets.test.ts`, `components/settings/SubtitlePreview.tsx`
+
+## Detail
+
+eas-cli does not upload the working tree. It makes a shallow copy of the
+project and then removes every path that matches the ignore rules, using the
+`ignore` npm package over `.easignore` (if present) or every `.gitignore`
+(`vcs/local.ts`, class `Ignore`). Whether git tracks the file is irrelevant: a
+file added with `git add -f` past a `*.mp4` rule exists in every clone and in
+CI, and is missing on the EAS build machine.
+
+The failure is silent when the `require()` for the asset sits inside a
+`try/catch`. `@expo/metro-config` enables `allowOptionalDependencies`, so Metro
+treats such a require as optional: an unresolvable one compiles to a runtime
+throw instead of failing `expo export:embed`, the IPA ships, and the screen
+shows its error state (subtitle preview, TestFlight build 292).
+
+Rules:
+
+- A JS-required asset must not match any `.gitignore` rule. Re-include it right
+  below the rule (`!assets/sample_subtitled.mp4`); `assets/bundled-assets.test.ts`
+  fails when one slips through.
+- Keep asset `require()` calls at module scope so a missing file fails the
+  bundle.
+- To check what EAS would upload: `eas build:inspect --platform ios --profile
+  production --stage archive --output <dir>` and look for the file.

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ Streamyfin.app
 npm-debug.*
 *.orig.*
 *.mp4
+# Tracked on purpose (subtitle preview sample). EAS archives the project with
+# these rules applied even to tracked files, so it must be re-included here.
+!assets/sample_subtitled.mp4
 
 # OS-specific Files
 # macOS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,10 @@ TV platform:
 - `streamystats-components-location` | components/home/Streamystats*.tv.tsx, watchlists/[watchlistId].tsx
 - `platform-specific-file-suffix-does-not-work` | .tv.* only resolves under EXPO_TV=1; require the TV file explicitly behind Platform.isTV
 
+Build and tooling:
+- `eas-archive-drops-gitignored-tracked-files` | EAS uploads skip anything matching .gitignore even if tracked; re-include required assets, keep asset require() at module scope
+- `bun-test-discovery-leaks-fds` | bare `bun test` leaves ~14k fds open; child processes spawned from tests get dead stdio, so do the work in-process
+
 ## Project overview
 
 Streamyfin is a cross platform Jellyfin client built with Expo and React Native. It runs

--- a/assets/bundled-assets.test.ts
+++ b/assets/bundled-assets.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import ignore from "ignore";
+
+// EAS Build never sees a working tree. eas-cli archives the project first and
+// drops every path that matches .gitignore, tracked or not, so a force-added
+// file is silently left behind. Metro then compiles a require() that cannot be
+// resolved into a runtime throw when it sits inside try/catch (an optional
+// dependency), so the build stays green and the asset first goes missing on
+// TestFlight. That is how the subtitle preview shipped as "Failed to load
+// preview": `*.mp4` is ignored and assets/sample_subtitled.mp4 was force-added.
+//
+// These tests pin every asset the JS bundle requires: it has to exist, and the
+// ignore rules eas-cli applies must not match it. The rules are evaluated with
+// the same `ignore` package eas-cli uses, in-process: bun's test discovery
+// leaves thousands of file descriptors open, which breaks the stdio of any
+// child process a test spawns, so `git check-ignore` is not an option here.
+
+const root = join(__dirname, "..");
+const SOURCE_DIRS = [
+  "app",
+  "components",
+  "constants",
+  "hooks",
+  "modules",
+  "providers",
+  "utils",
+];
+const SOURCE_FILE = /\.tsx?$/;
+const ASSET_REQUIRE = /require\(\s*["']@\/(assets\/[^"']+)["']\s*\)/g;
+
+const sourceFiles = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === "node_modules" ? [] : sourceFiles(path);
+    }
+    return SOURCE_FILE.test(entry.name) ? [path] : [];
+  });
+
+const requiredAssets = [
+  ...new Set(
+    SOURCE_DIRS.flatMap((dir) => sourceFiles(join(root, dir))).flatMap((file) =>
+      [...readFileSync(file, "utf8").matchAll(ASSET_REQUIRE)].map(
+        (match) => match[1],
+      ),
+    ),
+  ),
+].sort();
+
+/** "" (the root) and every directory between it and the file. */
+const parentDirs = (file: string): string[] => {
+  const parts = file.split("/").slice(0, -1);
+  return ["", ...parts.map((_, i) => parts.slice(0, i + 1).join("/"))];
+};
+
+/**
+ * Whether eas-cli would leave the file out of the upload. Every .gitignore
+ * between the repository root and the file applies, relative to its own
+ * directory, and a rule in a parent file wins over an exception in a child
+ * file — so any match ignores (mirror of eas-cli's vcs/local Ignore class).
+ */
+const droppedByEas = (file: string): boolean =>
+  parentDirs(file).some((dir) => {
+    const rules = join(root, dir, ".gitignore");
+    if (!existsSync(rules)) return false;
+    const relativePath = dir ? relative(dir, file) : file;
+    return ignore().add(readFileSync(rules, "utf8")).ignores(relativePath);
+  });
+
+describe("assets required by the JS bundle survive an EAS build", () => {
+  test("the scan finds the assets it is meant to guard", () => {
+    expect(requiredAssets).toContain("assets/sample_subtitled.mp4");
+  });
+
+  test("every required asset exists", () => {
+    const absent = requiredAssets.filter(
+      (asset) => !existsSync(join(root, asset)),
+    );
+    expect(absent).toEqual([]);
+  });
+
+  test("no required asset matches an ignore rule", () => {
+    // A non-empty list here names files EAS will drop from the upload even
+    // though git tracks them; re-include each one below the rule it matches.
+    expect(requiredAssets.filter(droppedByEas)).toEqual([]);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
         "cross-env": "10.1.0",
         "expo-doctor": "1.20.1",
         "husky": "9.1.7",
+        "ignore": "^5.3.2",
         "lint-staged": "17.3.0",
         "tsx": "4.23.12",
         "typescript": "6.0.3",

--- a/components/settings/SubtitlePreview.tsx
+++ b/components/settings/SubtitlePreview.tsx
@@ -22,6 +22,12 @@ import {
   SUBTITLE_PREVIEW_VIDEO_WIDTH,
 } from "@/utils/subtitles";
 
+// Required at module scope on purpose. Inside try/catch, Metro treats a
+// require() as an optional dependency: when the file is missing at bundle time
+// the build still passes and the failure only shows up on the device. Up here a
+// missing sample video fails the bundle instead.
+const SAMPLE_VIDEO = require("@/assets/sample_subtitled.mp4");
+
 export const SubtitlePreview = React.memo(() => {
   const { t } = useTranslation();
   const { settings } = useSettings();
@@ -37,7 +43,7 @@ export const SubtitlePreview = React.memo(() => {
     setIsLoading(true);
     setPlayerReady(false);
     try {
-      const asset = Asset.fromModule(require("@/assets/sample_subtitled.mp4"));
+      const asset = Asset.fromModule(SAMPLE_VIDEO);
       await asset.downloadAsync();
       setAssetUri(asset.localUri || asset.uri);
       setIsLoading(false);

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "cross-env": "10.1.0",
     "expo-doctor": "1.20.1",
     "husky": "9.1.7",
+    "ignore": "^5.3.2",
     "lint-staged": "17.3.0",
     "tsx": "4.23.12",
     "typescript": "6.0.3"


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Ship `assets/sample_subtitled.mp4` in EAS builds so the subtitle preview from #1543 loads on TestFlight. The file was force-added past the `*.mp4` rule in `.gitignore`, and eas-cli drops ignored paths from the upload even when git tracks them. The `require()` in `SubtitlePreview.tsx` sits inside try/catch, so Metro treated it as optional and the build passed anyway. TestFlight 292 shows "Failed to load preview", dev builds work because Metro serves the file over HTTP.

- `.gitignore`: re-include the file below the `*.mp4` rule.
- `SubtitlePreview.tsx`: the `require()` moves to module scope so a missing asset fails the bundle instead.
- `assets/bundled-assets.test.ts`: checks every JS-required asset against the ignore rules with the same `ignore` package eas-cli uses (new devDependency). Fails on `develop`.
- Two learned facts. One of them is that a bare `bun test` leaks about 14k file descriptors during discovery, so a child process spawned from a test loses its stdio. That is why the test does not shell out to `git check-ignore`.

Not in this PR: `setSubtitleStyle` writes `sub-font=""` for the default font and undoes the Noto Sans fallback from #1993. That is a separate fix.

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. `bun test assets/bundled-assets.test.ts`. On `develop` it fails naming `assets/sample_subtitled.mp4`, on this branch it passes.
2. `eas build:inspect --platform ios --profile production --stage archive --output /tmp/inspect`, then check that `/tmp/inspect/assets/sample_subtitled.mp4` exists. On `develop` it is missing.
3. On the next TestFlight build, open Settings → Audio & subtitles. The preview video plays instead of "Failed to load preview".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed packaging of the subtitle preview video so it is included reliably in builds.
  * Missing required media assets now fail during bundling instead of causing unexpected runtime errors.

* **Tests**
  * Added automated checks to verify required assets exist and are not excluded by ignore rules.

* **Documentation**
  * Added guidance for preventing asset packaging issues and test-process reliability problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->