### PR TITLE
fix(player): ignore home-indicator surface drags

### DIFF
--- a/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
@@ -33,17 +33,19 @@ struct PlayerControlsRootView: View {
 			// Portrait phones can't fit the full top-bar button row — late
 			// data pushes (episode list) add buttons after load, so the bar
 			// must adapt by width, not by content.
-			content(size: geometry.size)
+			content(size: geometry.size, bottomSafeAreaInset: geometry.safeAreaInsets.bottom)
 		}
 	}
 
-	private func content(size: CGSize) -> some View {
+	private func content(size: CGSize, bottomSafeAreaInset: CGFloat) -> some View {
 		ZStack {
 			// Tap-to-toggle catcher behind everything interactive; also the
 			// gesture surface — controls layered above receive their own
 			// touches first, so drags here only start on empty video area.
 			tapSurface(size: size)
-				.gesture(surfaceDragGesture(size: size))
+				.gesture(
+					surfaceDragGesture(size: size, bottomSafeAreaInset: bottomSafeAreaInset)
+				)
 				.gesture(holdSpeedGesture)
 
 			if viewModel.controlsVisible {
@@ -345,13 +347,20 @@ struct PlayerControlsRootView: View {
 	/// chapter haptics and pause-while-scrubbing come along). Vertical drag =
 	/// brightness on the left half, volume on the right (JS GestureOverlay
 	/// parity), with the edge pills transiently revealed as feedback.
-	private func surfaceDragGesture(size: CGSize) -> some Gesture {
+	private func surfaceDragGesture(size: CGSize, bottomSafeAreaInset: CGFloat) -> some Gesture {
 		DragGesture(minimumDistance: 12)
 			.onChanged { value in
 				guard !viewModel.controlsLocked,
 					!viewModel.showStillWatching,
 					viewModel.errorMessage == nil
 				else { return }
+
+				// iOS briefly delivers a home-indicator swipe before taking
+				// ownership. Ignore the sequence before it changes player state.
+				if bottomSafeAreaInset > 0,
+					value.startLocation.y >= size.height - bottomSafeAreaInset {
+					return
+				}
 
 				// A two-finger pinch or an engaged 2× hold owns this touch
 				// sequence — abandon any in-flight drag and ignore the rest of


### PR DESCRIPTION
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

# 📦 Pull Request

## 📝 Description
Prevents the native iOS player surface gesture from treating a home-indicator swipe as a brightness or volume drag. `PlayerControlsRootView` passes the live bottom safe-area inset into the gesture and returns before mutating player state when the touch originated in that system-owned region.

The edge path does not set `dragSuppressed`, so a system cancellation cannot leave later surface gestures disabled.

This is layer 1 of stack #2027. The controls-layout follow-up is #2026.

## 🏷️ Ticket / Issue
N/A. A targeted search of the open tracker found no matching issue.

### 🖼️ Screenshots / GIFs (if UI)
iOS: the reported landscape state was supplied during implementation and tested iteratively on a physical iPhone. This layer changes gesture ownership rather than persistent visual appearance.

Android: N/A. The code is isolated to the SwiftUI iOS player.

## ✅ Checklist
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] AI assistance is declared above

## 🔍 Testing Instructions
1. Open the native player on an iPhone with a home indicator.
2. Start playback and rotate to landscape.
3. Swipe upward from the home-indicator edge on both halves of the video.
4. Verify brightness and volume do not change before iOS handles the system gesture.
5. Start vertical drags away from the system edge and verify brightness and volume still respond normally.

Validation performed:
- Swift parser passed for `PlayerControlsRootView.swift`.
- The combined native player stack builds successfully with the `MpvPlayer` iOS Simulator scheme.
- `bun run check` passed.
- Typecheck, 351 unit tests, Biome lint/format, and i18n validation passed; the local aggregate `bun run test` stopped only at the repository baseline Expo Doctor dependency-version report.

No native SwiftUI gesture-test target currently exists for this surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iOS player controls to prevent accidental state changes when swiping from the home-indicator area.
  - Home-indicator gestures now work as expected without triggering player interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->