### PR TITLE
fix(player): keep the default subtitle font when the setting is System

### DIFF
--- a/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MPVLayerRenderer.kt
+++ b/modules/mpv-player/android/src/main/java/expo/modules/mpvplayer/MPVLayerRenderer.kt
@@ -23,6 +23,20 @@ internal fun normalizeVideoDimensions(width: Int, height: Int, rotation: Int): P
 }
 
 /**
+ * mpv `sub-font` for a subtitle font setting. "System" names mpv's own default
+ * rather than writing an empty family: an empty `sub-font` drops the default
+ * and leaves libass to pick a face glyph by glyph.
+ */
+internal fun mpvSubtitleFont(font: String): String = when (font) {
+    "System" -> "sans-serif"
+    "sans-serif" -> "Roboto"
+    "serif" -> "Noto Serif"
+    "monospace" -> "Droid Sans Mono"
+    "opendyslexic" -> "OpenDyslexic"
+    else -> font
+}
+
+/**
  * MPV renderer that wraps libmpv for video playback.
  * This mirrors the iOS MPVLayerRenderer implementation.
  */
@@ -910,14 +924,7 @@ class MPVLayerRenderer(private val context: Context) : MPVLib.EventObserver {
         }
 
         (config["font"] as? String)?.let { font ->
-            when (font) {
-                "System" -> mpv?.setPropertyString("sub-font", "")
-                "sans-serif" -> mpv?.setPropertyString("sub-font", "Roboto")
-                "serif" -> mpv?.setPropertyString("sub-font", "Noto Serif")
-                "monospace" -> mpv?.setPropertyString("sub-font", "Droid Sans Mono")
-                "opendyslexic" -> mpv?.setPropertyString("sub-font", "OpenDyslexic")
-                else -> mpv?.setPropertyString("sub-font", font)
-            }
+            mpv?.setPropertyString("sub-font", mpvSubtitleFont(font))
         }
 
         (config["background"] as? String)?.let { background ->

--- a/modules/mpv-player/android/src/test/java/expo/modules/mpvplayer/SubtitleFontTest.kt
+++ b/modules/mpv-player/android/src/test/java/expo/modules/mpvplayer/SubtitleFontTest.kt
@@ -1,0 +1,26 @@
+package expo.modules.mpvplayer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SubtitleFontTest {
+    @Test
+    fun systemRestoresMpvDefaultInsteadOfClearingTheFont() {
+        // An empty sub-font drops mpv's default family altogether, so the
+        // "System" choice has to name that default explicitly.
+        assertEquals("sans-serif", mpvSubtitleFont("System"))
+    }
+
+    @Test
+    fun mapsTheSettingsChoicesToInstalledFamilies() {
+        assertEquals("Roboto", mpvSubtitleFont("sans-serif"))
+        assertEquals("Noto Serif", mpvSubtitleFont("serif"))
+        assertEquals("Droid Sans Mono", mpvSubtitleFont("monospace"))
+        assertEquals("OpenDyslexic", mpvSubtitleFont("opendyslexic"))
+    }
+
+    @Test
+    fun passesUnknownFamiliesThrough() {
+        assertEquals("Comic Neue", mpvSubtitleFont("Comic Neue"))
+    }
+}

--- a/modules/mpv-player/ios/MPVLayerRenderer.swift
+++ b/modules/mpv-player/ios/MPVLayerRenderer.swift
@@ -448,6 +448,27 @@ final class MPVLayerRenderer {
     /// Family name of `NotoSans-Regular.ttf`, used as `--sub-font`.
     private static let subtitleFontFamily = "Noto Sans"
 
+    /// mpv `sub-font` for a subtitle font setting. "System" names the bundled
+    /// default rather than writing an empty family: an empty `sub-font` drops
+    /// the Latin default installed by setupSubtitleFonts and sends libass back
+    /// through CoreText glyph by glyph, which is the #1789 tofu path.
+    static func mpvSubtitleFont(_ font: String) -> String {
+        switch font {
+        case "System":
+            return subtitleFontFamily
+        case "sans-serif":
+            return "Helvetica"
+        case "serif":
+            return "Georgia"
+        case "monospace":
+            return "Menlo"
+        case "opendyslexic":
+            return "OpenDyslexic"
+        default:
+            return font
+        }
+    }
+
     /// Writable, backup-excluded directory handed to mpv as `--config-dir`.
     private static func mpvConfigDirectory() -> URL? {
         let fm = FileManager.default
@@ -1355,24 +1376,7 @@ final class MPVLayerRenderer {
         }
 
         if let font = config["font"] as? String {
-            if font == "System" {
-                setProperty(name: "sub-font", value: "")
-            } else {
-                let mappedFont: String
-                switch font {
-                case "sans-serif":
-                    mappedFont = "Helvetica"
-                case "serif":
-                    mappedFont = "Georgia"
-                case "monospace":
-                    mappedFont = "Menlo"
-                case "opendyslexic":
-                    mappedFont = "OpenDyslexic"
-                default:
-                    mappedFont = font
-                }
-                setProperty(name: "sub-font", value: mappedFont)
-            }
+            setProperty(name: "sub-font", value: Self.mpvSubtitleFont(font))
         }
 
         if let background = config["background"] as? String {


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Stop the default "System" subtitle font from clearing mpv's `sub-font`. `setSubtitleStyle` in both renderers wrote `sub-font=""` for "System", and since #1543 that runs on every playback. On iOS and tvOS it undoes the `Noto Sans` default that #1993 installs at init, so Latin text depends on whatever CoreText returns for an empty family instead of the bundled face. On Android it drops mpv's own `sans-serif` default the same way.

"System" now maps to the platform default explicitly (`Noto Sans` on Apple, `sans-serif` on Android). The mapping is a pure function on each renderer, with a JUnit test on the Android side. The iOS module has no test target, so the Swift side mirrors the same table without one.

Related: #1993

## 🏷️ Ticket / Issue

N/A

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Android unit test: `cd android && ./gradlew :mpv-player:testDebugUnitTest --tests 'expo.modules.mpvplayer.SubtitleFontTest'`. On `develop` the helper does not exist, on this branch the three cases pass.
2. iOS or tvOS: play a file with an SRT track while the font setting is "System". Subtitles should render in Noto Sans, and switching the font to OpenDyslexic and back to System during playback should return to the same face.
3. Android: same as 2, expecting the device's default sans font both times.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subtitle font handling on Android and iOS.
  - The **System** font option now uses the platform’s appropriate default font instead of potentially removing the subtitle font family.
  - Standard subtitle choices, including sans-serif, serif, monospace, and OpenDyslexic, now resolve more consistently across platforms.
  - Custom or unrecognized font names continue to be supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->