### PR TITLE
chore(player): update MPVKit to 0.41.0-av5

### DIFF
--- a/app.json
+++ b/app.json
@@ -181,7 +181,7 @@
         "./plugins/withGitPod.ts",
         {
           "podName": "MPVKit",
-          "podspecUrl": "https://raw.githubusercontent.com/streamyfin/MPVKit/0.41.0-av4/MPVKit.podspec"
+          "podspecUrl": "https://raw.githubusercontent.com/streamyfin/MPVKit/0.41.0-av5/MPVKit.podspec"
         }
       ]
     ],


### PR DESCRIPTION
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

# 📦 Pull Request

## 📝 Description
Updates the MPVKit podspec pin in `app.json` from `0.41.0-av4` to the published `0.41.0-av5` XCFramework.

The av5 build carries the refreshed AVFoundation video-output patch, including subtitle compositing and paused-redraw updates, consistent HDR compositing formats, seek/reset behavior fixes, and PiP reconfiguration handling.

## 🏷️ Ticket / Issue
N/A. No issue specifically tracks this dependency bump.

### 🖼️ Screenshots / GIFs (if UI)
N/A. This is a dependency-only change with no direct UI modification.

## ✅ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

## 🔍 Testing Instructions
1. Run `bun run prebuild` and confirm `ios/Podfile.lock` resolves `MPVKit (0.41.0-av5)`.
2. Build the `MpvPlayer` iOS Simulator scheme and confirm the av5 XCFramework compiles and links successfully.
3. Run `bun run check`; the read-only Biome check passes.
4. Run `bun run test`; typecheck, all 351 unit tests, Biome lint/format, and i18n validation pass. The aggregate command exits only at the repository's existing Expo Doctor dependency-version report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying media playback support to a newer version.
  * No other configuration changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->