### PR TITLE
fix(player): prevent native iOS control overlap

### DIFF
--- a/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
@@ -211,22 +211,18 @@ struct PlayerControlsRootView: View {
 			GeometryReader { geometry in
 				if viewModel.controlsVisible,
 					let chapterName = viewModel.currentChapterName,
-					let brightnessAnchor = anchors.brightness,
 					let scrubberAnchor = anchors.scrubber {
-					let brightnessFrame = geometry[brightnessAnchor]
 					let scrubberFrame = geometry[scrubberAnchor]
-					if brightnessFrame.maxY < scrubberFrame.midY {
-						Text(chapterName)
-							.font(.caption)
-							.foregroundStyle(.white.opacity(0.7))
-							.lineLimit(1)
-							.frame(width: scrubberFrame.width, alignment: .leading)
-							.position(
-								x: scrubberFrame.midX,
-								y: (brightnessFrame.maxY + scrubberFrame.midY) / 2
-							)
-							.allowsHitTesting(false)
-					}
+					let chapterY = anchors.brightness.map {
+						(geometry[$0].maxY + scrubberFrame.midY) / 2
+					} ?? scrubberFrame.minY
+					Text(chapterName)
+						.font(.caption)
+						.foregroundStyle(.white.opacity(0.7))
+						.lineLimit(1)
+						.frame(width: scrubberFrame.width, alignment: .leading)
+						.position(x: scrubberFrame.midX, y: chapterY)
+						.allowsHitTesting(false)
 				}
 			}
 		}
