### PR TITLE
fix(subtitles): stop asking Jellyfin to rewrite WebVTT sidecars

### DIFF
--- a/utils/profiles/download.test.ts
+++ b/utils/profiles/download.test.ts
@@ -21,8 +21,8 @@ describe("generateDownloadProfile", () => {
     const profile = generateDownloadProfile("auto");
 
     expect(profile.SubtitleProfiles).toEqual([
+      // "webvtt" is absent on purpose — see TEXT_EXTERNAL_FORMATS (#1892).
       ...[
-        "webvtt",
         "vtt",
         "srt",
         "subrip",

--- a/utils/profiles/subtitles.test.ts
+++ b/utils/profiles/subtitles.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "bun:test";
 import { getSubtitleProfiles } from "./subtitles";
 
 describe("getSubtitleProfiles", () => {
-  it("returns 52 entries for target mpv (default)", () => {
+  it("returns 51 entries for target mpv (default)", () => {
     const profiles = getSubtitleProfiles({ target: "mpv" });
-    expect(profiles.length).toBe(52);
+    expect(profiles.length).toBe(51);
 
     // Verify default call without args matches mpv
     expect(getSubtitleProfiles()).toEqual(profiles);
@@ -16,6 +16,34 @@ describe("getSubtitleProfiles", () => {
     // Check text sub sample
     expect(profiles).toContainEqual({ Format: "srt", Method: "Embed" });
     expect(profiles).toContainEqual({ Format: "srt", Method: "External" });
+  });
+
+  // A .vtt sidecar probes as codec "webvtt"; offering that name for External
+  // delivery makes the server rewrite the file and drop every cue (#1892).
+  it.each(["mpv", "download"] as const)(
+    "never offers webvtt as an External format for target %s",
+    (target) => {
+      const profiles = getSubtitleProfiles({ target });
+
+      expect(profiles).not.toContainEqual({
+        Format: "webvtt",
+        Method: "External",
+      });
+      // With no exact codec match the server takes the first External profile,
+      // so "vtt" must lead or the sidecar gets converted instead of passed on.
+      expect(profiles.find((p) => p.Method === "External")).toEqual({
+        Format: "vtt",
+        Method: "External",
+      });
+    },
+  );
+
+  // Embed matches a container codec and converts nothing, so the alias is safe.
+  it("still matches an embedded webvtt track in the container", () => {
+    expect(getSubtitleProfiles({ target: "mpv" })).toContainEqual({
+      Format: "webvtt",
+      Method: "Embed",
+    });
   });
 
   it("returns 4 entries for target exoplayer", () => {
@@ -30,7 +58,7 @@ describe("getSubtitleProfiles", () => {
 
   it("delivers text subtitles externally and burns image ones in for target download", () => {
     const profiles = getSubtitleProfiles({ target: "download" });
-    expect(profiles.length).toBe(26);
+    expect(profiles.length).toBe(25);
 
     // Text formats come down as sidecar files the offline player can switch.
     expect(profiles).toContainEqual({ Format: "srt", Method: "External" });

--- a/utils/profiles/subtitles.ts
+++ b/utils/profiles/subtitles.ts
@@ -47,6 +47,17 @@ const TEXT_BASED_FORMATS = [
   "vplayer",
 ] as const;
 
+// External delivery leaves out the "webvtt" alias. Jellyfin matches the profile
+// against the stream's codec, and a .vtt sidecar probes as codec "webvtt", so
+// offering that name wins the exact match and the server re-writes the file
+// through its VttWriter rather than sending it — and that writer's non-spec
+// "Region:" header costs every cue (#1892). Without the alias it falls through
+// to "vtt", where requested and input format agree and the file is sent as is.
+// Embed keeps the alias: it matches a container codec and converts nothing.
+const TEXT_EXTERNAL_FORMATS: readonly string[] = TEXT_BASED_FORMATS.filter(
+  (format) => format !== "webvtt",
+);
+
 const EXOPLAYER_SUBTITLE_PROFILES: SubtitleProfile[] = [
   { Format: "srt", Method: "External" },
   { Format: "vtt", Method: "External" },
@@ -66,7 +77,7 @@ const CHROMECAST_SUBTITLE_PROFILES: SubtitleProfile[] = [
 // sub-adds and can switch between; image formats have no external path and
 // still get burned in ("Encode") by the server.
 const DOWNLOAD_SUBTITLE_PROFILES: SubtitleProfile[] = [
-  ...TEXT_BASED_FORMATS.map(
+  ...TEXT_EXTERNAL_FORMATS.map(
     (Format): SubtitleProfile => ({ Format, Method: "External" }),
   ),
   ...IMAGE_BASED_FORMATS.map(
@@ -81,10 +92,13 @@ const buildMpvSubtitleProfiles = (): SubtitleProfile[] => {
     profiles.push({ Format: format, Method: "Embed" });
     profiles.push({ Format: format, Method: "Encode" });
   }
-  // Text-based formats: Embed or External
+  // Text-based formats: Embed for every codec MPV can render in-container,
+  // External only for the names the server can hand over untouched.
   for (const format of TEXT_BASED_FORMATS) {
     profiles.push({ Format: format, Method: "Embed" });
-    profiles.push({ Format: format, Method: "External" });
+    if (TEXT_EXTERNAL_FORMATS.includes(format)) {
+      profiles.push({ Format: format, Method: "External" });
+    }
   }
   return profiles;
 };


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

WebVTT subtitles never render. The track appears in the player's menu, selecting it succeeds, and no text ever shows — no error anywhere. The same file renders correctly in jellyfin-web.

**Root cause.** Jellyfin picks a subtitle delivery format by matching the client's device profile against the subtitle stream's **codec**, and a `.vtt` sidecar probes as codec `webvtt` (verified with `ffprobe`). `TEXT_BASED_FORMATS` in `utils/profiles/subtitles.ts` advertised the literal string `webvtt` for `External` delivery, so that exact match won and the server built a URL ending `Stream.webvtt`.

That URL is a request to *convert*. `SubtitleEncoder.GetSubtitles` returns a file untouched only when the requested format equals the input format — and the input format is the sidecar's own file extension, `vtt`. Since `vtt != webvtt`, the server re-serialised the subtitle through `MediaBrowser.MediaEncoding/Subtitles/VttWriter.cs`, which unconditionally writes this after the `WEBVTT` signature:

```
Region: id:subtitle width:80% lines:3 regionanchor:50%,100% viewportanchor:50%,90%
```

That is not a valid WebVTT block — the spec form is `REGION` with settings on the following lines. libavformat treats it as a malformed cue, fails to read a timestamp, and aborts the whole file: zero cues, no error surfaced.

jellyfin-web advertises only `vtt`, never `webvtt`, so it never triggers the conversion, and browsers tolerate the header anyway. Streamyfin's own Chromecast profile also only lists `vtt`, which is why casting already worked.

**The fix.** Drop `webvtt` from the `External` list (the new `TEXT_EXTERNAL_FORMATS`), so the server falls through to `vtt`, where requested and input format agree and the file is streamed verbatim. `webvtt` is kept for `Embed`, which matches a container's codec name and neither builds a URL nor converts anything.

The download profile carried the same alias, so offline copies of `.vtt` sidecars were being written to disk with the cues already stripped. Fixed in the same commit.

**Measured evidence** — live Jellyfin 10.11 server, same subtitle stream, both spellings:

| Requested | Content-Type | Bytes | Cues ffmpeg parses |
| --- | --- | --- | --- |
| `Stream.vtt` | `text/vtt` | 23 302 | **232** |
| `Stream.webvtt` | `application/octet-stream` | 28 369 | **0** |

Bisect on the writer's output, isolating the cause:

| Variant | Cues |
| --- | --- |
| Jellyfin output as-is (`Region:` header + per-cue settings) | 0 |
| Header kept, per-cue settings stripped | 0 |
| Header dropped, per-cue settings kept | 441 |
| Spec-form `REGION` block, per-cue settings kept | 441 |

**Known limitation — items downloaded before this fix.** The saved sidecar filename comes from `subtitle.Codec` (`providers/Downloads/additionalDownloads.ts:112`), which is `webvtt` both before and after this change. A re-download therefore lands on the same path as the old cue-stripped file and is skipped by the `if (destination.exists)` guard. Items downloaded before this fix keep the broken sidecar until they are deleted and downloaded again. Left out of scope deliberately, to keep the diff inside the profile files — happy to follow up by deriving the extension from the delivered URL instead, if you'd prefer that here.

**Also spotted, raised separately.** The same `External` list contains twelve formats Jellyfin has no writer for (`mov_text`, `microdvd`, `smi`, …), which return HTTP 400 and a silently missing subtitle. Not fixed here, because fixing it properly means reordering this same list and changing what this fix just set.

## 🏷️ Ticket / Issue

Fixes #1892

### 🖼️ Screenshots / GIFs (if UI)

N/A — no UI change. This only changes the subtitle delivery format the client negotiates with the server.

## ✅ Checklist

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR

**On the unticked box:** verified end to end on the iOS simulator (mpv) against a live Jellyfin 10.11 server — the subtitle from #1892 now renders. Not yet exercised on Android/ExoPlayer or on TV. The change is platform-independent (a device-profile string list) and the ExoPlayer and Chromecast profiles are untouched by the diff, but I would rather flag the gap than tick the box.

## 🔍 Testing Instructions

1. Find an item whose subtitle is an external `.vtt` sidecar beside the media file. Confirm with `ffprobe` that the stream's codec is `webvtt` and that the file's first line is `WEBVTT`.
2. On `develop`, play the item and select that subtitle track. **Expected before the fix:** the track is listed and selectable, and no text ever appears — no error in the app or in the server log.
3. Switch to this branch, rebuild, and play the same item.
4. Select the same subtitle track. **Expected after the fix: the cues render.**
5. To confirm the cause rather than the symptom, look at what the server returns in `PlaybackInfo` -> `MediaStreams[].DeliveryUrl`. Before: it ends `Stream.webvtt`. After: it ends `Stream.vtt`.
6. Regression check — all three should behave exactly as before: an item with an `.srt` sidecar (still exact-matches its own profile entry), an item with an embedded PGS track (still burned in), and any item cast to Chromecast (that profile is untouched).
7. Unit tests: `bun run test:unit` — 358 pass. `utils/profiles/subtitles.test.ts` pins that `webvtt` is never offered for `External`, and that `vtt` leads the `External` list for both the mpv and download targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External subtitle delivery for download and MPV targets no longer offers WebVTT.
  * WebVTT remains available for embedded subtitle tracks.
  * Updated subtitle profile counts and ordering to reflect the supported external formats.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->