### PR TITLE
chore(ci): prepare checks for merge queue

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -8,6 +8,8 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [develop, master]
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [develop, master]
 

--- a/.github/workflows/check-lockfile.yml
+++ b/.github/workflows/check-lockfile.yml
@@ -3,6 +3,8 @@ name: 🔒 Lockfile Consistency Check
 on:
   pull_request:
     branches: [develop, master]
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [develop, master]
 

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [master, develop]
   pull_request:
     branches: [master, develop]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '24 2 * * *'
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [develop, master]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
   push:
     branches: [develop]
@@ -32,8 +34,8 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
-          base-ref: ${{ github.event.pull_request.base.sha || 'develop' }}
-          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          base-ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'develop' }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.ref }}
 
   expo-doctor:
     name: 🚑 Expo Doctor Check

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches: [develop, master]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -17,15 +19,19 @@ jobs:
     name: "📝 Validate PR Title"
     runs-on: ubuntu-26.04
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      - if: github.event_name == 'pull_request'
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - if: github.event_name == 'merge_group'
+        run: echo "PR titles were validated before entering the merge queue"
+
       # Fork PRs only get a read-only GITHUB_TOKEN here, so the sticky comment
       # is posted from the privileged pr-title-comment.yml (workflow_run). Hand
       # off the result (PR number + lint error) as an artifact for it to read.
-      - if: always()
+      - if: always() && github.event_name == 'pull_request'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           LINT_ERROR: ${{ steps.lint_pr_title.outputs.error_message }}
@@ -34,7 +40,7 @@ jobs:
           printf '%s' "$PR_NUMBER" > pr-title-result/number
           printf '%s' "$LINT_ERROR" > pr-title-result/error
 
-      - if: always()
+      - if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-title-result


### PR DESCRIPTION
[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

# 📦 Pull Request

## 📝 Description
Prepares every ruleset-required GitHub Actions check to run against merge queue groups before an administrator enables a queue for `develop`.

- Adds the `merge_group` `checks_requested` trigger to app builds, lockfile validation, CodeQL, the security/quality gate, and PR title validation.
- Runs dependency review against the merge group's explicit base and head SHAs.
- Preserves the required PR-title check on merge groups without invoking PR-only title parsing or artifact uploads.
- Uses the merge-group ref in PR-title concurrency so independent queue groups do not cancel one another.

This PR intentionally does not enable the repository ruleset. Merge this workflow preparation into `develop` first, then follow the administrator runbook below.

## 🏷️ Ticket / Issue
N/A. No matching merge-queue issue exists in the repository tracker.

### 🖼️ Screenshots / GIFs (if UI)
N/A. This change only affects GitHub Actions workflow triggers.

## ✅ Checklist
- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

## 🔐 Administrator Runbook (after this PR merges)

> Do not enable the queue before these workflow changes are present on `develop`. A queue waits for required checks on its synthesized merge-group SHA; missing `merge_group` triggers leave it stuck until timeout.

### 1. Enable repository auto-merge

1. Open **Repository Settings → General → Pull Requests**.
2. Enable **Allow auto-merge**.
3. Keep **Allow squash merging** enabled.

This lets an authorized user click **Merge when ready** before reviews or checks finish. GitHub records that intent and automatically adds the PR to the required merge queue once its ordinary requirements pass. It does not enroll every opened PR automatically; a user with write access still opts in once per PR.

### 2. Update the existing review and CI ruleset

1. Open **Repository Settings → Rules → Rulesets → Review & CI Required**.
2. Under **Require status checks to pass before merging**, disable **Require branches to be up to date before merging** (`strict_required_status_checks_policy: false`). The queue provides current-base validation instead.
3. Keep these protections enabled:
   - Two approving reviews.
   - Dismiss stale approvals when new commits are pushed.
   - Resolve all review conversations.
   - All existing required status checks.
   - Required linear history and squash-only merging.

### 3. Create a develop-only merge queue ruleset

1. Open **Repository Settings → Rules → Rulesets → New ruleset → New branch ruleset**.
2. Name it `Merge queue for develop` and set **Enforcement status** to **Active**.
3. Under **Target branches**, include only `develop` using an exact branch name. Do not use a wildcard; GitHub does not support merge queues on wildcard branch rules.
4. Add the **Require merge queue** rule.
5. Start with these conservative settings:

| Setting | Initial value | Reason |
| --- | --- | --- |
| Merge method | Squash | Matches the repository's only allowed merge method. |
| Build concurrency | 1 | Prevents duplicate full Android/iOS builds while validating rollout. |
| Only merge non-failing pull requests | Enabled | Every queued entry must pass required checks. |
| Status check timeout | 90 minutes | Allows the signed iOS build enough time to complete. |
| Minimum pull requests to merge | 1 | Do not hold an otherwise-ready PR. |
| Maximum pull requests to merge | 1 | Isolates failures during initial rollout. |
| Wait time | 0 minutes | Merge as soon as the single entry passes. |

6. Save the ruleset. The existing `Review & CI Required` ruleset continues to supply the required reviews and check contexts; do not duplicate or remove those checks in the queue ruleset.

### 4. Verify the live queue

1. Open a small PR targeting `develop` and let its normal PR checks pass.
2. Click **Merge when ready**, then **Confirm merge when ready**.
3. In **Actions**, verify new runs appear with event `merge_group` and a ref beginning `gh-readonly-queue/develop/`.
4. Confirm all required contexts report on the merge-group SHA: PR title, dependency review, four quality checks, both CodeQL checks, lockfile validation, Android phone, Android TV, and signed iOS.
5. Confirm the PR appears on **Repository → Branches → develop → merge queue** and merges only after every required check succeeds.

For a non-merging smoke test, temporarily set **Minimum pull requests to merge** to `2` with a long wait time, enqueue only one PR, inspect its merge-group runs, then remove it from the queue. Restore the minimum to `1` afterward.

### 5. Rollback

If merge-group checks do not appear or the queue blocks healthy PRs:

1. Remove affected PRs from the queue in the GitHub web UI.
2. Set the `Merge queue for develop` ruleset enforcement to **Disabled**.
3. Restore **Require branches to be up to date before merging** in `Review & CI Required` until the workflow issue is corrected.
4. Leave this PR's `merge_group` triggers in place; they are inert when no queue is configured.

## 🔍 Testing Instructions
1. Confirm all five modified workflows declare `merge_group: types: [checks_requested]`.
2. Confirm normal pull requests still run semantic title validation and upload the title-result artifact.
3. Merge this PR into `develop` before enabling the queue.
4. Follow the administrator runbook above to enable and smoke-test the queue.
5. Verify every required status context is reported against the `gh-readonly-queue/develop/...` merge-group ref.

Validation performed:
- All modified workflows parse as valid YAML.
- VS Code reports no workflow diagnostics.
- `bun run check` passed.
- The full gate passed TypeScript, 351 unit tests, Biome lint/format, and i18n validation. It stopped only at the existing Expo Doctor dependency-version mismatch.
- Official `actionlint` container validation could not run because Docker Desktop was not running; no project dependency was added solely for workflow linting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI and Validation**
  * Build, lockfile, CodeQL, linting, and pull request title checks now run when changes enter the merge queue.
  * Dependency review continues to validate merge-queue changes using the appropriate commit references.
  * Pull request title linting and artifact uploads are limited to regular pull request events, with merge-queue checks receiving an appropriate status message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