@@ -497,11 +493,7 @@ struct PlayerControlsRootView: View {
 	private var fullWidthBottomChrome: some View {
 		VStack {
 			Spacer()
-			PlayerBottomBar(
-				viewModel: viewModel,
-				time: viewModel.time,
-				showsChapterName: !viewModel.showBrightnessSlider
-			)
+			PlayerBottomBar(viewModel: viewModel, time: viewModel.time)
 				.background {
 					GeometryReader { geometry in
 						Color.clear.preference(
@@ -634,13 +626,13 @@ private struct SubtitleScaleOverlay: View {
 	}
 }
 
-/// Bottom bar: current chapter name, the custom scrubber, then time labels
-/// with the wall-clock finish time under the remaining time (JS TimeDisplay).
+/// Bottom bar: the custom scrubber, then time labels with the wall-clock
+/// finish time under the remaining time (JS TimeDisplay). The root overlay
+/// positions the current chapter relative to this scrubber's anchor.
 struct PlayerBottomBar: View {
 	@ObservedObject var viewModel: PlayerViewModel
 	/// The fast clock — time labels and the chapter caption tick off this.
 	@ObservedObject var time: PlaybackTimeModel
-	let showsChapterName: Bool
 
 	private static let endsAtFormatter: DateFormatter = {
 		let formatter = DateFormatter()
@@ -654,12 +646,6 @@ struct PlayerBottomBar: View {
 		let remaining = max(0, viewModel.duration - position)
 
 		VStack(alignment: .leading, spacing: 6) {
-			if showsChapterName, let chapterName = viewModel.currentChapterName {
-				Text(chapterName)
-					.font(.caption)
-					.foregroundStyle(.white.opacity(0.7))
-					.lineLimit(1)
-			}
 			ScrubberView(viewModel: viewModel, time: time)
 				.anchorPreference(
 					key: PlayerChromeAnchorPreferenceKey.self,

--- a/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
@@ -83,7 +83,7 @@ struct PlayerControlsRootView: View {
 					.tint(.white)
 			}
 
-			adaptivePlaybackChrome
+			adaptivePlaybackChrome(bottomSafeAreaInset: bottomSafeAreaInset)
 
 			if viewModel.controlsVisible {
 				fullWidthBottomChrome
@@ -193,7 +193,6 @@ struct PlayerControlsRootView: View {
 				.onChanged { _ in viewModel.touchInteractionOccurred() }
 		)
 		.animation(.easeInOut(duration: 0.2), value: viewModel.showStillWatching)
-		.animation(.easeInOut(duration: 0.2), value: viewModel.controlsVisible)
 		.animation(.easeInOut(duration: 0.2), value: viewModel.activeSegment?.startSec)
 		.animation(.easeInOut(duration: 0.2), value: viewModel.countdownRemaining != nil)
 		.animation(.easeInOut(duration: 0.2), value: viewModel.volumeSliderRevealed)
@@ -208,22 +207,33 @@ struct PlayerControlsRootView: View {
 		.overlayPreferenceValue(PlayerChromeAnchorPreferenceKey.self) { anchors in
 			GeometryReader { geometry in
 				if viewModel.controlsVisible,
-					let chapterName = viewModel.currentChapterName,
 					let scrubberAnchor = anchors.scrubber {
 					let scrubberFrame = geometry[scrubberAnchor]
-					let chapterY = anchors.brightness.map {
-						(geometry[$0].maxY + scrubberFrame.midY) / 2
-					} ?? scrubberFrame.minY
-					Text(chapterName)
-						.font(.caption)
-						.foregroundStyle(.white.opacity(0.7))
-						.lineLimit(1)
-						.frame(width: scrubberFrame.width, alignment: .leading)
-						.position(x: scrubberFrame.midX, y: chapterY)
-						.allowsHitTesting(false)
+					let chapterMinY = anchors.brightness.map { geometry[$0].maxY }
+						?? scrubberFrame.minY
+					let chapterHeight = max(scrubberFrame.midY - chapterMinY, 0)
+					let chapterMaxX = anchors.chapterObstructions
+						.map { geometry[$0].minX }
+						.min() ?? scrubberFrame.maxX
+					let chapterWidth = max(chapterMaxX - scrubberFrame.minX, 0)
+					if chapterWidth > 0, chapterHeight > 0 {
+						CurrentChapterLabel(viewModel: viewModel, time: viewModel.time)
+							.frame(
+								width: chapterWidth,
+								height: chapterHeight,
+								alignment: .leading
+							)
+							.clipped()
+							.position(
+								x: scrubberFrame.minX + chapterWidth / 2,
+								y: chapterMinY + chapterHeight / 2
+							)
+							.allowsHitTesting(false)
+					}
 				}
 			}
 		}
+		.animation(.easeInOut(duration: 0.2), value: viewModel.controlsVisible)
 		// SwiftUI never delivers onEnded when the SYSTEM cancels the touch
 		// (incoming call, Control Center edge swipe, backgrounding) — release
 		// an engaged hold here or playback stays stuck at 2×.
@@ -420,10 +430,19 @@ struct PlayerControlsRootView: View {
 		.padding(.vertical, 8)
 	}
 
-	private var adaptivePlaybackChrome: some View {
+	private var brightnessSliderVisible: Bool {
+		viewModel.showBrightnessSlider
+			&& (viewModel.controlsVisible || viewModel.brightnessSliderRevealed)
+	}
+
+	private var volumeSliderVisible: Bool {
+		viewModel.showVolumeSlider
+			&& (viewModel.controlsVisible || viewModel.volumeSliderRevealed)
+	}
+
+	private func adaptivePlaybackChrome(bottomSafeAreaInset: CGFloat) -> some View {
 		HStack {
-			if viewModel.showBrightnessSlider
-				&& (viewModel.controlsVisible || viewModel.brightnessSliderRevealed) {
+			if brightnessSliderVisible {
 				BrightnessSliderView(
 					viewModel: viewModel,
 					controller: viewModel.brightnessController
@@ -435,6 +454,14 @@ struct PlayerControlsRootView: View {
 					PlayerChromeAnchors(brightness: anchor)
 				}
 				.transition(.opacity)
+			} else if viewModel.controlsVisible && volumeSliderVisible {
+				VolumeSliderView(
+					viewModel: viewModel,
+					controller: viewModel.volumeController
+				)
+				.hidden()
+				.allowsHitTesting(false)
+				.accessibilityHidden(true)
 			}
 
 			ZStack {
@@ -442,25 +469,35 @@ struct PlayerControlsRootView: View {
 					PlayerCenterControls(viewModel: viewModel, time: viewModel.time)
 						.transition(.opacity)
 				}
-				bottomChrome
+				bottomChrome(bottomSafeAreaInset: bottomSafeAreaInset)
 					.zIndex(1)
 			}
 			.frame(maxWidth: .infinity, maxHeight: .infinity)
 
-			if viewModel.showVolumeSlider
-				&& (viewModel.controlsVisible || viewModel.volumeSliderRevealed) {
+			if volumeSliderVisible {
 				VolumeSliderView(
 					viewModel: viewModel,
 					controller: viewModel.volumeController
 				)
 				.transition(.opacity)
+			} else if viewModel.controlsVisible && brightnessSliderVisible {
+				BrightnessSliderView(
+					viewModel: viewModel,
+					controller: viewModel.brightnessController
+				)
+				.hidden()
+				.allowsHitTesting(false)
+				.accessibilityHidden(true)
 			}
 		}
 		.padding(.horizontal)
 	}
 
-	private var bottomChrome: some View {
-		VStack {
+	private func bottomChrome(bottomSafeAreaInset: CGFloat) -> some View {
+		let hiddenControlsBottomPadding: CGFloat? =
+			bottomSafeAreaInset > 0 ? bottomSafeAreaInset : nil
+
+		return VStack {
 			Spacer()
 			HStack(alignment: .bottom) {
 				if let notice = viewModel.skippedSegmentNotice {
@@ -471,6 +508,12 @@ struct PlayerControlsRootView: View {
 						.padding(.vertical, 10)
 						.background(.ultraThinMaterial, in: Capsule())
 						.overlay(Capsule().stroke(.white.opacity(0.2), lineWidth: 1))
+						.anchorPreference(
+							key: PlayerChromeAnchorPreferenceKey.self,
+							value: .bounds
+						) { anchor in
+							PlayerChromeAnchors(chapterObstructions: [anchor])
+						}
 						.transition(.opacity)
 				}
 				Spacer()
@@ -479,13 +522,28 @@ struct PlayerControlsRootView: View {
 						NextEpisodeCountdownView(
 							viewModel: viewModel, next: next, remaining: countdown
 						)
+						.anchorPreference(
+							key: PlayerChromeAnchorPreferenceKey.self,
+							value: .bounds
+						) { anchor in
+							PlayerChromeAnchors(chapterObstructions: [anchor])
+						}
 					} else if let segment = viewModel.activeSegment, segment.skipMode != "auto" {
 						SkipSegmentButton(viewModel: viewModel, segment: segment)
+							.anchorPreference(
+								key: PlayerChromeAnchorPreferenceKey.self,
+								value: .bounds
+							) { anchor in
+								PlayerChromeAnchors(chapterObstructions: [anchor])
+							}
 					}
 				}
 			}
 		}
-		.padding(.bottom, viewModel.controlsVisible ? bottomBarHeight : 0)
+		.padding(
+			.bottom,
+			viewModel.controlsVisible ? bottomBarHeight : hiddenControlsBottomPadding
+		)
 	}
 
 	private var fullWidthBottomChrome: some View {
@@ -545,10 +603,16 @@ private struct BottomBarHeightPreferenceKey: PreferenceKey {
 private struct PlayerChromeAnchors {
 	var brightness: Anchor<CGRect>?
 	var scrubber: Anchor<CGRect>?
+	var chapterObstructions: [Anchor<CGRect>]
 
-	init(brightness: Anchor<CGRect>? = nil, scrubber: Anchor<CGRect>? = nil) {
+	init(
+		brightness: Anchor<CGRect>? = nil,
+		scrubber: Anchor<CGRect>? = nil,
+		chapterObstructions: [Anchor<CGRect>] = []
+	) {
 		self.brightness = brightness
 		self.scrubber = scrubber
+		self.chapterObstructions = chapterObstructions
 	}
 }
 
@@ -559,6 +623,21 @@ private struct PlayerChromeAnchorPreferenceKey: PreferenceKey {
 		let next = nextValue()
 		value.brightness = next.brightness ?? value.brightness
 		value.scrubber = next.scrubber ?? value.scrubber
+		value.chapterObstructions.append(contentsOf: next.chapterObstructions)
+	}
+}
+
+private struct CurrentChapterLabel: View {
+	@ObservedObject var viewModel: PlayerViewModel
+	@ObservedObject var time: PlaybackTimeModel
+
+	var body: some View {
+		if let chapterName = viewModel.chapterName(at: time.displayPosition) {
+			Text(chapterName)
+				.font(.caption)
+				.foregroundStyle(.white.opacity(0.7))
+				.lineLimit(1)
+		}
 	}
 }
 

--- a/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
@@ -203,9 +203,7 @@ struct PlayerControlsRootView: View {
 		.animation(.easeInOut(duration: 0.15), value: viewModel.showSubtitleScaleControl)
 		.animation(.easeInOut(duration: 0.15), value: viewModel.doubleTapSeekForward)
 		.onPreferenceChange(BottomBarHeightPreferenceKey.self) { height in
-			if height > 0 {
-				bottomBarHeight = height
-			}
+			bottomBarHeight = height
 		}
 		.overlayPreferenceValue(PlayerChromeAnchorPreferenceKey.self) { anchors in
 			GeometryReader { geometry in

--- a/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
+++ b/modules/mpv-player/ios/NativePlayer/Views/PlayerControlsRootView.swift
@@ -19,6 +19,7 @@ struct PlayerControlsRootView: View {
 	@State private var dragOnLeftHalf = false
 	@State private var dragStartFraction: Double = 0
 	@State private var dragStartLevel: Double = 0
+	@State private var bottomBarHeight: CGFloat = 0
 	/// A pinch or an engaged 2× hold took over this touch sequence — the drag
 	/// must stay dead until the fingers lift, or its accumulated translation
 	/// (finger spread / hold drift) would scrub or yank the sliders against a
@@ -55,21 +56,9 @@ struct PlayerControlsRootView: View {
 				// and must cover the play/skip buttons in landscape, not duck
 				// under them. Hit-testing is unaffected — the layer's empty
 				// middle isn't tappable.
-				controls(compact: size.width < 500)
+				topChrome(compact: size.width < 500)
 					.transition(.opacity)
 					.zIndex(1)
-				// Centered in the ZStack (true screen center) rather than in
-				// the bar VStack — the bottom bar is taller than the top bar,
-				// so centering between them would sit visibly high. The
-				// horizontal padding reserves the edge-slider gutters (20pt
-				// inset + 34pt pill + 8pt gap) so the row's ViewThatFits
-				// tiers fit BETWEEN the sliders instead of underneath them.
-				PlayerCenterControls(viewModel: viewModel, time: viewModel.time)
-					.padding(
-						.horizontal,
-						viewModel.showVolumeSlider || viewModel.showBrightnessSlider ? 62 : 24
-					)
-					.transition(.opacity)
 			}
 
 			if viewModel.controlsVisible && viewModel.showSubtitleScaleControl {
@@ -94,71 +83,12 @@ struct PlayerControlsRootView: View {
 					.tint(.white)
 			}
 
-			// Edge sliders: brightness left, volume right. The volume pill
-			// additionally appears alone on hardware volume presses while the
-			// chrome is hidden (the system volume HUD is suppressed).
-			HStack {
-				if viewModel.showBrightnessSlider
-					&& (viewModel.controlsVisible || viewModel.brightnessSliderRevealed) {
-					BrightnessSliderView(
-						viewModel: viewModel,
-						controller: viewModel.brightnessController
-					)
-					.transition(.opacity)
-				}
-				Spacer()
-				if viewModel.showVolumeSlider
-					&& (viewModel.controlsVisible || viewModel.volumeSliderRevealed) {
-					VolumeSliderView(
-						viewModel: viewModel,
-						controller: viewModel.volumeController
-					)
-					.transition(.opacity)
-				}
-			}
-			.padding(.horizontal, 20)
+			adaptivePlaybackChrome
 
-			// Skip pill / countdown card live outside controlsVisible so they
-			// stay actionable while the chrome is hidden — but not while the
-			// controls are locked (nothing tappable in lock mode; an armed
-			// countdown still auto-advances, which suits hands-off viewing).
-			if !viewModel.controlsLocked {
-				VStack {
-					Spacer()
-					HStack {
-						Spacer()
-						if let countdown = viewModel.countdownRemaining, let next = viewModel.nextEpisode {
-							NextEpisodeCountdownView(viewModel: viewModel, next: next, remaining: countdown)
-						} else if let segment = viewModel.activeSegment, segment.skipMode != "auto" {
-							SkipSegmentButton(viewModel: viewModel, segment: segment)
-						}
-					}
-				}
-				.padding(.trailing, 24)
-				// Clears the bottom bar, which grew a chapter label + ends-at line.
-				.padding(.bottom, viewModel.controlsVisible ? 124 : 32)
-			}
-
-			// Says what an automatic skip just did. Auto-skip is otherwise
-			// silent and reads as the video jumping on its own. Bottom left,
-			// opposite the skip pill, so the two can never collide.
-			if let notice = viewModel.skippedSegmentNotice {
-				VStack {
-					Spacer()
-					HStack {
-						Text(notice)
-							.font(.subheadline.weight(.medium))
-							.foregroundStyle(.white)
-							.padding(.horizontal, 16)
-							.padding(.vertical, 10)
-							.background(.ultraThinMaterial, in: Capsule())
-							.overlay(Capsule().stroke(.white.opacity(0.2), lineWidth: 1))
-						Spacer()
-					}
-				}
-				.padding(.leading, 24)
-				.padding(.bottom, viewModel.controlsVisible ? 124 : 32)
-				.transition(.opacity)
+			if viewModel.controlsVisible {
+				fullWidthBottomChrome
+					.transition(.opacity)
+					.zIndex(1)
 			}
 
 			// Hold-to-speed feedback pill; lives outside controlsVisible so it
@@ -272,6 +202,34 @@ struct PlayerControlsRootView: View {
 		.animation(.easeInOut(duration: 0.15), value: viewModel.isHoldSpeedActive)
 		.animation(.easeInOut(duration: 0.15), value: viewModel.showSubtitleScaleControl)
 		.animation(.easeInOut(duration: 0.15), value: viewModel.doubleTapSeekForward)
+		.onPreferenceChange(BottomBarHeightPreferenceKey.self) { height in
+			if height > 0 {
+				bottomBarHeight = height
+			}
+		}
+		.overlayPreferenceValue(PlayerChromeAnchorPreferenceKey.self) { anchors in
+			GeometryReader { geometry in
+				if viewModel.controlsVisible,
+					let chapterName = viewModel.currentChapterName,
+					let brightnessAnchor = anchors.brightness,
+					let scrubberAnchor = anchors.scrubber {
+					let brightnessFrame = geometry[brightnessAnchor]
+					let scrubberFrame = geometry[scrubberAnchor]
+					if brightnessFrame.maxY < scrubberFrame.midY {
+						Text(chapterName)
+							.font(.caption)
+							.foregroundStyle(.white.opacity(0.7))
+							.lineLimit(1)
+							.frame(width: scrubberFrame.width, alignment: .leading)
+							.position(
+								x: scrubberFrame.midX,
+								y: (brightnessFrame.maxY + scrubberFrame.midY) / 2
+							)
+							.allowsHitTesting(false)
+					}
+				}
+			}
+		}
 		// SwiftUI never delivers onEnded when the SYSTEM cancels the touch
 		// (incoming call, Control Center edge swipe, backgrounding) — release
 		// an engaged hold here or playback stays stuck at 2×.
@@ -363,10 +321,8 @@ struct PlayerControlsRootView: View {
 				}
 
 				// A two-finger pinch or an engaged 2× hold owns this touch
-				// sequence — abandon any in-flight drag and ignore the rest of
-				// the sequence. Resuming later would apply the accumulated
-				// translation (finger spread / hold drift) against a stale
-				// baseline and make volume/brightness or the scrubber jump.
+				// sequence. Abandon any in-flight drag and ignore the rest;
+				// resuming would apply accumulated movement to a stale baseline.
 				if viewModel.isPinching || viewModel.isHoldSpeedActive || dragSuppressed {
 					if !dragSuppressed {
 						dragSuppressed = true
@@ -461,14 +417,101 @@ struct PlayerControlsRootView: View {
 		viewModel.scheduleAutoHide()
 	}
 
-	private func controls(compact: Bool) -> some View {
+	private func topChrome(compact: Bool) -> some View {
 		VStack(spacing: 0) {
 			PlayerTopBar(viewModel: viewModel, compact: compact)
 			Spacer()
-			PlayerBottomBar(viewModel: viewModel, time: viewModel.time)
 		}
 		.padding(.horizontal, 24)
 		.padding(.vertical, 8)
+	}
+
+	private var adaptivePlaybackChrome: some View {
+		HStack {
+			if viewModel.showBrightnessSlider
+				&& (viewModel.controlsVisible || viewModel.brightnessSliderRevealed) {
+				BrightnessSliderView(
+					viewModel: viewModel,
+					controller: viewModel.brightnessController
+				)
+				.anchorPreference(
+					key: PlayerChromeAnchorPreferenceKey.self,
+					value: .bounds
+				) { anchor in
+					PlayerChromeAnchors(brightness: anchor)
+				}
+				.transition(.opacity)
+			}
+
+			ZStack {
+				if viewModel.controlsVisible {
+					PlayerCenterControls(viewModel: viewModel, time: viewModel.time)
+						.transition(.opacity)
+				}
+				bottomChrome
+					.zIndex(1)
+			}
+			.frame(maxWidth: .infinity, maxHeight: .infinity)
+
+			if viewModel.showVolumeSlider
+				&& (viewModel.controlsVisible || viewModel.volumeSliderRevealed) {
+				VolumeSliderView(
+					viewModel: viewModel,
+					controller: viewModel.volumeController
+				)
+				.transition(.opacity)
+			}
+		}
+		.padding(.horizontal)
+	}
+
+	private var bottomChrome: some View {
+		VStack {
+			Spacer()
+			HStack(alignment: .bottom) {
+				if let notice = viewModel.skippedSegmentNotice {
+					Text(notice)
+						.font(.subheadline.weight(.medium))
+						.foregroundStyle(.white)
+						.padding(.horizontal, 16)
+						.padding(.vertical, 10)
+						.background(.ultraThinMaterial, in: Capsule())
+						.overlay(Capsule().stroke(.white.opacity(0.2), lineWidth: 1))
+						.transition(.opacity)
+				}
+				Spacer()
+				if !viewModel.controlsLocked {
+					if let countdown = viewModel.countdownRemaining, let next = viewModel.nextEpisode {
+						NextEpisodeCountdownView(
+							viewModel: viewModel, next: next, remaining: countdown
+						)
+					} else if let segment = viewModel.activeSegment, segment.skipMode != "auto" {
+						SkipSegmentButton(viewModel: viewModel, segment: segment)
+					}
+				}
+			}
+		}
+		.padding(.bottom, viewModel.controlsVisible ? bottomBarHeight : 0)
+	}
+
+	private var fullWidthBottomChrome: some View {
+		VStack {
+			Spacer()
+			PlayerBottomBar(
+				viewModel: viewModel,
+				time: viewModel.time,
+				showsChapterName: !viewModel.showBrightnessSlider
+			)
+				.background {
+					GeometryReader { geometry in
+						Color.clear.preference(
+							key: BottomBarHeightPreferenceKey.self,
+							value: geometry.size.height
+						)
+					}
+				}
+		}
+		.padding(.horizontal)
 	}
 
 	private func errorOverlay(message: String) -> some View {
@@ -498,6 +541,34 @@ struct PlayerControlsRootView: View {
 		.padding(32)
 		.frame(maxWidth: 420)
 		.background(.black.opacity(0.85), in: RoundedRectangle(cornerRadius: 20))
+	}
+}
+
+private struct BottomBarHeightPreferenceKey: PreferenceKey {
+	static var defaultValue: CGFloat = 0
+
+	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+		value = max(value, nextValue())
+	}
+}
+
+private struct PlayerChromeAnchors {
+	var brightness: Anchor<CGRect>?
+	var scrubber: Anchor<CGRect>?
+
+	init(brightness: Anchor<CGRect>? = nil, scrubber: Anchor<CGRect>? = nil) {
+		self.brightness = brightness
+		self.scrubber = scrubber
+	}
+}
+
+private struct PlayerChromeAnchorPreferenceKey: PreferenceKey {
+	static var defaultValue = PlayerChromeAnchors()
+
+	static func reduce(value: inout PlayerChromeAnchors, nextValue: () -> PlayerChromeAnchors) {
+		let next = nextValue()
+		value.brightness = next.brightness ?? value.brightness
+		value.scrubber = next.scrubber ?? value.scrubber
 	}
 }
 
@@ -569,6 +640,7 @@ struct PlayerBottomBar: View {
 	@ObservedObject var viewModel: PlayerViewModel
 	/// The fast clock — time labels and the chapter caption tick off this.
 	@ObservedObject var time: PlaybackTimeModel
+	let showsChapterName: Bool
 
 	private static let endsAtFormatter: DateFormatter = {
 		let formatter = DateFormatter()
@@ -582,13 +654,19 @@ struct PlayerBottomBar: View {
 		let remaining = max(0, viewModel.duration - position)
 
 		VStack(alignment: .leading, spacing: 6) {
-			if let chapterName = viewModel.currentChapterName {
+			if showsChapterName, let chapterName = viewModel.currentChapterName {
 				Text(chapterName)
 					.font(.caption)
 					.foregroundStyle(.white.opacity(0.7))
 					.lineLimit(1)
 			}
 			ScrubberView(viewModel: viewModel, time: time)
+				.anchorPreference(
+					key: PlayerChromeAnchorPreferenceKey.self,
+					value: .bounds
+				) { anchor in
+					PlayerChromeAnchors(scrubber: anchor)
+				}
 			HStack(alignment: .top) {
 				Text(formatTime(position))
 				Spacer()


### PR DESCRIPTION
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

# 📦 Pull Request

## 📝 Description
Reworks the native iOS playback chrome in `PlayerControlsRootView` so landscape controls do not overlap each other across iPhone sizes.

- Side controls and transient skip/countdown actions use intrinsic SwiftUI layout.
- The seek scrubber remains full width.
- Bottom-bar clearance follows its measured height and resets when the bar disappears, avoiding stale padding after hidden-state rotation.
- The current chapter stays left-aligned with the scrubber and is positioned between the measured brightness-control bottom and scrubber centerline without fixed device dimensions.

This is layer 2 of stack #2027 and depends on #2025. Review this PR against `fix/ios-player-home-gesture`, not `develop`.

## 🏷️ Ticket / Issue
N/A. A targeted search of the open tracker found no matching issue.

### 🖼️ Screenshots / GIFs (if UI)
iOS: the before state was supplied during implementation. The resulting landscape layout was iteratively tested on a physical iPhone. No GitHub-hosted image artifact is available from the local tooling session.

Android: N/A. The code is isolated to the SwiftUI iOS player.

## ✅ Checklist
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] AI assistance is declared above

## 🔍 Testing Instructions
1. Check out this branch with #2025 beneath it and open the native player on an iPhone.
2. Rotate to landscape and reveal the controls.
3. Verify brightness and volume remain at the edges while center transport controls stay visually centered.
4. Enter an intro/credit segment and verify the skip button does not overlap the volume control.
5. Verify the scrubber spans the full available width.
6. Play media with chapters and verify the chapter label is left-aligned and vertically centered in the available gap above the scrubber.
7. Hide the controls, rotate, reveal them again, and verify skip/countdown clearance uses the new bottom-bar height without a stale jump.

Validation performed:
- Swift parser passed for the complete child branch.
- The equivalent combined native player code built successfully with the `MpvPlayer` iOS Simulator scheme.
- `bun run check` passed.
- Typecheck, 351 unit tests, Biome lint/format, and i18n validation passed; the local aggregate `bun run test` stopped only at the repository baseline Expo Doctor dependency-version report.

No native SwiftUI UI-test target currently exists for this layout surface.

## Before 

<img width="2556" height="1179" alt="image" src="https://github.com/user-attachments/assets/0a1ed359-47dc-408d-a78b-a69328da7fc6" />


## After


<img width="2556" height="1179" alt="image" src="https://github.com/user-attachments/assets/e0b37e5c-571f-45d2-817c-6469faafd6b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Refined the player overlay with clearer separation between playback controls, status information, and the bottom control bar.
  - Positioned brightness and volume sliders alongside the central playback controls for easier access.
  - Improved layout consistency when controls are hidden.
  - Adjusted the bottom bar dynamically for different screen sizes and safe-area insets.
  - Displayed chapter labels above the scrubber while preventing overlap with other playback controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->