### PR TITLE
fix(notifications): post the push token to the plugin once per sign in

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -56,6 +56,7 @@ import {
   writeToLog,
 } from "@/utils/log";
 import { storage } from "@/utils/mmkv";
+import { pushRegistrationKey } from "@/utils/pushRegistration";
 
 const Notifications = !Platform.isTV ? require("expo-notifications") : null;
 
@@ -403,18 +404,28 @@ function Layout() {
   const notificationListener = useRef<EventSubscription>(null);
   const responseListener = useRef<EventSubscription>(null);
 
+  // Posted once per server, user and token. The api and the user object change
+  // identity on sign in, so without this the token went out twice within a second.
+  const registeredPush = useRef<string | null>(null);
+
   useEffect(() => {
-    if (!Platform.isTV && expoPushToken && api && user) {
-      api
-        ?.post("/Streamyfin/device", {
-          token: expoPushToken.data,
-          deviceId: getOrSetDeviceId(),
-          userId: user.Id,
-        })
-        .catch((_) =>
-          writeErrorLog("Failed to push expo push token to plugin"),
-        );
-    }
+    if (Platform.isTV || !expoPushToken || !api || !user) return;
+
+    const key = pushRegistrationKey(api.basePath, user.Id, expoPushToken.data);
+    if (!key || registeredPush.current === key) return;
+
+    registeredPush.current = key;
+    api
+      .post("/Streamyfin/device", {
+        token: expoPushToken.data,
+        deviceId: getOrSetDeviceId(),
+        userId: user.Id,
+      })
+      .catch((_) => {
+        // A failed post is worth another try the next time the effect runs.
+        registeredPush.current = null;
+        writeErrorLog("Failed to push expo push token to plugin");
+      });
   }, [api, expoPushToken, user]);
 
   const registerNotifications = useCallback(async () => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -56,7 +56,7 @@ import {
   writeToLog,
 } from "@/utils/log";
 import { storage } from "@/utils/mmkv";
-import { pushRegistrationKey } from "@/utils/pushRegistration";
+import { pushRegistrationStep } from "@/utils/pushRegistration";
 
 const Notifications = !Platform.isTV ? require("expo-notifications") : null;
 
@@ -406,15 +406,21 @@ function Layout() {
 
   // Posted once per server, user and token. The api and the user object change
   // identity on sign in, so without this the token went out twice within a second.
+  // Sign out clears the session, and the key with it, so the next sign in posts again.
   const registeredPush = useRef<string | null>(null);
 
   useEffect(() => {
-    if (Platform.isTV || !expoPushToken || !api || !user) return;
+    if (Platform.isTV) return;
 
-    const key = pushRegistrationKey(api.basePath, user.Id, expoPushToken.data);
-    if (!key || registeredPush.current === key) return;
+    const step = pushRegistrationStep(
+      registeredPush.current,
+      api?.basePath,
+      user?.Id,
+      expoPushToken?.data,
+    );
+    registeredPush.current = step.key;
+    if (!step.post || !api || !user || !expoPushToken) return;
 
-    registeredPush.current = key;
     api
       .post("/Streamyfin/device", {
         token: expoPushToken.data,
@@ -422,8 +428,9 @@ function Layout() {
         userId: user.Id,
       })
       .catch((_) => {
-        // A failed post is worth another try the next time the effect runs.
-        registeredPush.current = null;
+        // Forgotten only if nothing newer was posted meanwhile, so the next change
+        // of session or token posts again. No retry on its own, as before.
+        if (registeredPush.current === step.key) registeredPush.current = null;
         writeErrorLog("Failed to push expo push token to plugin");
       });
   }, [api, expoPushToken, user]);

--- a/utils/pushRegistration.test.ts
+++ b/utils/pushRegistration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { pushRegistrationKey } from "./pushRegistration";
+import { pushRegistrationKey, pushRegistrationStep } from "./pushRegistration";
 
 describe("pushRegistrationKey", () => {
   test("is null while any of the three parts is missing", () => {
@@ -21,5 +21,40 @@ describe("pushRegistrationKey", () => {
     expect(pushRegistrationKey("https://other", "u", "t")).not.toBe(base);
     expect(pushRegistrationKey("https://jf", "v", "t")).not.toBe(base);
     expect(pushRegistrationKey("https://jf", "u", "s")).not.toBe(base);
+  });
+});
+
+describe("pushRegistrationStep", () => {
+  test("posts the first time, and not again for the same server, user and token", () => {
+    const first = pushRegistrationStep(null, "https://jf", "u", "t");
+    expect(first.post).toBe(true);
+
+    const again = pushRegistrationStep(first.key, "https://jf", "u", "t");
+    expect(again.post).toBe(false);
+    expect(again.key).toBe(first.key);
+  });
+
+  test("posts again after a different user, server or token", () => {
+    const { key } = pushRegistrationStep(null, "https://jf", "u", "t");
+
+    expect(pushRegistrationStep(key, "https://jf", "v", "t").post).toBe(true);
+    expect(pushRegistrationStep(key, "https://other", "u", "t").post).toBe(
+      true,
+    );
+    expect(pushRegistrationStep(key, "https://jf", "u", "s").post).toBe(true);
+  });
+
+  // Sign out deletes the device on the server and clears the session, so the same
+  // sign in afterwards has to post again.
+  test("forgets the key when the session ends, so the same sign in posts again", () => {
+    const { key } = pushRegistrationStep(null, "https://jf", "u", "t");
+
+    const signedOut = pushRegistrationStep(key, undefined, undefined, "t");
+    expect(signedOut.key).toBeNull();
+    expect(signedOut.post).toBe(false);
+
+    expect(
+      pushRegistrationStep(signedOut.key, "https://jf", "u", "t").post,
+    ).toBe(true);
   });
 });

--- a/utils/pushRegistration.test.ts
+++ b/utils/pushRegistration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { pushRegistrationKey } from "./pushRegistration";
+
+describe("pushRegistrationKey", () => {
+  test("is null while any of the three parts is missing", () => {
+    expect(pushRegistrationKey(undefined, "u", "t")).toBeNull();
+    expect(pushRegistrationKey("https://jf", undefined, "t")).toBeNull();
+    expect(pushRegistrationKey("https://jf", "u", undefined)).toBeNull();
+    expect(pushRegistrationKey("", "u", "t")).toBeNull();
+  });
+
+  test("is the same for the same server, user and token", () => {
+    expect(pushRegistrationKey("https://jf", "u", "t")).toBe(
+      pushRegistrationKey("https://jf", "u", "t"),
+    );
+  });
+
+  test("changes when the server, the user or the token changes", () => {
+    const base = pushRegistrationKey("https://jf", "u", "t");
+
+    expect(pushRegistrationKey("https://other", "u", "t")).not.toBe(base);
+    expect(pushRegistrationKey("https://jf", "v", "t")).not.toBe(base);
+    expect(pushRegistrationKey("https://jf", "u", "s")).not.toBe(base);
+  });
+});

--- a/utils/pushRegistration.ts
+++ b/utils/pushRegistration.ts
@@ -1,9 +1,13 @@
 /**
- * The key under which a push token was last posted to the Streamyfin plugin: one
- * server, one user, one token. The effect that posts it runs again whenever the api
- * or the user object changes identity, which on sign in is twice within a second, and
- * the plugin answered the second post with a 500 on its device id. Posting once per
- * key is enough: the plugin keeps one row per device and updates it in place.
+ * What the push token registration does on one run of its effect, given what it
+ * posted last time. The plugin keeps one row per device and updates it in place, so
+ * posting once per server, user and token is enough; the effect runs again whenever
+ * the api or the user object changes identity, which on sign in is twice within a
+ * second, and the plugin answered the second post with a 500 on its device id.
+ *
+ * A missing part means there is no session to register with, which is what sign out
+ * looks like: the key is forgotten, so signing in again on the same server, as the
+ * same user, with the same token, posts again. Sign out deleted the device.
  */
 export const pushRegistrationKey = (
   serverUrl: string | undefined,
@@ -11,3 +15,13 @@ export const pushRegistrationKey = (
   token: string | undefined,
 ): string | null =>
   serverUrl && userId && token ? `${serverUrl}|${userId}|${token}` : null;
+
+export const pushRegistrationStep = (
+  last: string | null,
+  serverUrl: string | undefined,
+  userId: string | undefined,
+  token: string | undefined,
+): { key: string | null; post: boolean } => {
+  const key = pushRegistrationKey(serverUrl, userId, token);
+  return { key, post: key !== null && key !== last };
+};

--- a/utils/pushRegistration.ts
+++ b/utils/pushRegistration.ts
@@ -1,0 +1,13 @@
+/**
+ * The key under which a push token was last posted to the Streamyfin plugin: one
+ * server, one user, one token. The effect that posts it runs again whenever the api
+ * or the user object changes identity, which on sign in is twice within a second, and
+ * the plugin answered the second post with a 500 on its device id. Posting once per
+ * key is enough: the plugin keeps one row per device and updates it in place.
+ */
+export const pushRegistrationKey = (
+  serverUrl: string | undefined,
+  userId: string | undefined,
+  token: string | undefined,
+): string | null =>
+  serverUrl && userId && token ? `${serverUrl}|${userId}|${token}` : null;


### PR DESCRIPTION
# 📦 Pull Request

[![AI Assisted](https://img.shields.io/badge/AI_Assisted-18181b?style=for-the-badge&logo=openai&logoColor=white)](#)

## 📝 Description

The effect that registers the Expo push token with the Streamyfin plugin depends on `api`, `user` and the token. On sign in the api and the user object change identity within a second, so the token was posted to `/Streamyfin/device` twice. The plugin registered the device with a lookup followed by an insert, so the second post could fail on the device id with a 500, and the app logged "Failed to push expo push token to plugin" for a token it had in fact registered.

The token is now posted once per server, user and token: the last key is remembered in a ref and a repeat is skipped. Sign out clears the session, and the key with it, since it also deletes the device on the server; the same sign in afterwards posts again. A failed post forgets the key, so the next change of session or token posts again; there is no retry on its own, as before. The decision is a pure step in `utils/pushRegistration.ts`, tested for the first post, the repeat, a changed part, and sign out followed by the same sign in. The plugin side stops answering 500 to a second registration in streamyfin/jellyfin-plugin-streamyfin#149, whatever the client does; this keeps the client from asking twice.

## 🏷️ Ticket / Issue

N/A. Seen on a Jellyfin 12.0.0 server log on 2026-09-11 while testing the plugin's push receipts with an iPhone 15 Pro Max on the TestFlight build: two `Posting device token for deviceId: ...` lines one second apart, the second followed by `UNIQUE constraint failed: DeviceTokens.DeviceId`.

### 🖼️ Screenshots / GIFs (if UI)

N/A, no UI change.

## ✅ Checklist

- [x] I’ve read the [contribution guidelines](CONTRIBUTING.md)
- [ ] Verified that changes behave as expected for all platforms
- [x] Code passes lint/formatting and type checks (`tsc`/`biome`)
- [x] No secrets, hardcoded credentials, or private config files are included
- [x] I've declared if AI was used to assist with this PR (by uncommenting the line at the bottom, or not)

## 🔍 Testing Instructions

1. `bun test utils/pushRegistration.test.ts` (6 tests), `bun run typecheck`, `biome check` on the three files.
2. On a real phone (the token only exists on a device), sign in to a server that runs the Streamyfin plugin and read the server log: one `Posting device token for deviceId: ...` line per sign in instead of two.
3. Sign out: the device is still removed (`DELETE /Streamyfin/device/{id}`), unchanged by this.
4. Sign in again on the same phone: the token is posted again, since the key includes the server, the user and the token.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate push notification registrations for the same server, account, and device.
  * Failed registrations can retry automatically on a subsequent attempt.
  * Push notification registration now updates when the server, account, or device token changes.
  * Registration can resume after a session ends and a new session begins.

* **Tests**
  * Added coverage for registration deduplication, changed registration details, retries, and missing registration information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->