### PR TITLE
fix(ci): hold crowdin/github-action on v2 until CLI 5 sends explicit export options

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -28,7 +28,11 @@ jobs:
           fetch-depth: 0
 
       - name: 🌐 Sync Translations with Crowdin
-        uses: crowdin/github-action@71fdb8814261dd703be4ca7c6450d21b1868da4b # v3.0.1
+        # Held on v2 (Crowdin CLI 4): v3 ships CLI 5, which drops the explicit `false`
+        # export options from crowdin.yml, so the project export settings take over and
+        # the download comes back empty. Do not merge the v3 bump until this is fixed:
+        # https://github.com/crowdin/crowdin-cli/issues/1107
+        uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
         with:
           upload_sources: true
           upload_translations: true


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

Since #2033 moved the translation sync to `crowdin/github-action` v3, every run of `.github/workflows/crowdin.yml` ends with `Couldn't find any file to download. Since you are using the 'Skip untranslated files' option` followed by `NOTHING TO COMMIT`, while the job stays green (runs [33780861340](https://github.com/streamyfin/streamyfin/actions/runs/33780861340) and [33783249112](https://github.com/streamyfin/streamyfin/actions/runs/33783249112)). No translation has reached `I10n_crowdin_translations` since.

v3 ships Crowdin CLI 5. Its `download` command only adds `skipUntranslatedStrings`, `skipUntranslatedFiles` and `exportApprovedOnly` to the build request when they are `true` (`buildExportGroups` in `src-next/cli/commands/download/DownloadCommand.ts`). The explicit `false` values in our `crowdin.yml` are dropped, the Crowdin project export settings take over, and the archive comes back empty. CLI 4 sent the configured values on every run, which is why the same workflow downloaded 30 files on 2026-08-31 (run [33371189512](https://github.com/streamyfin/streamyfin/actions/runs/33371189512)). We confirmed the approval setting is involved too: French at 100% translated was still not exported.

This PR pins the action back to `v2.17.0` (same digest as before #2033) with a comment explaining why. Reported upstream as crowdin/crowdin-cli#1107. Renovate will propose v3 again; leave that PR unmerged until a fixed CLI ships in the action, then drop the comment.

## 🏷️ Ticket / Issue

Follow-up to #2033. Upstream report: crowdin/crowdin-cli#1107.

### 🖼️ Screenshots / GIFs (if UI)

N/A

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms (CI only, verified on the next sync run after merge)
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. Merge. The workflow listens to its own file, so the sync runs right away on `develop`.
2. Open the run log, step `Sync Translations with Crowdin`: `DOWNLOAD TRANSLATIONS` must end with `Building translation (100%)` and `PUSH TO BRANCH I10n_crowdin_translations` with a `forced update`, not `NOTHING TO COMMIT`.
3. The Crowdin PR on `I10n_crowdin_translations` gets the translations made since 2026-08-31 (French should be complete).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored reliable translation synchronization by reverting the Crowdin integration to a compatible version.
  - Prevented translation downloads from resulting in empty files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->