### PR TITLE
fix(settings): make the intro crash-report toggle disableable

### DIFF
--- a/.claude/learned-facts/switch-pointerevents-ignored.md
+++ b/.claude/learned-facts/switch-pointerevents-ignored.md
@@ -1,0 +1,25 @@
+# Switch Ignores Its Own pointerEvents
+
+**Date**: 2026-08-31
+**Category**: ui
+**Key files**: `components/IntroSheet.tsx`, `components/common/SettingSwitch.tsx`
+
+## Detail
+
+`<Switch pointerEvents="none">` does not make a React Native Switch inert on
+Android (and is unreliable on iOS): the native control consumes its own taps,
+flips visually, and the controlled `value` prop snaps it straight back. The
+user sees a toggle that can be tapped but never changes.
+
+Make a presentational switch inert by wrapping it in a `View
+pointerEvents="none"` — a parent View does honor the prop, so the tap falls
+through to the wrapping pressable (IntroSheet's crash-report row relies on
+this: the row's TouchableOpacity is the single mutation path). Setting the
+prop directly on the Switch is why the intro crash-report toggle ignored taps
+on the switch itself while taps on the row text worked.
+
+## Symptom pattern
+
+One switch "can't be toggled" while every other switch in the app works. The
+working ones wire `onValueChange` directly; the broken one relies on
+`pointerEvents` on the Switch plus a row-level press handler.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ UI and headers:
 - `macos-header-buttons-fix` | macOS Catalyst: use RNGH Pressable, not RN TouchableOpacity
 - `header-button-locations` | Defined in _layout.tsx, HeaderBackButton, Chromecast, RoundButton, etc.
 - `stack-screen-header-configuration` | Sub-pages need explicit Stack.Screen with headerTransparent + back button
+- `switch-pointerevents-ignored` | Switch ignores its own pointerEvents (Android); wrap in a View pointerEvents="none"
 
 State and data:
 - `use-network-aware-query-client-limitations` | Object.create breaks private fields; only for invalidateQueries

--- a/app/(auth)/(tabs)/(home)/settings.tv.tsx
+++ b/app/(auth)/(tabs)/(home)/settings.tv.tsx
@@ -1409,6 +1409,7 @@ export default function SettingsTV() {
           <TVSettingsToggle
             label={t("home.settings.plugins.crash_reports")}
             value={settings.sentryEnabled}
+            disabledByAdmin={pluginSettings?.sentryEnabled?.locked === true}
             onToggle={(value) => updateSettings({ sentryEnabled: value })}
           />
 

--- a/components/IntroSheet.tsx
+++ b/components/IntroSheet.tsx
@@ -27,7 +27,10 @@ export const IntroSheet = forwardRef<IntroSheetRef>((_, ref) => {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { settings, updateSettings } = useSettings();
+  const { settings, updateSettings, pluginSettings } = useSettings();
+  // An admin-locked toggle cannot take the write: updateSettings drops it and
+  // the read stays pinned, so the row would look broken rather than locked.
+  const sentryLocked = pluginSettings?.sentryEnabled?.locked === true;
 
   useImperativeHandle(ref, () => ({
     present: () => {
@@ -193,6 +196,7 @@ export const IntroSheet = forwardRef<IntroSheetRef>((_, ref) => {
                 so the TouchableOpacity carries the remote-select press there. */}
             <TouchableOpacity
               activeOpacity={0.7}
+              disabled={sentryLocked}
               onPress={() =>
                 updateSettings({ sentryEnabled: !settings?.sentryEnabled })
               }
@@ -213,12 +217,23 @@ export const IntroSheet = forwardRef<IntroSheetRef>((_, ref) => {
                 </Text>
               </View>
               {/* Presentational only — the row press above is the single
-                  mutation path, so a tap on the switch can't double-toggle. */}
-              <SettingSwitch
-                value={settings?.sentryEnabled === true}
-                pointerEvents='none'
-              />
+                  mutation path. The inertness has to come from a wrapping
+                  View: a Switch ignores its own pointerEvents on Android, so
+                  its native touch handler flipped it and the controlled value
+                  snapped it straight back — a toggle that couldn't be
+                  disabled by tapping the one control that looks tappable. */}
+              <View pointerEvents='none'>
+                <SettingSwitch
+                  value={settings?.sentryEnabled === true}
+                  disabled={sentryLocked}
+                />
+              </View>
             </TouchableOpacity>
+            {sentryLocked && (
+              <Text className='text-xs text-red-500 mt-1'>
+                {t("home.settings.disabled_by_admin")}
+              </Text>
+            )}
           </View>
 
           <View>

--- a/components/settings/PluginSettings.tsx
+++ b/components/settings/PluginSettings.tsx
@@ -9,7 +9,11 @@ import { ListGroup } from "../list/ListGroup";
 import { ListItem } from "../list/ListItem";
 
 export const PluginSettings = () => {
-  const { settings, updateSettings } = useSettings();
+  const { settings, updateSettings, pluginSettings } = useSettings();
+
+  // The lock must be visible: updateSettings drops the write for locked keys,
+  // so an unlocked-looking switch would read as broken rather than pinned.
+  const sentryLocked = pluginSettings?.sentryEnabled?.locked === true;
 
   const router = useRouter();
 
@@ -68,9 +72,11 @@ export const PluginSettings = () => {
       <ListItem
         title={t("home.settings.plugins.crash_reports")}
         subtitle={t("home.settings.plugins.crash_reports_hint")}
+        disabledByAdmin={sentryLocked}
       >
         <SettingSwitch
           value={settings.sentryEnabled}
+          disabled={sentryLocked}
           onValueChange={(value) => updateSettings({ sentryEnabled: value })}
         />
       </ListItem>

--- a/utils/atoms/settings.ts
+++ b/utils/atoms/settings.ts
@@ -22,7 +22,7 @@ import {
 import { storage } from "../mmkv";
 import {
   type AppliedPluginDefaults,
-  pendingPluginDefaults,
+  pluginRefreshOverlay,
   resolveEffectiveSettings,
 } from "./settingsOverrides";
 
@@ -873,34 +873,38 @@ export const useSettings = () => {
     );
     setPluginSettings(newPluginSettings);
 
-    if (newPluginSettings && _settings) {
-      const applied = loadAppliedPluginDefaults();
-      const pending = pendingPluginDefaults(
-        newPluginSettings,
-        applied,
-        normalizePluginValue,
-      );
-      const enableStreamystats =
-        newPluginSettings.streamyStatsServerUrl?.value &&
-        _settings.searchEngine !== "Streamystats";
+    // Write against the atom's value at apply time, not the hook's render
+    // snapshot: this runs while the user can be changing settings (the intro
+    // sheet is up during first-run login), and a merge built from the
+    // snapshot resurrected whatever the user had just overwritten.
+    if (newPluginSettings) {
+      setSettings((currentSettings) => {
+        if (!currentSettings) return currentSettings;
 
-      if (Object.keys(pending).length > 0 || enableStreamystats) {
+        const applied = loadAppliedPluginDefaults();
+        const result = pluginRefreshOverlay(
+          currentSettings,
+          newPluginSettings,
+          applied,
+          normalizePluginValue,
+        );
+        if (!result) return currentSettings;
+
         const newSettings = {
           ...defaultValues,
-          ..._settings,
-          ...pending,
-          ...(enableStreamystats ? { searchEngine: "Streamystats" } : {}),
+          ...currentSettings,
+          ...result.overlay,
         } as Settings;
-        setSettings(newSettings);
         saveSettings(newSettings);
-        if (Object.keys(pending).length > 0) {
-          storage.setAny(PLUGIN_APPLIED_DEFAULTS, { ...applied, ...pending });
+        if (result.applied) {
+          storage.setAny(PLUGIN_APPLIED_DEFAULTS, result.applied);
         }
-      }
+        return newSettings;
+      });
     }
 
     return newPluginSettings;
-  }, [api, _settings]);
+  }, [api, setPluginSettings, setSettings]);
 
   const updateSettings = (update: Partial<Settings>) => {
     // Admin-locked settings are enforced at write time too: a control that

--- a/utils/atoms/settingsOverrides.test.ts
+++ b/utils/atoms/settingsOverrides.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { PluginLockableSettings, Settings } from "./settings";
 import {
   pendingPluginDefaults,
+  pluginRefreshOverlay,
   resolveEffectiveSettings,
 } from "./settingsOverrides";
 
@@ -176,5 +177,73 @@ describe("pendingPluginDefaults", () => {
       identity,
     );
     expect(pending).toEqual({});
+  });
+
+  test("never seeds consent keys, even on the first sync", () => {
+    // The crash-report opt-out lives on the intro sheet, which is available
+    // before the first plugin sync runs at login. Seeding the admin default
+    // after the fact silently re-enabled reporting over that opt-out — the
+    // user's toggle turned itself back on. Consent only moves by explicit
+    // user action; an admin enforces it with a lock instead.
+    const pending = pendingPluginDefaults(
+      plugin({ sentryEnabled: { locked: false, value: true } }),
+      {},
+      identity,
+    );
+    expect(pending).toEqual({});
+  });
+});
+
+describe("pluginRefreshOverlay", () => {
+  test("computes the overlay against the settings passed in", () => {
+    // The caller must pass the atom's value at write time. The refresh runs
+    // while the user can be toggling (the intro sheet is up during login),
+    // and the old merge from a render-time snapshot resurrected the value
+    // the user had just overwritten.
+    const result = pluginRefreshOverlay(
+      { sentryEnabled: false } as Partial<Settings>,
+      plugin({
+        sentryEnabled: { locked: false, value: true },
+        forwardSkipTime: { locked: false, value: 45 },
+      }),
+      {},
+      identity,
+    );
+    // sentryEnabled is never seeded, so only the skip time moves.
+    expect(result).toEqual({
+      overlay: { forwardSkipTime: 45 },
+      applied: { forwardSkipTime: 45 },
+    });
+  });
+
+  test("returns null when there is nothing to write", () => {
+    const result = pluginRefreshOverlay(
+      {} as Partial<Settings>,
+      undefined,
+      {},
+      identity,
+    );
+    expect(result).toBeNull();
+  });
+
+  test("a streamystats-only refresh leaves the applied record untouched", () => {
+    // Recording applied defaults for a write that seeded nothing would mark
+    // pending defaults as done without ever writing them. The URL here is
+    // already applied, so the only outstanding write is the search engine.
+    const result = pluginRefreshOverlay(
+      { searchEngine: "Jellyfin" } as Partial<Settings>,
+      plugin({
+        streamyStatsServerUrl: {
+          locked: false,
+          value: "https://stats.example",
+        },
+      }),
+      { streamyStatsServerUrl: "https://stats.example" },
+      identity,
+    );
+    expect(result).toEqual({
+      overlay: { searchEngine: "Streamystats" },
+      applied: null,
+    });
   });
 });

--- a/utils/atoms/settingsOverrides.ts
+++ b/utils/atoms/settingsOverrides.ts
@@ -22,6 +22,15 @@ export const hasMeaningfulSettingValue = (value: unknown): boolean =>
   value !== undefined && value !== null && value !== "";
 
 /**
+ * Settings an unlocked plugin default must never seed. Crash-report consent
+ * can only change by explicit user action (or an admin lock): the intro sheet
+ * is the opt-out surface and it is available before the first plugin sync
+ * happens at login, so a deferred seed would silently re-enable reporting
+ * over the user's explicit opt-out.
+ */
+const NEVER_SEED_KEYS: ReadonlySet<keyof Settings> = new Set(["sentryEnabled"]);
+
+/**
  * Effective settings, in precedence order:
  *
  *   app defaults → unlocked plugin values (fallback only) → the user's stored
@@ -88,6 +97,7 @@ export const pendingPluginDefaults = (
   for (const [key, setting] of Object.entries(plugin ?? {})) {
     if (!setting || setting.locked) continue;
     const settingsKey = key as keyof Settings;
+    if (NEVER_SEED_KEYS.has(settingsKey)) continue;
     const value = normalize(settingsKey, setting.value);
     if (!hasMeaningfulSettingValue(value)) continue;
     // Structural compare: object-typed settings ({ key, value }) are rebuilt by
@@ -98,4 +108,42 @@ export const pendingPluginDefaults = (
     pending[key] = value;
   }
   return pending as Partial<Settings>;
+};
+
+/**
+ * The overlay a plugin refresh should write, computed against the user's
+ * CURRENT settings, plus the applied-defaults record to persist (null when no
+ * seed happened, so a streamystats-only refresh leaves the record alone and
+ * the seed decision is retried on the next one).
+ *
+ * The refresh runs while the user can be changing settings — the intro sheet
+ * is up during first-run login — so the caller must evaluate this inside the
+ * settings write rather than merging against a render-time snapshot. Building
+ * the merge from the snapshot instead resurrected whatever the user had just
+ * overwritten when the refresh's fetch resolved after their toggle.
+ */
+export const pluginRefreshOverlay = (
+  current: Partial<Settings>,
+  plugin: PluginLockableSettings | undefined,
+  applied: AppliedPluginDefaults,
+  normalize: NormalizePluginValue,
+): {
+  overlay: Partial<Settings>;
+  applied: AppliedPluginDefaults | null;
+} | null => {
+  const pending = pendingPluginDefaults(plugin, applied, normalize);
+  const enableStreamystats =
+    !!plugin?.streamyStatsServerUrl?.value &&
+    current.searchEngine !== "Streamystats";
+  if (Object.keys(pending).length === 0 && !enableStreamystats) {
+    return null;
+  }
+  return {
+    overlay: {
+      ...pending,
+      ...(enableStreamystats ? { searchEngine: "Streamystats" } : {}),
+    },
+    applied:
+      Object.keys(pending).length > 0 ? { ...applied, ...pending } : null,
+  };
 };


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Tapping the crash-report switch on the intro sheet could not turn it off. Three fixes, one user-visible bug:

- **Tap path (the reported repro)**: the row press is the single mutation path and the switch was made presentational with `pointerEvents="none"` on the Switch itself — but a Switch ignores its own `pointerEvents` on Android, so its native touch handler flipped it and the controlled value snapped it straight back. The switch is now wrapped in a `View pointerEvents="none"`, which a parent View honors, so a tap anywhere on the row — switch included — falls through to the row.
- **Plugin sync reverting consent**: the login-time plugin sync seeded the plugin's unlocked `sentryEnabled` default over an opt-out made on the pre-login intro sheet (the applied-defaults record predates the setting). Consent keys are now never seeded via `NEVER_SEED_KEYS` in the plugin-settings policy. Admin enforcement via locks is unchanged.
- **In-flight refresh race**: a plugin refresh merged from the hook's render snapshot, resurrecting a toggle that landed while its fetch was in flight. The write now evaluates the new pure `pluginRefreshOverlay` against the atom's value at apply time.

An admin-locked toggle now renders as locked ("Disabled by admin") on the intro, mobile settings and TV settings instead of silently eating the press.

## 🏷️ Ticket / Issue

N/A — found during internal testing.

### 🖼️ Screenshots / GIFs (if UI)

N/A — no visual change when unlocked; locked state reuses the existing "Disabled by admin" pattern.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Fresh install (or set Settings → Intro → Reset intro) so the intro sheet shows
2. On the intro sheet, tap the crash-report **switch itself** — it now toggles off (previously it snapped back on Android); the whole row also still toggles
3. Sign in to a Jellyfin server with the Streamyfin plugin — the toggle stays off (previously the login-time plugin sync could flip it back on)
4. Settings → Plugins → Crash reports and the TV settings equivalent behave the same
5. Optional, admin-locked case: with the plugin config locking `sentryEnabled`, all three surfaces show "Disabled by admin" and don't accept presses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added administrator controls for crash-reporting settings, including disabled controls and explanatory warnings when locked.
  * Improved TV settings behavior for administrator-locked crash-reporting options.

* **Bug Fixes**
  * Prevented crash-report consent from being enabled automatically during plugin settings refreshes.
  * Improved settings refresh reliability and preserved current user settings.
  * Fixed interaction handling for disabled switches in introductory settings screens.

* **Documentation**
  * Documented switch interaction behavior and the recommended accessibility pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->